### PR TITLE
Fixed a small bug in the error message

### DIFF
--- a/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -110,11 +110,11 @@ class Wordpress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
         }
 
 		if (strtolower($testMethodName) != $testMethodName) {
-			$suggested = preg_replace('/([A-Z])/', '_$1', $functionName);
+			$suggested = preg_replace('/([A-Z])/', '_$1', $methodName);
 			$suggested = strtolower ($suggested);
 			$suggested = str_replace ('__', '_', $suggested);
 			
-            $error = "Function name \"$functionName\" is in camel caps format, try '".$suggested."'";
+            $error = "Function name \"$methodName\" is in camel caps format, try '".$suggested."'";
             $phpcsFile->addError($error, $stackPtr);
         }
     }//end processTokenWithinScope()


### PR DESCRIPTION
If you had a camel cased function name, the error would say:

`Function name "" is in camel caps format, try '' (Wordpress.NamingConventions.ValidFunctionName)`

With this patch, it now will show the old function name and proposed function name in the error message.
