### PR TITLE
XSS sniff: Add rawurlencode() to the sanitizing functions

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -193,6 +193,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		'is_email',
 		'json_encode',
 		'like_escape',
+		'rawurlencode',
 		'sanitize_bookmark',
 		'sanitize_bookmark_field',
 		'sanitize_email',


### PR DESCRIPTION
This function is almost identical to `urlencode()`, which is already in the list. The difference is that [`rawurlencode()` is more up-to-date with the standards](http://stackoverflow.com/q/996139/1924128), while `urlencode()` is more of a legacy function.