### PR TITLE
Allow camel caps method names in child classes

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -98,6 +98,11 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
             return;
         }
 
+        // If this is a child class, it may have to use camelCase.
+        if (  $phpcsFile->findExtendedClassName( $currScope ) ) {
+            return;
+        }
+
         $methodProps    = $phpcsFile->getMethodProperties($stackPtr);
         $scope          = $methodProps['scope'];
         $scopeSpecified = $methodProps['scope_specified'];

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -20,3 +20,8 @@ class My_Plugin {
 
 	public function __invoke() {} // OK
 }
+
+class Test extends WP_UnitTestCase {
+
+	public function setUp() {} // OK
+}


### PR DESCRIPTION
Fixes #278