### PR TITLE
False positive ? "Equals sign not aligned correctly; expected 1 space but found 5 spaces"

### DIFF
--- a/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -27,3 +27,14 @@ $my_array = array(
 	'foo3' => 'somevalue3',
 	'foo34' => 'somevalue3',
 );
+
+// Should be good. See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/138
+$options = array( 'min_range' => 0 );
+$key     = filter_var( $key, FILTER_VALIDATE_INT, $options );
+
+// Should be good. See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/138#issuecomment-30581086
+$args['value']  = false;
+$args['type']   = 'checkbox';
+$args['field']  = 'template_default';
+$args['label']  = __( 'Make default ?', Plugin_Notes::$name );
+$args['inline'] = true;


### PR DESCRIPTION
The following code snippet is generating the `Equals sign not aligned correctly; expected 1 space but found 5 spaces` error, while I would expect it to pass without error.

Is it me or did I find another false positive ?

``` php
    $options = array( 'min_range' => 0 );
    $key     = filter_var( $key, FILTER_VALIDATE_INT, $options );
```

**Edit:**
This one is a bit awkward: it doesn't generate the error when I use phpcs, however it does when using phpcs _from PHPStorm_. Both use the same sniffs as synchronized with the current repo. Very weird indeed.
