### PR TITLE
XSS sniff: better handling for sprintf()

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -264,6 +264,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	public static $formattingFunctions = array(
 		'sprintf',
 		'vsprintf',
+		'wp_sprintf',
 	);
 
 	/**

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -248,6 +248,29 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		'wp_die',
 	);
 
+	/**
+	 * Functions that format strings.
+	 *
+	 * These functions are often used for formatting translation strings, and it is
+	 * common practice to escape the individual parameters passed to them as needed
+	 * instead of escaping the entire result. This is especially true when the string
+	 * being formatted contains HTML, which makes escaping the full result more
+	 * difficult.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var array
+	 */
+	public static $formattingFunctions = array(
+		'sprintf',
+		'vsprintf',
+	);
+
+	/**
+	 * Whether the custom functions were added to the default lists yet.
+	 *
+	 * @var bool
+	 */
 	public static $addedCustomFunctions = false;
 
 	/**
@@ -355,7 +378,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			}
 
 			// Handle arrays for those functions that accept them.
-			if ( $tokens[ $i ]['code'] === T_ARRAY && in_array( $function, array( 'vprintf', 'wp_die' ) ) ) {
+			if ( $tokens[ $i ]['code'] === T_ARRAY ) {
 				$i++; // Skip the opening parenthesis.
 				continue;
 			}
@@ -414,6 +437,11 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			// This is a function
 			else {
 				$functionName = $tokens[$i]['content'];
+
+				if ( in_array( $functionName, self::$formattingFunctions ) ) {
+					continue;
+				}
+
 				if (
 					in_array( $functionName, self::$autoEscapedFunctions ) === false
 					&&

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -137,6 +137,13 @@ _doing_it_wrong( __METHOD__, "Invalid value for the 'bob' argument " . esc_html(
 trigger_error( "There was an error: {$message}", E_USER_NOTICE ); // Bad
 trigger_error( "There was an error: " . esc_html( $message ), E_USER_NOTICE ); // OK
 
-echo '<p>' . sprintf( esc_html__( 'Some text -> %sLink text%s', 'textdomain' ), '<a href="' . esc_url( add_query_arg( array( 'page' => 'my_page' ), admin_url( 'admin.php' ) ) ) . '">', '</a>' ). '</p>';
+echo '<p>' . sprintf( esc_html__( 'Some text -> %sLink text%s', 'textdomain' ), '<a href="' . esc_url( add_query_arg( array( 'page' => 'my_page' ), admin_url( 'admin.php' ) ) ) . '">', '</a>' ). '</p>'; // OK
 
-echo '<br/><strong>' . sprintf( esc_html__( 'Found %d results', 'textdomain' ), $result_count ) . '</strong><br/><br/>';
+echo '<br/><strong>' . sprintf( esc_html__( 'Found %d results', 'textdomain' ), (int) $result_count ) . '</strong><br/><br/>'; // OK
+
+echo sprintf( 'Hello %s', $foo ); // Bad
+echo sprintf( 'Hello %s', esc_html( $foo ) ); // OK
+echo sprintf( 'Hello %s! Hi %s!', esc_html( $foo ), $bar ); // Bad
+
+echo vsprintf( 'Hello %s', array( $foo ) ); // Bad
+echo vsprintf( 'Hello %s', array( esc_html( $foo ) ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -147,3 +147,6 @@ echo sprintf( 'Hello %s! Hi %s!', esc_html( $foo ), $bar ); // Bad
 
 echo vsprintf( 'Hello %s', array( $foo ) ); // Bad
 echo vsprintf( 'Hello %s', array( esc_html( $foo ) ) ); // OK
+
+echo sprintf( __( 'Welcome to Genesis %s', 'genesis' ), PARENT_THEME_BRANCH ); // Bad x 2
+echo sprintf( esc_html__( 'Welcome to Genesis %s', 'genesis' ), esc_html( PARENT_THEME_BRANCH ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -72,6 +72,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			144 => 1,
 			146 => 1,
 			148 => 1,
+			151 => 2,
 		);
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -69,6 +69,9 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			130 => 1,
 			134 => 1,
 			137 => 1,
+			144 => 1,
+			146 => 1,
+			148 => 1,
 		);
 
     }//end getErrorList()


### PR DESCRIPTION
`sprintf()` is often used for formatting translation strings, and it is common practice to escape the individual parameters passed to it as needed instead of escaping the entire result. This is especially true when the string being formatted contains HTML, which makes escaping the full result more difficult.

This provides better handling for `sprintf()` by ignoring the function itself and only requiring escaping for its parameters.

Note that `sprintf()` also provides limited sanitization for the values passed to it when number formatting is performed (i.e., for all but the `%s` placeholder). I had originally wanted to take this into account, but it proved too complex. So all parameters passed to `sprintf()` need to be escaped, even when they will be formatted using, e.g., `%d`, and are really safe.

#reviewmerge

Fixes #212