### PR TITLE
Removes content_width as non-overwritable global. Fixes #276

### DIFF
--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -60,7 +60,6 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff implements PHP_CodeSniffer
 		'wp_locale',
 		'locale',
 		'l10n',
-		'content_width',
 		'_wp_additional_image_sizes',
 		'wp_embed',
 		'wp_taxonomies',


### PR DESCRIPTION
I removed content_width from the globals array which makes it so it won't get flagged. #276 