### PR TITLE
abstract WordPress_Sniff class

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ */
+
+/**
+ * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
+ *
+ * Provides a bootstrap for the sniffs, to reduce code duplication.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @version   0.4.0
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Get the last pointer in a line.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array   $tokens   Tokens.
+	 * @param integer $stackPtr The position of the current token in the stack passed
+	 *                          in $tokens.
+	 *
+	 * @return integer Position of the last pointer on that line.
+	 */
+	protected function get_last_ptr_on_line( array $tokens, $stackPtr ) {
+
+		$currentLine = $tokens[ $stackPtr ]['line'];
+		$nextPtr = $stackPtr + 1;
+
+		while ( isset( $tokens[ $nextPtr ] ) && $tokens[ $nextPtr ]['line'] === $currentLine ) {
+			$nextPtr++;
+			// Do nothing, we just want the last token of the line.
+		}
+
+		// We've made it to the next line, back up one to the last in the previous line.
+		// We do this for micro-optimization of the above loop.
+		$lastPtr = $nextPtr - 1;
+
+		return $lastPtr;
+	}
+
+	/**
+	 * Find whitelisting comment.
+	 *
+	 * Comment must be at the end of the line, and use // format.
+	 * It can be prefixed or suffixed with anything e.g. "foobar" will match:
+	 * ... // foobar okay
+	 * ... // WPCS: foobar whitelist.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string  $comment  Comment to find.
+	 * @param array   $tokens   Tokens.
+	 * @param integer $stackPtr The position of the current token in the stack passed
+	 *                          in $tokens.
+	 *
+	 * @return boolean True if whitelisting comment was found, false otherwise.
+	 */
+	protected function has_whitelist_comment( $comment, array $tokens, $stackPtr ) {
+
+		$lastPtr = $this->get_last_ptr_on_line( $tokens, $stackPtr );
+
+		if ( T_COMMENT === $tokens[ $lastPtr ]['code'] ) {
+
+			return preg_match(
+				'#' . preg_quote( $comment ) . '#i'
+				, $tokens[ $lastPtr ]['content']
+			);
+
+		} else {
+			return false;
+		}
+	}
+}
+
+// EOF

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -22,18 +22,51 @@
 abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 	/**
+	 * The current file being sniffed.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var PHP_CodeSniffer_File
+	 */
+	protected $phpcsFile;
+
+	/**
+	 * The list of tokens in the current file being sniffed.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var array
+	 */
+	protected $tokens;
+
+	/**
+	 * Initialize the class for the current process.
+	 *
+	 * This method must be called by child classes before using many of the methods
+	 * below.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file currently being processed.
+	 */
+	protected function init( PHP_CodeSniffer_File $phpcsFile ) {
+		$this->phpcsFile = $phpcsFile;
+		$this->tokens = $phpcsFile->getTokens();
+	}
+
+	/**
 	 * Get the last pointer in a line.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param array   $tokens   Tokens.
 	 * @param integer $stackPtr The position of the current token in the stack passed
 	 *                          in $tokens.
 	 *
 	 * @return integer Position of the last pointer on that line.
 	 */
-	protected function get_last_ptr_on_line( array $tokens, $stackPtr ) {
+	protected function get_last_ptr_on_line( $stackPtr ) {
 
+		$tokens = $this->tokens;
 		$currentLine = $tokens[ $stackPtr ]['line'];
 		$nextPtr = $stackPtr + 1;
 
@@ -57,26 +90,48 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * ... // foobar okay
 	 * ... // WPCS: foobar whitelist.
 	 *
+	 * There is an exception, and that is when PHP is being interspersed with HTML.
+	 * In that case, the comment should come at the end of the statement (right
+	 * before the closing tag, ?>). For example:
+	 *
+	 * <input type="text" id="<?php echo $id; // XSS OK ?>" />
+	 *
 	 * @since 0.4.0
 	 *
 	 * @param string  $comment  Comment to find.
-	 * @param array   $tokens   Tokens.
 	 * @param integer $stackPtr The position of the current token in the stack passed
 	 *                          in $tokens.
 	 *
 	 * @return boolean True if whitelisting comment was found, false otherwise.
 	 */
-	protected function has_whitelist_comment( $comment, array $tokens, $stackPtr ) {
+	protected function has_whitelist_comment( $comment, $stackPtr ) {
 
-		$lastPtr = $this->get_last_ptr_on_line( $tokens, $stackPtr );
+		$end_of_line = $lastPtr = $this->get_last_ptr_on_line( $stackPtr );
 
-		if ( T_COMMENT === $tokens[ $lastPtr ]['code'] ) {
+		// There is a findEndOfStatement() method, but it considers more tokens than
+		// we need to here.
+		$end_of_statement = $this->phpcsFile->findNext(
+			array( T_CLOSE_TAG, T_SEMICOLON )
+			, $stackPtr
+		);
 
-			return preg_match(
-				'#' . preg_quote( $comment ) . '#i'
-				, $tokens[ $lastPtr ]['content']
-			);
+		// Check at the end of the statement if it comes before the end of the line.
+		if ( $end_of_statement < $end_of_line ) {
 
+			// If the statement was ended by a semicolon, we find the next non-
+			// whitespace token. If the semicolon was left out and it was terminated
+			// by an ending tag, we need to look backwards.
+			if ( T_SEMICOLON === $this->tokens[ $end_of_statement ]['code'] ) {
+				$lastPtr = $this->phpcsFile->findNext( T_WHITESPACE, $end_of_statement + 1, null, true );
+			} else {
+				$lastPtr = $this->phpcsFile->findPrevious( T_WHITESPACE, $end_of_statement - 1, null, true );
+			}
+		}
+
+		$last = $this->tokens[ $lastPtr ];
+
+		if ( T_COMMENT === $last['code'] ) {
+			return preg_match( '#' . preg_quote( $comment ) . '#i', $last['content'] );
 		} else {
 			return false;
 		}

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -35,6 +35,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
 	{
+		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();
 
 		// Check for global input variable
@@ -51,7 +52,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
 		}
 
 		// Check for whitelisting comment
-		if ( ! $this->has_whitelist_comment( 'input var', $tokens, $stackPtr ) ) {
+		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
 			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
 	}//end process()

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -7,7 +7,7 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/79
  */
-class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff implements PHP_CodeSniffer_Sniff
+class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
 {
 
 	/**
@@ -51,20 +51,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff implements PHP_CodeSniffer
 		}
 
 		// Check for whitelisting comment
-		$currentLine = $tokens[$stackPtr]['line'];
-		$nextPtr = $stackPtr;
-		while ( isset( $tokens[$nextPtr + 1]['line'] ) && $tokens[$nextPtr + 1]['line'] == $currentLine ) {
-			$nextPtr++;
-			// Do nothing, we just want the last token of the line
-		}
-
-		$is_whitelisted = ( 
-			$tokens[$nextPtr]['code'] === T_COMMENT 
-			&& 
-			preg_match( '#input var okay#i', $tokens[$nextPtr]['content'] ) > 0
-			);
-
-		if ( ! $is_whitelisted ) {
+		if ( ! $this->has_whitelist_comment( 'input var', $tokens, $stackPtr ) ) {
 			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
 	}//end process()

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -8,7 +8,7 @@
  * @package  WordPress_Coding_Standards
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Variables_GlobalVariablesSniff implements PHP_CodeSniffer_Sniff
+class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff
 {
 
 	public $globals = array(
@@ -275,6 +275,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff implements PHP_CodeSniffer
 	 * @return void
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
@@ -297,7 +298,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff implements PHP_CodeSniffer
 			$assignment = $phpcsFile->findNext( T_WHITESPACE, $tokens[ $bracketPtr ]['bracket_closer'] + 1, null, true );
 
 			if ( $assignment && T_EQUAL === $tokens[ $assignment ]['code'] ) {
-				if ( ! $this->is_whitelisted( $tokens, $assignment, 'override' ) ) {
+				if ( ! $this->has_whitelist_comment( 'override', $assignment ) ) {
 					$phpcsFile->addError( 'Overridding WordPress globals is prohibited', $stackPtr );
 					return;
 				}
@@ -330,44 +331,12 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff implements PHP_CodeSniffer
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search ) ) {
 					$next = $phpcsFile->findNext( array( T_WHITESPACE, T_COMMENT ), $ptr + 1, null, true, null, true );
 					if ( T_EQUAL === $tokens[ $next ]['code'] ) {
-						if ( ! $this->is_whitelisted( $tokens, $next, 'override' ) ) {
+						if ( ! $this->has_whitelist_comment( 'override', $next ) ) {
 							$phpcsFile->addError( 'Overridding WordPress globals is prohibited', $ptr );
 						}
 					}
 				}
 			}
 		}
-	}
-
-	/**
-	 * Check for whitelisting comments
-	 *
-	 * @param array   $tokens
-	 * @param integer $ptr
-	 * @param string  $identifier
-	 *
-	 * @return bool
-	 */
-	private function is_whitelisted( $tokens, $ptr, $identifier = 'override' ) {
-		// Checking for the ignore comment, ex: //override ok
-		$isAtEndOfStatement = false;
-		$commentOkRegex     = '/' . $identifier . '\W*(ok|pass|clear|whitelist)/i';
-		$tokensCount        = count( $tokens );
-		for ( $i = $ptr; $i < $tokensCount; $i++ ) {
-			if ( $tokens[$i]['code'] === T_SEMICOLON ) {
-				$isAtEndOfStatement = true;
-			}
-
-			if ( $isAtEndOfStatement === true && in_array( $tokens[$i]['code'], array( T_SEMICOLON, T_WHITESPACE, T_COMMENT ) ) === false ) {
-				break;
-			}
-
-			preg_match( $commentOkRegex, $tokens[$i]['content'], $matches );
-			if ( T_COMMENT === $tokens[$i]['code'] && ! empty( $matches ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -17,7 +17,7 @@
  * @author   Weston Ruter <weston@x-team.com>
  * @link     http://codex.wordpress.org/Data_Validation Data Validation on WordPress Codex
  */
-class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
+class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 {
 
 	public $customAutoEscapedFunctions = array();
@@ -279,6 +279,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 			self::$addedCustomFunctions = true;
 		}
 
+		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();
 
 		$function = $tokens[ $stackPtr ]['content'];
@@ -308,22 +309,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff implements PHP_CodeSniffer_Sniff
 		}
 
 		// Checking for the ignore comment, ex: //xss ok
-		$isAtEndOfStatement = false;
-		$commentOkRegex     = '/xss\W*(ok|pass|clear|whitelist)/i';
-		$tokensCount        = count( $tokens );
-		for ( $i = $stackPtr; $i < $tokensCount; $i++ ) {
-			if ( $tokens[$i]['code'] === T_SEMICOLON ) {
-				$isAtEndOfStatement = true;
-			}
-
-			if ( $isAtEndOfStatement === true && in_array( $tokens[$i]['code'], array( T_SEMICOLON, T_WHITESPACE, T_COMMENT ) ) === false ) {
-				break;
-			}
-
-			preg_match( $commentOkRegex, $tokens[$i]['content'], $matches );
-			if ( ( $tokens[$i]['code'] === T_COMMENT ) && ( empty( $matches ) === false ) ) {
-				return;
-			}
+		if ( $this->has_whitelist_comment( 'xss', $stackPtr ) ) {
+			return;
 		}
 
 		// This is already determined if this is a function and not T_ECHO.

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -119,3 +119,9 @@ wp_die( -1 ); // OK
 <input type="submit" name="sync-progress" class="button button-primary button-large" value="<?php esc_attr_e( 'Start Sync', 'foo' ); ?>" /><!-- OK -->
 <input type="hidden" name="sync-action" class="sync-action" value="<?php echo esc_attr( $continue_sync ? 'sync_progress' : '' ); ?>" /><!-- OK -->
 <?php
+
+// Testing whitelisting comments.
+echo $html_fragment; // Bad
+echo $html_fragment; // xss OK.
+echo $html_fragment; // WPCS: XSS whitelist.
+?><?php echo $html_fragment; // XSS pass ?><?php

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -65,6 +65,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
                 111 => 1,
                 112 => 1,
                 113 => 1,
+	            124 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Adds an abstract class, `WordPress_Sniff` to provide a bootstrap for our sniffs. Includes a method for checking for whitelisting comments. I've converted the sniffs that allow for whitelisting comments to use this method, however, the logic is a bit different than previously used, so it'd be helpful if some folks would test this against projects where they use whitelisting comments heavily.

Feedback would also be appreciated regarding https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/246#issuecomment-80720786 and  a9ad818.

Closes #246 