### PR TITLE
Fix T_ELSE immediately followed by T_COLON

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -83,7 +83,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
+            && ! ( $tokens[$stackPtr]['code'] === T_ELSE && $tokens[($stackPtr + 1)]['code'] === T_COLON )
+        ) {
             $error = 'Space after opening control structure is required';
             if (isset($phpcsFile->fixer) === true) {
                 $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterStructureOpen');
@@ -106,7 +108,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
 
         $parenthesisOpener = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-        if (($stackPtr + 1) === $parenthesisOpener) {
+        if (($stackPtr + 1) === $parenthesisOpener && $tokens[$parenthesisOpener]['code'] !== T_COLON) {
             // Checking this: $value = my_function[*](...).
             $error = 'No space before opening parenthesis is prohibited';
             if (isset($phpcsFile->fixer) === true) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -85,9 +85,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $this->blank_line_check            = (bool) $this->blank_line_check;
-        $this->blank_line_after_check      = (bool) $this->blank_line_after_check;
-        $this->space_before_colon_required = (bool) $this->space_before_colon_required;
+        $this->blank_line_check       = (bool) $this->blank_line_check;
+        $this->blank_line_after_check = (bool) $this->blank_line_after_check;
 
         $tokens = $phpcsFile->getTokens();
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -48,9 +48,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
     /**
      * Require for space before T_COLON when using the alternative syntax for control structures
      *
-     * @var boolean
+     * @var string one of 'required', 'forbidden', optional'
      */
-    public $space_before_colon_required = true;
+    public $space_before_colon = 'required';
 
 
     /**
@@ -117,7 +117,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
         // alternative syntax
         if ( $tokens[$scopeOpener]['code'] === T_COLON ) {
 
-            if ( $this->space_before_colon_required ) {
+            if ( $this->space_before_colon === 'required') {
 
                 if ( $tokens[$scopeOpener - 1]['code'] !== T_WHITESPACE ) {
                    $error = 'Space between opening control structure and T_COLON is required';
@@ -135,7 +135,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
                    }
                 }
 
-            } else {
+            } elseif ( $this->space_before_colon === 'forbidden' ) {
 
                 if ( $tokens[$scopeOpener - 1]['code'] === T_WHITESPACE ) {
                     $error = 'Extra space between opening control structure and T_COLON found';

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -85,9 +85,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $this->blank_line_check         = (bool) $this->blank_line_check;
-        $this->blank_line_after_check   = (bool) $this->blank_line_after_check;
-        $this->space_before_colon_check = (bool) $this->space_before_colon_check;
+        $this->blank_line_check            = (bool) $this->blank_line_check;
+        $this->blank_line_after_check      = (bool) $this->blank_line_after_check;
+        $this->space_before_colon_required = (bool) $this->space_before_colon_required;
 
         $tokens = $phpcsFile->getTokens();
 
@@ -117,7 +117,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
         // alternative syntax
         if ( $tokens[$scopeOpener]['code'] === T_COLON ) {
 
-            if ( $this->space_before_colon_check ) {
+            if ( $this->space_before_colon_required ) {
 
                 if ( $tokens[$scopeOpener - 1]['code'] !== T_WHITESPACE ) {
                    $error = 'Space between opening control structure and T_COLON is required';

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -37,3 +37,7 @@ if ( true ) {
     }
 
 }
+
+if ( false ):
+else:
+endif;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -41,3 +41,7 @@ if ( true ) {
 if ( false ):
 else:
 endif;
+
+if ( false ) :
+else :
+endif;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -36,6 +36,6 @@ if ( true ) {
     }
 }
 
-if ( false ):
-else:
+if ( false ) :
+else :
 endif;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -39,3 +39,7 @@ if ( true ) {
 if ( false ) :
 else :
 endif;
+
+if ( false ) :
+else :
+endif;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -35,3 +35,7 @@ if ( true ) {
 
     }
 }
+
+if ( false ):
+else:
+endif;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -47,6 +47,8 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
                 17 => 1,
                 29 => 4,
                 37 => 1,
+                41 => 1,
+                42 => 1,
                );
 
         // Uncomment when "$blank_line_check" parameter will be "true" by default.


### PR DESCRIPTION
Curently `else:` throws two errors:

1. Space after opening control structure is required (the Coding Standards handbook doesn't say anything on this)
1. No space before opening parenthesis is prohibited (this is just wrong - there is no paranthesis on this line)

This pull request prevents the sniffer from throwing these two errors.

------

If my interpretation of 1. is considered correct, I could add a fixable error for `else :`
