### PR TITLE
XSS sniff: Mark _e() and _ex() as unsafe printing functions

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -249,6 +249,16 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	);
 
 	/**
+	 * Printing functions that incorporate unsafe values.
+	 *
+	 * @var array
+	 */
+	public static $unsafePrintingFunctions = array(
+		'_e' => 'esc_html_e() or esc_attr_e()',
+		'_ex' => 'esc_html_ex() or esc_attr_ex()',
+	);
+
+	/**
 	 * Functions that format strings.
 	 *
 	 * These functions are often used for formatting translation strings, and it is
@@ -338,6 +348,15 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		// Checking for the ignore comment, ex: //xss ok
 		if ( $this->has_whitelist_comment( 'xss', $stackPtr ) ) {
 			return;
+		}
+
+		if ( isset( $end_of_statement, self::$unsafePrintingFunctions[ $function ] ) ) {
+			$error = $phpcsFile->addError( "Expected next thing to be an escaping function (like %s), not '%s'", $stackPtr, 'UnsafePrintingFunction', array( self::$unsafePrintingFunctions[ $function ], $function ) );
+
+			// If the error was reported, don't bother checking the function's arguments.
+			if ( $error ) {
+				return $end_of_statement;
+			}
 		}
 
 		$ternary = false;

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -154,3 +154,6 @@ echo sprintf( esc_html__( 'Welcome to Genesis %s', 'genesis' ), esc_html( PARENT
 echo esc_html( strval( $_var ) ? $_var : gettype( $_var ) ); // OK
 echo ( $is_hidden ) ? ' style="display:none;"' : ''; // OK
 echo sprintf( 'Howdy, %s', esc_html( $name ? $name : __( 'Partner' ) ) ); // OK
+
+_e( 'Something' ); // Bad
+esc_html_e( 'Something' ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -73,6 +73,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			146 => 1,
 			148 => 1,
 			151 => 2,
+			158 => 1,
 		);
 
     }//end getErrorList()


### PR DESCRIPTION
In #33, a list of localization functions like these were flagged as
needing escaping. In #315 I amended this list, removing non-printing
localization functions like `__()`, among other things. These changes
caused a regression in the treatment of the `_e()` and `_ex()`
functions, which remained on the list. They were previously flagged as
needing escaping, even when their parameters were “safe” values
(encapsed strings). That behavior was intentional, and was added
because these functions incorporate other values into their final
output, which need to be escaped before being printed. After #315,
however, these functions themselves were not flagged, only their
parameters when deemed unsafe (e.g., `_e( $var )`). This restores the
previous behavior, by classifying these as ‘unsafe printing functions’,
and flagging them as such when they are used.

For performance, I’ve opted to skip checking the parameters of these
functions when they are flagged, since the recommended replacements
will remedy any issues there as well. If the error for the function
itself is disabled though, any non-safe values incorporated into the
parameters will still be flagged.