### PR TITLE
XSS: don't flag code after an empty exit

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -296,7 +296,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			$end_of_statement = $tokens[ $stackPtr ]['parenthesis_closer'];
 		}
 
-		if ( $tokens[ $stackPtr ]['code'] === T_EXIT ) {
+		if ( $tokens[ $stackPtr ]['code'] === T_EXIT && $tokens[ $stackPtr + 1 ]['code'] === T_OPEN_PARENTHESIS ) {
 			$stackPtr++; // Ignore the starting bracket
 		}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -83,3 +83,10 @@ do_something(
 	_x( 'Some string', 'context', 'domain' )
 	, array( $foo ) // OK
 );
+
+// There was a bug where an empty exit followed by other code would give an error.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // OK
+} else {
+	other();
+}


### PR DESCRIPTION
This bug would happen when there was code like this:

```php
if ( ! defined( ‘ABSPATH’ ) ) {
exit; // We skipped over the semicolon, assuming the next thing would be an opening parenthesis.
}

// This code would get flagged as needing escaping.
other_code();
```

See #312