### PR TITLE
Improve performance of the ArrayAssignmentRestictions sniff

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -5,7 +5,6 @@
 	<rule ref="WordPress-Core"/>
 
 	<!-- the following are inherited by other sniffs -->
-	<rule ref="WordPress.Arrays.ArrayAssignmentRestrictions"/>
 	<rule ref="WordPress.Functions.FunctionRestrictions"/>
 	<rule ref="WordPress.Variables.VariableRestrictions"/>
 

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -76,17 +76,17 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_Co
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
 	{
-		$tokens = $phpcsFile->getTokens();
-
-		$token = $tokens[$stackPtr];
-
-		$exclude = explode( ',', $this->exclude );
 
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
+			$phpcsFile->removeTokenListener( $this, $this->register() );
 			return;
 		}
+
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[ $stackPtr ];
+		$exclude = explode( ',', $this->exclude );
 
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ) ) ) {
 			$equal = $phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );


### PR DESCRIPTION
If no groups of keys to look for are registered, it will remove itself
from listening to the rest of the file. Previously it would keep
getting called for each token in the file it sniffs for, even though
there were no checks to be performed. It did bail early, but now it
will only get called once per file with no groups registered.

We also remove the sniff from the VIP ruleset. This further improves
performance by keeping the sniff from being run at all. This may seem
like a strange thing to do, but this sniff actually does nothing by
itself. It is extended by some other sniffs, and should probably have
been abstract (but changing it now would not be backward compatible).

Even though the sniff is no longer part of the default configuration,
the performance improvements to the sniff itself are still useful, for
people who may have (unnecessarily) included it in custom
configurations.

The possibility of custom configurations specifying this sniff is
another reason not to make it abstract. Perhaps we should consider
moving it’s code to the base `WordPress_Sniff` and deprecating it in
future.