### PR TITLE
Travis CI: run against PHP 5.6, nightly, and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ php:
     - 5.5
     - 5.6
 
+matrix:
+  allow_failures:
+    - php: nightly
+    - php: hhvm
+
 before_script:
     - export PHPCS_GITHUB_SRC=squizlabs/PHP_CodeSniffer
     - export PHPCS_DIR=/tmp/phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - nightly
+    - hhvm
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
 
 before_script:
     - export PHPCS_GITHUB_SRC=squizlabs/PHP_CodeSniffer


### PR DESCRIPTION
Failures are allowed for PHP nightly (7.0) and HHVM.

#reviewmerge