### PR TITLE
Improve performance of the Files.FileName sniff

### DIFF
--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -55,7 +55,7 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
                 $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
 
-		$phpcsFile->removeTokenListener( $this, $this->register() );
+        $phpcsFile->removeTokenListener( $this, $this->register() );
 
     }//end process()
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -42,7 +42,7 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
      * @param int                  $stackPtr  The position of the current token in the
      *                                        stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
@@ -55,7 +55,7 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
                 $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
 
-        $phpcsFile->removeTokenListener( $this, $this->register() );
+        return $phpcsFile->numTokens + 1;
 
     }//end process()
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -23,6 +23,14 @@
 class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
 {
 
+	/**
+	 * A list of files that have already been processed.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var array
+	 */
+	protected $processed_files;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -47,19 +55,18 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        // Make sure this is the first PHP open tag so we don't process
-        // the same file twice.
-        $prevOpenTag = $phpcsFile->findPrevious(T_OPEN_TAG, ($stackPtr - 1));
-        if ($prevOpenTag !== false) {
-            return;
-        }
 
         $fileName = basename($phpcsFile->getFileName());
+
+		if ( isset( $this->processed_files[ $fileName ] ) ) {
+			return;
+		}
+
+		$this->processed_files[ $fileName ] = true;
+
         if (strpos($fileName, '_') !== false) {
                 $expected = str_replace('_', '-', $fileName);
-                $error    = ucfirst('Filename "'.$fileName.'" with underscores found; use '.$expected.' instead');
+                $error    = 'Filename "'.$fileName.'" with underscores found; use '.$expected.' instead';
                 $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -23,15 +23,6 @@
 class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
 {
 
-	/**
-	 * A list of files that have already been processed.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @var array
-	 */
-	protected $processed_files;
-
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -58,17 +49,13 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
 
         $fileName = basename($phpcsFile->getFileName());
 
-		if ( isset( $this->processed_files[ $fileName ] ) ) {
-			return;
-		}
-
-		$this->processed_files[ $fileName ] = true;
-
         if (strpos($fileName, '_') !== false) {
                 $expected = str_replace('_', '-', $fileName);
                 $error    = 'Filename "'.$fileName.'" with underscores found; use '.$expected.' instead';
                 $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
+
+	    $phpcsFile->removeTokenListener( $this, $this->register() );
 
     }//end process()
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -55,7 +55,7 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
                 $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
         }
 
-	    $phpcsFile->removeTokenListener( $this, $this->register() );
+		$phpcsFile->removeTokenListener( $this, $this->register() );
 
     }//end process()
 


### PR DESCRIPTION
Instead of searching through the tokens of a file for each opening PHP
tag that is encountered, we keep a cache of the files that have been
checked, with lightning-fast lookup when we’re checking if a file has
already been processed.

Also removes a useless call to `ucfirst()` on a string that already has
an uppercase first letter.