### PR TITLE
XSS sniff: require escaping for die(), exit(), printf()

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -292,6 +292,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			$needs_sanitizing_function = true;
 
 			$stackPtr++; // Ignore the starting bracket
+
+			$end_of_statement = $tokens[ $stackPtr ]['parenthesis_closer'];
 		}
 
 		if ( $tokens[ $stackPtr ]['code'] === T_EXIT ) {
@@ -323,7 +325,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			}
 		}
 
-		$end_of_statement = $phpcsFile->findNext( T_SEMICOLON, $stackPtr );
+		// This is already determined if $needs_sanitizing_function.
+		if ( ! isset( $end_of_statement ) ) {
+			$end_of_statement = $phpcsFile->findNext( T_SEMICOLON, $stackPtr );
+		}
 
 		// Check for the ternary operator.
 		$ternary = $phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -280,6 +280,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 
 		$needs_sanitizing_function = false;
 
+		$function = $tokens[ $stackPtr ]['content'];
+
 		// If function, not T_ECHO nor T_PRINT
 		if ( $tokens[$stackPtr]['code'] == T_STRING ) {
 			// Skip if it is a function but is not of the printing functions ( self::needSanitizingFunctions )
@@ -336,6 +338,11 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			// Ignore whitespaces
 			if ( $tokens[$i]['code'] == T_WHITESPACE )
 				continue;
+
+			if ( 'vprintf' === $function && $tokens[ $i ]['code'] === T_ARRAY ) {
+				$i++; // Skip the opening parenthesis.
+				continue;
+			}
 
 			// Wake up on concatenation characters, another part to check
 			if ( in_array( $tokens[$i]['code'], array( T_STRING_CONCAT ) ) ) {

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -247,6 +247,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		return array(
 			T_ECHO,
 			T_PRINT,
+			T_EXIT,
 			T_STRING,
 		);
 
@@ -282,6 +283,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 				return;
 			}
 
+			$stackPtr++; // Ignore the starting bracket
+		}
+
+		if ( $tokens[ $stackPtr ]['code'] === T_EXIT ) {
 			$stackPtr++; // Ignore the starting bracket
 		}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -67,3 +67,5 @@ exit( esc_html( $foo ) ); // OK
 
 die( $foo ); // Bad
 die( esc_html( $foo ) ); // OK
+
+printf( 'Hello %s', $foo ); // Bad

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -74,3 +74,12 @@ printf( 'Hello %s! Hi %s!', esc_html( $foo ), $bar ); // Bad
 
 vprintf( 'Hello %s', array( $foo ) ); // Bad
 vprintf( 'Hello %s', array( esc_html( $foo ) ) ); // OK
+
+// The below checks that functions which are marked as needed further sanitization
+// don't spill over into later arguments when nested in a function call. There was
+// a bug which would cause line 84 to be marked as needing sanitization because _x()
+// is marked as needing sanitization.
+do_something(
+	_x( 'Some string', 'context', 'domain' )
+	, array( $foo ) // OK
+);

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -69,3 +69,8 @@ die( $foo ); // Bad
 die( esc_html( $foo ) ); // OK
 
 printf( 'Hello %s', $foo ); // Bad
+printf( 'Hello %s', esc_html( $foo ) ); // OK
+printf( 'Hello %s! Hi %s!', esc_html( $foo ), $bar ); // Bad
+
+vprintf( 'Hello %s', array( $foo ) ); // Bad
+vprintf( 'Hello %s', array( esc_html( $foo ) ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -61,3 +61,9 @@ echo empty( $foo ) ? 'no foo' : $foo; // Bad
 echo $foo ? esc_html( $foo ) : 'no foo'; // OK
 
 echo 4; // OK
+
+exit( $foo ); // Bad
+exit( esc_html( $foo ) ); // OK
+
+die( $foo ); // Bad
+die( esc_html( $foo ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -55,6 +55,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 60 => 1,
                 65 => 1,
                 68 => 1,
+                71 => 1,
                );
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -56,6 +56,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 65 => 1,
                 68 => 1,
                 71 => 1,
+                73 => 1,
+                75 => 1,
                );
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -53,6 +53,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 46 => 1,
                 59 => 1,
                 60 => 1,
+                65 => 1,
+                68 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Other functions we should possibly add: https://stackoverflow.com/questions/4673747/what-php-functions-create-output

See #170