### PR TITLE
Remove BOM that breaks JSON output parsing

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Modified version of Squiz operator white spacing, based upon Squiz code
  *


### PR DESCRIPTION
WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php contains byte-order marks before the opening PHP tags. This causes output reports to also include this output. Unfortunately this breaks parsing of the JSON reports (See https://github.com/Block8/PHPCI/issues/768). 

This patch just removes the extra characters before the opening PHP tags.