### PR TITLE
Check for presence of tokens always available in a file with valid syntax

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -56,8 +56,17 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             $phpcsFile->addError($error, $stackPtr, 'NotLowerCase', $data);
         }
 
-        $arrayStart   = $tokens[$stackPtr]['parenthesis_opener'];
-        $arrayEnd     = $tokens[$arrayStart]['parenthesis_closer'];
+        if ( ! isset( $tokens[$stackPtr]['parenthesis_opener'] ) ) {
+            $phpcsFile->addError('Missing parenthesis opener.', $stackPtr);
+            return;
+        }
+        $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
+        if ( ! isset( $tokens[$arrayStart]['parenthesis_closer'] ) ) {
+            $phpcsFile->addError('Missing parenthesis closer.', $arrayStart);
+            return;
+        }
+        $arrayEnd = $tokens[$arrayStart]['parenthesis_closer'];
+
         $keywordStart = $tokens[$stackPtr]['column'];
 
         if ($arrayStart != ($stackPtr + 1)) {
@@ -201,7 +210,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     $stackPtrCount = count($tokens[$stackPtr]['nested_parenthesis']);
                 }
 
-                if (count($tokens[$nextToken]['nested_parenthesis']) > ($stackPtrCount + 1)) {
+                if (isset($tokens[$nextToken]['nested_parenthesis']) && count($tokens[$nextToken]['nested_parenthesis']) > ($stackPtrCount + 1)) {
                     // This comma is inside more parenthesis than the ARRAY keyword,
                     // then there it is actually a comma used to seperate arguments
                     // in a function call.

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -37,6 +37,10 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 		$tokens = $phpcsFile->getTokens();
 
 		$token = $tokens[ $stackPtr ];
+		if ( ! isset( $token['bracket_closer'] ) ) {
+			$phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr );
+			return;
+		}
 
 		$need_spaces = $phpcsFile->findNext(
 			array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_WHITESPACE, T_MINUS ),


### PR DESCRIPTION
Addresses PHPCS outputting some notices when processing files that have syntax errors (which really shouldn't be processed anyway).

See https://github.com/WP-API/WP-API/pull/558
