### PR TITLE
XSS sniff: Add wp_die() to the list of printing functions

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -353,6 +353,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 				continue;
 			}
 
+			if ( $tokens[ $i ]['code'] === T_DOUBLE_ARROW && 'wp_die' === $function ) {
+				continue;
+			}
+
 			// Wake up on concatenation characters, another part to check
 			if ( in_array( $tokens[$i]['code'], array( T_STRING_CONCAT ) ) ) {
 				$watch = true;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -374,13 +374,13 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			if ( $watch === false )
 				continue;
 
-			$watch = false;
-
 			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
 			// Also T_LNUMBER, e.g.: echo 45;
 			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER ) ) ) {
 				continue;
 			}
+
+			$watch = false;
 
 			// Allow int/double/bool casted variables
 			if ( in_array( $tokens[$i]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ) ) ) {

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -97,3 +97,9 @@ printf(
 	, 'world'
 	// There were other long arguments down here "in real life", which is why this was multi-line.
 );
+
+wp_die( $message ); // Bad
+wp_die( esc_html( $message ) ); // OK
+wp_die( esc_html( $message ), $title ); // Bad
+wp_die( esc_html( $message ), '', array( 'back_link' => $link_text ) ); // Bad
+wp_die( esc_html( $message ), '', array( 'back_link' => esc_html( $link_text ) ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -58,6 +58,9 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 71 => 1,
                 73 => 1,
                 75 => 1,
+                101 => 1,
+                103 => 1,
+                104 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
`wp_die()` takes three parameters, and [all of their values may be
printed to the
user](https://developer.wordpress.org/reference/functions/_default_wp_di
e_handler/), without any escaping.