### PR TITLE
Add wp_verify_nonce() to auto-escaped funcs

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -165,7 +165,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		'wp_shortlink_wp_head',
 		'wp_tag_cloud',
 		'wp_title',
-		'checked',
+		'wp_verify_nonce',
 	);
 
 	public static $sanitizingFunctions = array(


### PR DESCRIPTION
This function only returns `false`, 1, or 2.

Though this function isn't generally `echo`ed, this list is also used by the [Validated/Sanitized Input Sniff](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/20de02d447428c6befd95f6785b987b771242e83/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php#L158), and it is common to do something like `wp_verify_nonce( $_POST['nonce'], 'some_action' )`.

I've just replaced a duplicate `checked` that was out of alphabetical order.
