### PR TITLE
Allow integers in XSS sniff

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -344,7 +344,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			$watch = false;
 
 			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
-			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING ) ) ) {
+			// Also T_LNUMBER, e.g.: echo 45;
+			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER ) ) ) {
 				continue;
 			}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -59,3 +59,5 @@ echo ent2ncr( esc_html( $_data ) );
 echo $foo ? $foo : 'no foo'; // Bad
 echo empty( $foo ) ? 'no foo' : $foo; // Bad
 echo $foo ? esc_html( $foo ) : 'no foo'; // OK
+
+echo 4; // OK


### PR DESCRIPTION
Currently the XSS sniff will flag this:

```php
echo 5;
```

Of course, that’s harmless.