### PR TITLE
Revert "Add wp_verify_nonce() to auto-escaped funcs"

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -165,7 +165,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		'wp_shortlink_wp_head',
 		'wp_tag_cloud',
 		'wp_title',
-		'wp_verify_nonce',
+		'checked',
 	);
 
 	public static $sanitizingFunctions = array(


### PR DESCRIPTION
Reverts WordPress-Coding-Standards/WordPress-Coding-Standards#282
