### PR TITLE
Fix issue #176 - PHP5.2 compatibility

### DIFF
--- a/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -135,18 +135,7 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 				continue;
 			}
 
-			array_walk(
-				$patterns, 
-				function( &$pattern ) {
-					$pattern = preg_quote( $pattern, '#' );
-					$pattern = preg_replace(
-						array( '#\\\\\*#', '[\'"]' ),
-						array( '.*', '\'' ), 
-						$pattern
-						);
-					return $pattern;
-				}
-				);
+			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
 
 			$pattern = implode( '|', $patterns );
 
@@ -179,6 +168,16 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 		}
 
 	}//end process()
+	
+	private function test_patterns( $pattern ) {
+		$pattern = preg_quote( $pattern, '#' );
+		$pattern = preg_replace(
+			array( '#\\\\\*#', '[\'"]' ),
+			array( '.*', '\'' ), 
+			$pattern
+			);
+		return $pattern;
+	}
 
 
 }//end class


### PR DESCRIPTION
As reported in issue #176

> Found when running a travis build: https://travis-ci.org/Yoast/wordpress-seo/builds/28375064
> 
> Considering the minimum requirement for WP is still (unfortunately) PHP 5.2.6, I'd suggest that the codesniffs should also be able to work under PHP 5.2.
> 
> Parse error: syntax error, unexpected T_FUNCTION in /home/travis/.phpenv/versions/5.2.17/pear/PHP/CodeSniffer/Standards/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php on line 140
