### PR TITLE
Ignore docblock comments within arrays

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -314,7 +314,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_S
             $count     = count($indices);
             $lastIndex = $indices[($count - 1)]['value'];
 
-            $trailingContent = $phpcsFile->findPrevious(array(T_WHITESPACE, T_COMMENT), ($arrayEnd - 1), $lastIndex, true);
+            $trailingContent = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($arrayEnd - 1), $lastIndex, true);
             if ($tokens[$trailingContent]['code'] !== T_COMMA) {
                 $error = 'Comma required after last value in array declaration';
                 $phpcsFile->addError($error, $trailingContent, 'NoCommaAfterLast');

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc
@@ -192,3 +192,11 @@ $q = new WP_Query( array(
 		),
 	),
 ) );
+
+array(
+	'key',
+	/**
+	 * Doc comment.
+	 */
+//  'core'
+);


### PR DESCRIPTION
When checking that the last line of an array ends in a comma, both whitespace ( `T_WHITESPACE`) and regular comments (`T_COMMENT`) were ignored, but not docblock comments (those beginning with `/**`, `T_DOC_COMMENT`). This fixes that.

Fixes #230