### PR TITLE
Change array key spacing message from warning to error

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -54,11 +54,11 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 
 		// It should have spaces only if it only has strings or numbers as the key
 		if ( $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
-			$error = 'Array keys should be surrounded by spaces unless they contain a string or an integer.';
+			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
         	$phpcsFile->addError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 		}
 		elseif( ! $need_spaces && ( $spaced1 || $spaced2 ) ) {
-			$error = 'Array keys should NOT be surrounded by spaces if they only contain a string or an integer.';
+			$error = 'Array keys must NOT be surrounded by spaces if they only contain a string or an integer.';
         	$phpcsFile->addError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
 		}
 

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -55,11 +55,11 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 		// It should have spaces only if it only has strings or numbers as the key
 		if ( $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
 			$error = 'Array keys should be surrounded by spaces unless they contain a string or an integer.';
-        	$phpcsFile->addWarning( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
+        	$phpcsFile->addError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 		}
 		elseif( ! $need_spaces && ( $spaced1 || $spaced2 ) ) {
 			$error = 'Array keys should NOT be surrounded by spaces if they only contain a string or an integer.';
-        	$phpcsFile->addWarning( $error, $stackPtr, 'SpacesAroundArrayKeys' );
+        	$phpcsFile->addError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
 		}
 
 	}//end process()

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -20,20 +20,6 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 	 */
 	public function getErrorList()
 	{
-		return array();
-	}//end getErrorList()
-
-
-	/**
-	 * Returns the lines where warnings should occur.
-	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of warnings that should occur on that line.
-	 *
-	 * @return array(int => int)
-	 */
-	public function getWarningList()
-	{
 		return array(
 			4 => 1,
 			5 => 1,
@@ -49,6 +35,20 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 			29 => 1,
 			31 => 1,
 		);
+	}//end getErrorList()
+
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList()
+	{
+		return array();
 	}//end getWarningList()
 
 


### PR DESCRIPTION
As it's a hard rule mentioned in the core guide and most other spacing rules are enforced with errors, I suggest changing the enforcement of this rule from warning to error.