### PR TITLE
Account for ternary operator in XSS sniff

### DIFF
--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -55,3 +55,7 @@ echo ent2ncr( $text );
 echo number_format ( 1024 );
 
 echo ent2ncr( esc_html( $_data ) );
+
+echo $foo ? $foo : 'no foo'; // Bad
+echo empty( $foo ) ? 'no foo' : $foo; // Bad
+echo $foo ? esc_html( $foo ) : 'no foo'; // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -51,6 +51,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 41 => 1,
                 43 => 1,
                 46 => 1,
+                59 => 1,
+                60 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
When a ternary operator is present in an `echo` statement, it is safe
to skip over everything before the `?`, since that part isn’t output.

Includes unit tests.

Fixes #281