### PR TITLE
Allow blank lines in multiline function definitions

### DIFF
--- a/WordPress/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -235,9 +235,10 @@ class WordPress_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeS
 
                 if ($expectedIndent !== $foundIndent) {
                     $error = "Multi-line function ".$this->_type." not indented correctly; expected $expectedIndent spaces but found $foundIndent";
-                    //If indented with tab spaces don't throw error!
-                    if ( false === strpos( $tokens[$i]['content'], "\t" ) )
-                        $phpcsFile->addError($error, $i);
+                    // If indented with tabs or is just a newline don't throw error
+                    if ( ! preg_match( "/(^\r?\n$|\t)/", $tokens[$i]['content'] ) ) {
+                        $phpcsFile->addError( $error, $i );
+                    }
                 }
             }//end if
         }//end for


### PR DESCRIPTION
Fixes #249
