### PR TITLE
Fix EscapeOutput regression

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -330,7 +330,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 
 		// This is already determined if $is_printing_function.
 		if ( ! isset( $end_of_statement ) ) {
-			$end_of_statement = $phpcsFile->findNext( T_SEMICOLON, $stackPtr );
+			$end_of_statement = $phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
 		}
 
 		// Check for the ternary operator.

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -363,7 +363,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 				continue;
 			}
 
-			if ( in_array( $tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ) ) && 'wp_die' === $function ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ) ) ) {
 				continue;
 			}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -113,3 +113,9 @@ echo (int) $foo, $bar; // Bad
 echo (int) get_post_meta( $post_id, SOME_NUMBER, true ), do_something( $else ); // Bad
 
 wp_die( -1 ); // OK
+
+?>
+<p class="notice"><?php echo esc_html( $message ) ?></p> <!-- OK -->
+<input type="submit" name="sync-progress" class="button button-primary button-large" value="<?php esc_attr_e( 'Start Sync', 'foo' ); ?>" /><!-- OK -->
+<input type="hidden" name="sync-action" class="sync-action" value="<?php echo esc_attr( $continue_sync ? 'sync_progress' : '' ); ?>" /><!-- OK -->
+<?php


### PR DESCRIPTION
A regression was introduced in the `EscapeOutputSniff`, probably as part of #312, #314, #315, #316, or #317.

The second two of the three OK lines added to this unit test are failing. It seems not adding a semicolon to the first instance causes the second OK line to croak, but the third OK line seems to fail regardless of prior semicolons.