### PR TITLE
Yoda sniff: fix issues with return statements

### DIFF
--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -75,7 +75,7 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $tokens[ $i ]['code'], array( T_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
 				return;
 			}
 		}

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -78,3 +78,7 @@ $accessibility_mode = ( 'on' === sanitize_key( $_GET['accessibility-mode'] ) ) ?
 if ( $on !== self::$network_mode ) { // OK
 	self::$network_mode = (bool) $on;
 }
+
+return 0 === strpos( $foo, 'a' ); // OK
+return 0 == $foo; // OK
+return $foo == 0; // Bad

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -49,6 +49,7 @@ class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest
             55 => 1,
             62 => 1,
             68 => 1,
+            84 => 1,
         );
 
     }//end getErrorList()


### PR DESCRIPTION
With the updates to the Yoda sniff (#319), a bug was introduced that
would cause this code to be flagged:

```php
return 0 === strpos( $foo, 'a' );
```

This is fixed by adding `return` to the list of tokens that, when
encountered without being preceded by a variable, indicate a condition
either already implements, or does not require, Yodaism.

#reviewmerge