### PR TITLE
XSS sniff: allow for negative numbers

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -379,8 +379,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 				continue;
 
 			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
-			// Also T_LNUMBER, e.g.: echo 45;
-			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER ) ) ) {
+			// Also T_LNUMBER, e.g.: echo 45; exit -1;
+			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_MINUS ) ) ) {
 				continue;
 			}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -104,3 +104,5 @@ wp_die( esc_html( $message ), $title ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => $link_text ) ); // Bad
 wp_die( esc_html( $message ), '', array( 'back_link' => esc_html( $link_text ) ) ); // OK
 wp_die( esc_html( $message ), '', array( 'response' => 200 ) ); // OK
+
+wp_die( -1 ); // OK


### PR DESCRIPTION
I have quite a few instances of `wp_die( -1 );` in some of my code.
This is used a lot in WordPress too.