### PR TITLE
XSS sniff: don't flag comments as needing escaping

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -340,9 +340,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		$watch = true;
 		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
 
-			// Ignore whitespaces
-			if ( $tokens[$i]['code'] == T_WHITESPACE )
+			// Ignore whitespaces and comments.
+			if ( in_array( $tokens[ $i ]['code'], array( T_WHITESPACE, T_COMMENT ) ) ) {
 				continue;
+			}
 
 			if ( 'vprintf' === $function && $tokens[ $i ]['code'] === T_ARRAY ) {
 				$i++; // Skip the opening parenthesis.

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -90,3 +90,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 } else {
 	other();
 }
+
+printf(
+	/* translators: this comment is just for you. */
+	esc_html__( 'Hello %s.', 'domain' )
+	, 'world'
+	// There were other long arguments down here "in real life", which is why this was multi-line.
+);


### PR DESCRIPTION
Because, hey, they don’t.