### PR TITLE
Add granular error/warning names - issue #297, #140

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -57,12 +57,12 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
         }
 
         if ( ! isset( $tokens[$stackPtr]['parenthesis_opener'] ) ) {
-            $phpcsFile->addError('Missing parenthesis opener.', $stackPtr);
+            $phpcsFile->addError('Missing parenthesis opener.', $stackPtr, 'NoParenthesis');
             return;
         }
         $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
         if ( ! isset( $tokens[$arrayStart]['parenthesis_closer'] ) ) {
-            $phpcsFile->addError('Missing parenthesis closer.', $arrayStart);
+            $phpcsFile->addError('Missing parenthesis closer.', $arrayStart, 'NoParenthesis');
             return;
         }
         $arrayEnd = $tokens[$arrayStart]['parenthesis_closer'];
@@ -93,7 +93,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             if ($tokens[($openBracket + 1)]['code'] !== T_WHITESPACE && $tokens[($openBracket + 1)]['code'] !== T_CLOSE_PARENTHESIS) {
                 // Checking this: $value = my_function([*]...).
                 $warning = 'No space after opening parenthesis of array is bad style';
-                $phpcsFile->addWarning($warning, $stackPtr);
+                $phpcsFile->addWarning($warning, $stackPtr, 'NoSpaceAfterOpenParenthesis');
             }
 
             $closer = $tokens[$openBracket]['parenthesis_closer'];
@@ -109,7 +109,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                 // $value = my_function( ).
                 if ($between !== $closer) {
                     $warning = 'No space before closing parenthesis of array is bad style';
-                    $phpcsFile->addWarning($warning, $closer);
+                    $phpcsFile->addWarning($warning, $closer, 'NoSpaceBeforeCloseParenthesis');
                 }
             }
 
@@ -130,26 +130,26 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                 if ($tokens[($nextArrow - 1)]['code'] !== T_WHITESPACE) {
                     $content = $tokens[($nextArrow - 1)]['content'];
                     $error   = "Expected 1 space between \"$content\" and double arrow; 0 found";
-                    $phpcsFile->addError($error, $nextArrow);
+                    $phpcsFile->addError($error, $nextArrow, 'NoSpaceBeforeDoubleArrow');
                 } else {
                     $spaceLength = strlen($tokens[($nextArrow - 1)]['content']);
                     if ($spaceLength !== 1) {
                         $content = $tokens[($nextArrow - 2)]['content'];
                         $error   = "Expected 1 space between \"$content\" and double arrow; $spaceLength found";
-                        $phpcsFile->addError($error, $nextArrow);
+                        $phpcsFile->addError($error, $nextArrow, 'SpaceBeforeDoubleArrow');
                     }
                 }
 
                 if ($tokens[($nextArrow + 1)]['code'] !== T_WHITESPACE) {
                     $content = $tokens[($nextArrow + 1)]['content'];
                     $error   = "Expected 1 space between double arrow and \"$content\"; 0 found";
-                    $phpcsFile->addError($error, $nextArrow);
+                    $phpcsFile->addError($error, $nextArrow, 'NoSpaceAfterDoubleArrow');
                 } else {
                     $spaceLength = strlen($tokens[($nextArrow + 1)]['content']);
                     if ($spaceLength !== 1) {
                         $content = $tokens[($nextArrow + 2)]['content'];
                         $error   = "Expected 1 space between double arrow and \"$content\"; $spaceLength found";
-                        $phpcsFile->addError($error, $nextArrow);
+                        $phpcsFile->addError($error, $nextArrow, 'SpaceAfterDoubleArrow');
                     }
                 }
             }//end while
@@ -163,13 +163,13 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     if ($tokens[($comma + 1)]['code'] !== T_WHITESPACE) {
                         $content = $tokens[($comma + 1)]['content'];
                         $error   = "Expected 1 space between comma and \"$content\"; 0 found";
-                        $phpcsFile->addError($error, $comma);
+                        $phpcsFile->addError($error, $comma, 'NoSpaceAfterComma');
                     } else {
                         $spaceLength = strlen($tokens[($comma + 1)]['content']);
                         if ($spaceLength !== 1) {
                             $content = $tokens[($comma + 2)]['content'];
                             $error   = "Expected 1 space between comma and \"$content\"; $spaceLength found";
-                            $phpcsFile->addError($error, $comma);
+                            $phpcsFile->addError($error, $comma, 'SpaceAfterComma');
                         }
                     }
 
@@ -177,7 +177,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                         $content     = $tokens[($comma - 2)]['content'];
                         $spaceLength = strlen($tokens[($comma - 1)]['content']);
                         $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                        $phpcsFile->addError($error, $comma);
+                        $phpcsFile->addError($error, $comma, 'SpaceBeforeComma');
                     }
                 }//end foreach
             }//end if
@@ -222,7 +222,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                         $content     = $tokens[($nextToken - 2)]['content'];
                         $spaceLength = strlen($tokens[($nextToken - 1)]['content']);
                         $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                        $phpcsFile->addError($error, $nextToken);
+                        $phpcsFile->addError($error, $nextToken, 'SpaceBeforeComma');
                     }
 
                     // Find the value, which will be the first token on the line,
@@ -250,7 +250,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             if ($tokens[$nextToken]['code'] === T_DOUBLE_ARROW) {
                 if ($singleUsed === true) {
                     $error = 'Key specified for array entry; first entry has no key';
-                    $phpcsFile->addError($error, $nextToken);
+                    $phpcsFile->addError($error, $nextToken, 'KeySpecified');
                     return;
                 }
 
@@ -325,7 +325,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             $trailingContent = $phpcsFile->findPrevious(array(T_WHITESPACE, T_COMMENT), ($arrayEnd - 1), $lastIndex, true);
             if ($tokens[$trailingContent]['code'] !== T_COMMA) {
                 $error = 'Comma required after last value in array declaration';
-                $phpcsFile->addError($error, $trailingContent);
+                $phpcsFile->addError($error, $trailingContent, 'NoCommaAfterLast');
             }
 
             foreach ($indices as $value) {
@@ -342,7 +342,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                         // was indented and not flush with the opening parenthesis.
                         if ($tokens[$value['value']]['column'] !== ($keywordStart + 1)) {
                             $error = 'Array value not aligned correctly; expected '.($keywordStart + 1).' spaces but found '.$tokens[$value['value']]['column'];
-                            $phpcsFile->addError($error, $value['value']);
+                            $phpcsFile->addError($error, $value['value'], 'ValueNotAligned');
                         }
                     }
                 */
@@ -380,20 +380,20 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             if (isset($index['index']) === false) {
                 // Array value only.
                 if (($tokens[$index['value']]['line'] === $tokens[$stackPtr]['line']) && ($numValues > 1)) {
-                    $phpcsFile->addError('The first value in a multi-value array must be on a new line', $stackPtr);
+                    $phpcsFile->addError('The first value in a multi-value array must be on a new line', $stackPtr, 'FirstValueNoNewline');
                 }
 
                 continue;
             }
 
             if (($tokens[$index['index']]['line'] === $tokens[$stackPtr]['line'])) {
-                $phpcsFile->addError('The first index in a multi-value array must be on a new line', $stackPtr);
+                $phpcsFile->addError('The first index in a multi-value array must be on a new line', $stackPtr, 'FirstIndexNoNewline');
                 continue;
             }
 
             /*
                 if ($tokens[$index['index']]['column'] !== $indicesStart) {
-                    $phpcsFile->addError('Array key not aligned correctly; expected '.$indicesStart.' spaces but found '.$tokens[$index['index']]['column'], $index['index']);
+                    $phpcsFile->addError('Array key not aligned correctly; expected '.$indicesStart.' spaces but found '.$tokens[$index['index']]['column'], $index['index'], 'KeyNotAligned');
                     continue;
                 }
 
@@ -401,7 +401,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     $expected  = ($arrowStart - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
                     $expected .= ($expected === 1) ? ' space' : ' spaces';
                     $found     = ($tokens[$index['arrow']]['column'] - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
-                    $phpcsFile->addError("Array double arrow not aligned correctly; expected $expected but found $found", $index['arrow']);
+                    $phpcsFile->addError("Array double arrow not aligned correctly; expected $expected but found $found", $index['arrow'], 'DoubleArrowNotAligned');
                     continue;
                 }
 
@@ -409,7 +409,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     $expected  = ($valueStart - (strlen($tokens[$index['arrow']]['content']) + $tokens[$index['arrow']]['column']));
                     $expected .= ($expected === 1) ? ' space' : ' spaces';
                     $found     = ($tokens[$index['value']]['column'] - (strlen($tokens[$index['arrow']]['content']) + $tokens[$index['arrow']]['column']));
-                    $phpcsFile->addError("Array value not aligned correctly; expected $expected but found $found", $index['arrow']);
+                    $phpcsFile->addError("Array value not aligned correctly; expected $expected but found $found", $index['arrow'], 'ValueNotAligned');
                 }
             */
 
@@ -439,7 +439,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     }
                     if ( $fail ) {
                         $error = 'Each line in an array declaration must end in a comma';
-                        $phpcsFile->addError($error, $index['value']);
+                        $phpcsFile->addError($error, $index['value'], 'NoComma');
                     }
                 }
 
@@ -448,7 +448,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
                     $content     = $tokens[($nextComma - 2)]['content'];
                     $spaceLength = strlen($tokens[($nextComma - 1)]['content']);
                     $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                    $phpcsFile->addError($error, $nextComma);
+                    $phpcsFile->addError($error, $nextComma, 'SpaceBeforeComma');
                 }
             }
         }//end foreach

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -38,7 +38,7 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 
 		$token = $tokens[ $stackPtr ];
 		if ( ! isset( $token['bracket_closer'] ) ) {
-			$phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr );
+			$phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr, 'MissingBracketCloser' );
 			return;
 		}
 
@@ -55,11 +55,11 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 		// It should have spaces only if it only has strings or numbers as the key
 		if ( $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
 			$error = 'Array keys should be surrounded by spaces unless they contain a string or an integer.';
-        	$phpcsFile->addWarning( $error, $stackPtr );
+        	$phpcsFile->addWarning( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 		}
 		elseif( ! $need_spaces && ( $spaced1 || $spaced2 ) ) {
 			$error = 'Array keys should NOT be surrounded by spaces if they only contain a string or an integer.';
-        	$phpcsFile->addWarning( $error, $stackPtr );
+        	$phpcsFile->addWarning( $error, $stackPtr, 'SpacesAroundArrayKeys' );
 		}
 
 	}//end process()

--- a/WordPress/Sniffs/Classes/ValidClassNameSniff.php
+++ b/WordPress/Sniffs/Classes/ValidClassNameSniff.php
@@ -64,7 +64,7 @@ class WordPress_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sn
             $error  = 'Possible parse error: ';
             $error .= $tokens[$stackPtr]['content'];
             $error .= ' missing opening or closing brace';
-            $phpcsFile->addWarning($error, $stackPtr);
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace');
             return;
         }
 
@@ -81,7 +81,7 @@ class WordPress_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sn
         if ($valid === false) {
             $type  = ucfirst($tokens[$stackPtr]['content']);
             $error = "$type name \"$name\" is not in camel caps format";
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps');
         }
 
     }//end process()

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -60,7 +60,7 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
         if (strpos($fileName, '_') !== false) {
                 $expected = str_replace('_', '-', $fileName);
                 $error    = ucfirst('Filename "'.$fileName.'" with underscores found; use '.$expected.' instead');
-                $phpcsFile->addError($error, $stackPtr);
+                $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
 
     }//end process()

--- a/WordPress/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -72,14 +72,14 @@ class WordPress_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff impleme
                     $gap   = strlen($tokens[($nextParam + 1)]['content']);
                     $arg   = $tokens[$nextParam]['content'];
                     $error = "Expected 1 space between argument \"$arg\" and equals sign; ".($gap - 1)." found";
-                    $phpcsFile->addError($error, $nextToken);
+                    $phpcsFile->addError($error, $nextToken, 'SpaceBeforeEquals');
                 }
 
                 if ($tokens[($nextToken + 1)]['code'] !== T_WHITESPACE) {
                     $gap   = strlen($tokens[($nextToken + 1)]['content']);
                     $arg   = $tokens[$nextParam]['content'];
                     $error = "Expected 1 space between default value and equals sign for argument \"$arg\";";
-                    $phpcsFile->addError($error, $nextToken);
+                    $phpcsFile->addError($error, $nextToken, 'SpaceAfterEquals');
                 }
             }
 
@@ -91,7 +91,7 @@ class WordPress_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff impleme
                     $space = strlen($tokens[($nextComma - 1)]['content']);
                     $arg   = $tokens[$nextParam]['content'];
                     $error = "Expected 0 spaces between argument \"$arg\" and comma; $space found";
-                    $phpcsFile->addError($error, $nextToken);
+                    $phpcsFile->addError($error, $nextToken, 'SpaceBeforeComma');
                 }
             }
 
@@ -124,28 +124,28 @@ class WordPress_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff impleme
 
                         if ($gap !== 1) {
                             $error = "Expected 1 space between type hint and argument \"$arg\"; $gap found";
-                            $phpcsFile->addError($error, $nextToken);
+                            $phpcsFile->addError($error, $nextToken, 'SpacingAfterHint');
                         }
 
                         if ($multiLine === false) {
                             if ($tokens[($comma + 1)]['code'] !== T_WHITESPACE) {
                                 $error = "Expected 1 space between comma and type hint \"$hint\"; 0 found";
-                                $phpcsFile->addError($error, $nextToken);
+                                $phpcsFile->addError($error, $nextToken, 'NoSpaceBeforeHint');
                             } else {
                                 $gap = strlen($tokens[($comma + 1)]['content']);
                                 if ($gap !== 1) {
                                     $error = "Expected 1 space between comma and type hint \"$hint\"; $gap found";
-                                    $phpcsFile->addError($error, $nextToken);
+                                    $phpcsFile->addError($error, $nextToken, 'SpacingBeforeHint');
                                 }
                             }
                         }
                     } else if ($multiLine === false && $gap !== 1) {
                         $error = "Expected 1 space between comma and argument \"$arg\"; $gap found";
-                        $phpcsFile->addError($error, $nextToken);
+                        $phpcsFile->addError($error, $nextToken, 'SpacingBeforeArg');
                     }//end if
                 } else {
                     $error = "Expected 1 space between comma and argument \"$arg\"; 0 found";
-                    $phpcsFile->addError($error, $nextToken);
+                    $phpcsFile->addError($error, $nextToken, 'NoSpaceBeforeArg');
                 }//end if
             } else {
                 // First argument in function declaration.
@@ -167,7 +167,7 @@ class WordPress_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff impleme
 
                         if ($gap !== 1) {
                             $error = "Expected 1 space between type hint and argument \"$arg\"; $gap found";
-                            $phpcsFile->addError($error, $nextToken);
+                            $phpcsFile->addError($error, $nextToken, 'SpacingAfterHint');
                         }
                     }
                 }//end if

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -56,7 +56,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
             $suggested = str_replace('__', '_', $suggested);
 
             $error = "Function name \"$functionName\" is in camel caps format, try '".$suggested."'";
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'FunctionNameInvalid');
         }
 
     }//end processTokenOutsideScope()
@@ -82,7 +82,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
             $magicPart = substr($methodName, 2);
             if (in_array($magicPart, $this->_magicMethods) === false) {
                  $error = "Method name \"$className::$methodName\" is invalid; only PHP magic methods should be prefixed with a double underscore";
-                 $phpcsFile->addError($error, $stackPtr);
+                 $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore');
             }
 
             return;
@@ -123,7 +123,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
             $suggested = str_replace('__', '_', $suggested);
 
             $error = "Function name \"$methodName\" is in camel caps format, try '".$suggested."'";
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'FunctionNameInvalid');
         }
 
     }//end processTokenWithinScope()

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -40,7 +40,7 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		if ( in_array( trim( $tokens[$stackPtr]['content'], '"\'' ), array( 'show_admin_bar' ) ) ) {
-			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr );
+			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected');
 		}
 	}//end process()
 

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -121,7 +121,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 		}
 
 		if ( isset( $interval ) && $interval < ( 15 * 60 ) ) {
-			$phpcsFile->addError( 'Scheduling crons at %s sec ( less than 15 min ) is prohibited.', $stackPtr, 'cron_schedules_interval', array( $interval ) );
+			$phpcsFile->addError( 'Scheduling crons at %s sec ( less than 15 min ) is prohibited.', $stackPtr, 'CronSchedulesInterval', array( $interval ) );
 			return;
 		}
 
@@ -130,7 +130,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 
 
 	public function confused( $phpcsFile, $stackPtr ) {
-		$phpcsFile->addWarning( 'Detected changing of cron_schedules, but could not detect the interval value.', $stackPtr );
+		$phpcsFile->addWarning( 'Detected changing of cron_schedules, but could not detect the interval value.', $stackPtr, 'ChangeDetected' );
 	}
 
 

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -72,9 +72,9 @@ class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_
 		$error = 'Filesystem writes are forbidden, you should not be using %s()';
 
 		if ( $this->error === true ) {
-			$phpcsFile->addError( $error, $stackPtr, '', $data );
+			$phpcsFile->addError( $error, $stackPtr, 'FileWriteDetected', $data );
 		} else {
-			$phpcsFile->addWarning( $error, $stackPtr, '', $data );
+			$phpcsFile->addWarning( $error, $stackPtr, 'FileWriteDetected', $data );
 		}
 
 	}//end addError()

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -50,7 +50,7 @@ class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends Generic_Sniffs_PHP
         $data  = array($function);
         $error = 'The use of PHP session function %s() is prohibited.';
 
-        $phpcsFile->addError( $error, $stackPtr, null, $data );
+        $phpcsFile->addError( $error, $stackPtr, $function, $data );
 
     }//end addError()
 

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -65,7 +65,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff implements PHP_CodeSniffer
 			);
 
 		if ( ! $is_whitelisted ) {
-			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, null, array( $varName ) );
+			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
 	}//end process()
 

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -27,7 +27,7 @@ class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_Forbid
     protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null )
     {
         $error = 'Using date_default_timezone_set() and similar isn’t allowed, instead use WP internal timezone support.';
-        $phpcsFile->addError( $error, $stackPtr );
+        $phpcsFile->addError( $error, $stackPtr, $function );
 
     }//end addError()
 

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -71,7 +71,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff implements PHP_CodeSniff
 				return;
 		} else {
 			if ( ! $is_casted ) {
-				$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, null, array( $tokens[$stackPtr]['content'] ) );
+				$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', array( $tokens[$stackPtr]['content'] ) );
 				return;
 			}
 		}
@@ -140,7 +140,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff implements PHP_CodeSniff
 		}
 		
 		if ( ! $is_validated ) {
-			$phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, null, array( $tokens[$stackPtr]['content'] ) );
+			$phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', array( $tokens[$stackPtr]['content'] ) );
 			// return; // Should we just return and not look for sanitizing functions ?
 		}
 
@@ -169,7 +169,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff implements PHP_CodeSniff
 		}
 
 		if ( ! $is_sanitized ) {
-			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, null, array( $tokens[$stackPtr]['content'] ) );
+			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', array( $tokens[$stackPtr]['content'] ) );
 		}
 
 

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -42,12 +42,12 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
         $token  = $tokens[$stackPtr];
 
         if ( preg_match( '#rel=[\'"]?stylesheet[\'"]?#', $token['content'], $matches ) > 0 ) {
-            $phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr );
+            $phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr, 'NonEnqueuedStylesheet' );
             return;
         }
 
         if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'], $matches ) > 0 ) {
-            $phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr );
+            $phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr, 'NonEnqueuedScript' );
             return;
         }
 

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -70,12 +70,12 @@ class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeS
 
         if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
             $error = 'No space before opening casting parenthesis is prohibited';
-            $phpcsFile->addWarning($error, $stackPtr);
+            $phpcsFile->addWarning($error, $stackPtr, 'NoSpaceBeforeOpenParenthesis');
         }
 
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             $error = 'No space after closing casting parenthesis is prohibited';
-            $phpcsFile->addWarning($error, $stackPtr);
+            $phpcsFile->addWarning($error, $stackPtr, 'NoSpaceAfterCloseParenthesis');
         }
 	}//end process()
 

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -347,7 +347,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 
 			// Now check that next token is a function call.
 			if ( in_array( $tokens[$i]['code'], array( T_STRING ) ) === false ) {
-				$phpcsFile->addError( "Expected next thing to be a escaping function, not '%s'", $i, null, $tokens[$i]['content'] );
+				$phpcsFile->addError( "Expected next thing to be a escaping function, not '%s'", $i, 'OutputNotEscaped', $tokens[$i]['content'] );
 				continue;
 			}
 
@@ -360,7 +360,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 					in_array( $functionName, self::$sanitizingFunctions ) === false
 					) {
 
-					$phpcsFile->addError( "Expected a sanitizing function (see Codex for 'Data Validation'), but instead saw '%s'", $i, null, $tokens[$i]['content'] );
+					$phpcsFile->addError( "Expected a sanitizing function (see Codex for 'Data Validation'), but instead saw '%s'", $i, 'OutputNotSanitized', $tokens[$i]['content'] );
 				}
 
 				// Skip pointer to after the function


### PR DESCRIPTION
I've added granular error/warning names in most places.
* I've ignored some sniff files which only throw one specific error as those can be disabled by just disabling the sniff itself.
* For error/warning names, I've used the Squiz and PEAR coding standards for inspiration and stuck to the names used in there for the same error if one existed.
* In 1 instance (VIP/CronIntervalSniff), the existing error name did not comply with the CamelCaps convention for the names. I've changed the name. This will break backward compatibility for any rulesets referencing the 'old' name.