### PR TITLE
Allow custom sanitizing functions to be added to the XSS sniff

### DIFF
--- a/Sniffs/XSS/EscapeOutputSniff.php
+++ b/Sniffs/XSS/EscapeOutputSniff.php
@@ -20,6 +20,10 @@
 class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 {
 
+	public $customAutoEscapedFunctions = array();
+
+	public $customSanitizingFunctions = array();
+
 	public static $autoEscapedFunctions = array(
 		'allowed_tags',
 		'bloginfo',
@@ -245,6 +249,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		'_x',
 	);
 
+	public static $addedCustomFunctions = false;
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -275,6 +280,13 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
 	{
+		// Merge any custom functions with the defaults, if we haven't already.
+		if ( ! self::$addedCustomFunctions ) {
+			self::$sanitizingFunctions = array_merge( self::$sanitizingFunctions, $this->customSanitizingFunctions );
+			self::$autoEscapedFunctions = array_merge( self::$autoEscapedFunctions, $this->customAutoEscapedFunctions );
+			self::$addedCustomFunctions = true;
+		}
+
 		$tokens = $phpcsFile->getTokens();
 
 		// If function, not T_ECHO nor T_PRINT


### PR DESCRIPTION
I've tested this and its working. See #144.
