### PR TITLE
Support for echo with comma-separated args

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -352,6 +352,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			// Skip to the end of a function call if it has been casted to a safe value.
 			if ( T_OPEN_PARENTHESIS === $tokens[ $i ]['code'] && $in_cast ) {
 				$i = $tokens[ $i ]['parenthesis_closer'];
+				$in_cast = false;
 				continue;
 			}
 
@@ -379,6 +380,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 
 			// Wake up for commas.
 			if ( $tokens[ $i ]['code'] === T_COMMA ) {
+				$in_cast = false;
 				$watch = true;
 				continue;
 			}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -338,12 +338,20 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			$stackPtr = $ternary + 1;
 		}
 
+		$in_cast = false;
+
 		// looping through echo'd components
 		$watch = true;
 		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
 
 			// Ignore whitespaces and comments.
 			if ( in_array( $tokens[ $i ]['code'], array( T_WHITESPACE, T_COMMENT ) ) ) {
+				continue;
+			}
+
+			// Skip to the end of a function call if it has been casted to a safe value.
+			if ( T_OPEN_PARENTHESIS === $tokens[ $i ]['code'] && $in_cast ) {
+				$i = $tokens[ $i ]['parenthesis_closer'];
 				continue;
 			}
 
@@ -370,7 +378,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			}
 
 			// Wake up for commas.
-			if ( $is_printing_function && $tokens[$i]['code'] === T_COMMA ) {
+			if ( $tokens[ $i ]['code'] === T_COMMA ) {
 				$watch = true;
 				continue;
 			}
@@ -388,6 +396,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 
 			// Allow int/double/bool casted variables
 			if ( in_array( $tokens[$i]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ) ) ) {
+				$in_cast = true;
 				continue;
 			}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -104,3 +104,8 @@ wp_die( esc_html( $message ), $title ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => $link_text ) ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => esc_html( $link_text ) ) ); // OK
 wp_die( esc_html( $message ), '', array( 'response' => 200 ) ); // OK
+
+echo '<h2>', esc_html( $foo ), '</h2>'; // OK
+echo 'a', 'b'; // OK
+echo 'Hello, ', $foo; // Bad
+echo esc_html( $foo ), $bar; // Bad

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -109,5 +109,7 @@ echo '<h2>', esc_html( $foo ), '</h2>'; // OK
 echo 'a', 'b'; // OK
 echo 'Hello, ', $foo; // Bad
 echo esc_html( $foo ), $bar; // Bad
+echo (int) $foo, $bar; // Bad
+echo (int) get_post_meta( $post_id, SOME_NUMBER, true ), do_something( $else ); // Bad
 
 wp_die( -1 ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -63,6 +63,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 104 => 1,
                 110 => 1,
                 111 => 1,
+                112 => 1,
+                113 => 1,
                );
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -61,6 +61,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 101 => 1,
                 103 => 1,
                 104 => 1,
+                110 => 1,
+                111 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
`echo` accepts an unlimited number of arguments, separated by commas.
This was previously supported, however, there was a bug that any
arguments after the first escaping function would be ignored.

Recent changes (specifically e329860329df49f54a727aa2125b217b06a50e1f),
have made it so that now any commas themselves are being reported as
needing sanitization.

The fix is a simple change on line 373 so that we always wake up for
commas. All of the arguments given to `echo` are always checked, and
the commas themselves are ignored.

However, this causes an issue with the casting of function calls with
multiple arguments.

```php
echo (int) get_post_meta( $post_id, ‘some_integer’, true );
```

The first comma in the casted function would cause us to wake up
prematurely, and report the later arguments as needing escaping. I’ve
fixed this issue by watching for an opening parenthesis when the value
is being casted, and jumping to the end of the casted function. There
is already a test (on line 29) that demonstrates that this is working.