### PR TITLE
Allows to install coding standard using composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "wordpress-coding-standards/wordpress-coding-standards",
+  "type": "phpcs-standard",
+  "description": "WordPress Coding Standards",
+  "require": {
+    "goatherd/phpcs_installer": "*"
+  },
+  "extra": {
+    "phpcs-standard": "WordPress"
+  }
+}


### PR DESCRIPTION
Allows to install this coding standard using composer.
Adding following to your composer.json file will also install phpcs.

`comoser.json`:

```
{
  "require-dev": {
    "wordpress-coding-standards/wordpress-coding-standards": "dev-master"
  }
}
```
