### PR TITLE
XSS sniff: Support for ternaries within escaping functions

### DIFF
--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -150,3 +150,7 @@ echo vsprintf( 'Hello %s', array( esc_html( $foo ) ) ); // OK
 
 echo sprintf( __( 'Welcome to Genesis %s', 'genesis' ), PARENT_THEME_BRANCH ); // Bad x 2
 echo sprintf( esc_html__( 'Welcome to Genesis %s', 'genesis' ), esc_html( PARENT_THEME_BRANCH ) ); // OK
+
+echo esc_html( strval( $_var ) ? $_var : gettype( $_var ) ); // OK
+echo ( $is_hidden ) ? ' style="display:none;"' : ''; // OK
+echo sprintf( 'Howdy, %s', esc_html( $name ? $name : __( 'Partner' ) ) ); // OK


### PR DESCRIPTION
In #281 I introduces support for the ternary operator in cases like
this:

```php
echo ( $var ) ? esc_html( $var ) : ‘something’;
```
But sometimes it makes more since to put the ternary condition inside
of the escaping function:

```php
echo esc_html( $var ? $var : $other_var );
```

Up to now, both `$var` and `$other_var` would be flagged as needing
escaping. This PR fixes that.

#reviewmerge