### PR TITLE
Yoda Sniff: Use tokenizer instead of regex

### DIFF
--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -84,6 +84,13 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			return;
 		}
 
+		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 )
+		$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true );
+
+		if ( T_VARIABLE === $tokens[ $next_non_empty ]['code'] ) {
+			return;
+		}
+
 		$phpcsFile->addError( 'Use Yoda Condition checks, you must', $stackPtr );
 
 	}//end process()

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -3,7 +3,7 @@ if ( $true == true || $false == false ) {  // Bad x 2 (in an 'if')
 	echo 'True';
 } elseif ( $true == true && $false == true ) { // Bad x 2 (in an 'elseif')
 	echo 'False';
-} elseif ( false == $true && true == $false ) { // Good - this is the correct was to do conditional checks
+} elseif ( false == $true && true == $false ) { // Good - this is the correct way to do conditional checks
 	echo 'False';
 }
 
@@ -35,8 +35,8 @@ if ( $true !== true ) { // Bad x 1
 	echo 'False';
 }
 
-// make sure the test exclues functions on the conditional check
 if ( $true == strtolower( $check ) ) { // Good
+// make sure the test excludes functions on the conditional check
 	echo 'True';
 }
 // makes sure the test excludes variable casting in the conditional check

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -35,8 +35,8 @@ if ( $true !== true ) { // Bad x 1
 	echo 'False';
 }
 
-if ( $true == strtolower( $check ) ) { // Good
 // make sure the test excludes functions on the conditional check
+if ( strtolower( $check ) == $true  ) { // Good
 	echo 'True';
 }
 // makes sure the test excludes variable casting in the conditional check
@@ -57,3 +57,19 @@ if ( $true == 0 ) { // Bad x 1
 } elseif ( 1 == $false ) { // Good x 1
 	echo 'False';
 }
+
+// Testing constant comparison.
+if ( $taxonomy === MyClass::TAXONOMY_SLUG ) { // Bad
+	$link = true;
+} elseif ( MyClass::TAXONOMY_SLUG === $taxonomy ) { // OK
+	$link = false;
+}
+
+if ( $foo === FOO_CONSTANT ) { // Bad
+	$link = true;
+} elseif ( FOO_CONSTANT === $foo ) { // OK
+	$link = false;
+}
+
+if ( $foo == $bar ) {} // Bad
+if ( ( $foo ) == $bar ) {} // OK

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -71,5 +71,4 @@ if ( $foo === FOO_CONSTANT ) { // Bad
 	$link = false;
 }
 
-if ( $foo == $bar ) {} // Bad
-if ( ( $foo ) == $bar ) {} // OK
+if ( $foo == $bar ) {} // OK

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -47,6 +47,8 @@ class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest
             32 => 1,
             49 => 1,
             55 => 1,
+            62 => 1,
+            68 => 1,
         );
 
     }//end getErrorList()


### PR DESCRIPTION
This fixes issues with comparison to constants not being flagged, and
probably will be less buggy overall.

There is one side-effect:

```php
// Before this was good:
if ( $true == strtolower( $check ) ) {}

// Now it’s bad, but this is OK:
if ( strtolower( $check ) == $true  ) {}
```

I think this is the correct behavior.

Another thing to consider is when comparing a variable to a variable. I
don’t remember what the previous behavior was, but this is current
behavior:

```php
if ( $foo == $bar ) {} // Bad
if ( ( $foo ) == $bar ) {} // OK
```

Finally, the matching code is no longer included in the error message.
It’s possible to add that back in, but it would take some work.

Feedback welcome. :-)

Fixes #290