### PR TITLE
Add disabled() to auto-escaped funcs

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -58,6 +58,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		'comments_popup_script',
 		'comments_rss_link',
 		'delete_get_calendar_cache',
+		'disabled',
 		'do_shortcode_tag',
 		'edit_bookmark_link',
 		'edit_comment_link',


### PR DESCRIPTION
See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/280#issuecomment-66392572
