### PR TITLE
XSS sniff: ignore ending parenthesis for wp_die()

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -353,7 +353,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 				continue;
 			}
 
-			if ( $tokens[ $i ]['code'] === T_DOUBLE_ARROW && 'wp_die' === $function ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ) ) && 'wp_die' === $function ) {
 				continue;
 			}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -103,3 +103,4 @@ wp_die( esc_html( $message ) ); // OK
 wp_die( esc_html( $message ), $title ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => $link_text ) ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => esc_html( $link_text ) ) ); // OK
+wp_die( esc_html( $message ), '', array( 'response' => 200 ) ); // OK


### PR DESCRIPTION
Otherwise the ending parenthesis of the array will be reported in this:

```php
wp_die( esc_html( $message ), '', array( 'response' => 200 ) );
```