### PR TITLE
Add centralized list of input superglobals

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -40,6 +40,15 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	protected $tokens;
 
 	/**
+	 * A list of superglobals that incorporate user input.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var string[]
+	 */
+	protected static $input_superglobals = array( '$_COOKIE', '$_GET', '$_FILE', '$_POST', '$_REQUEST', '$_SERVER' );
+
+	/**
 	 * Initialize the class for the current process.
 	 *
 	 * This method must be called by child classes before using many of the methods

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Flag any usage of super global input var ( _GET / _POST / _REQUEST )
+ * Flag any usage of super global input var ( _GET / _POST / etc. )
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -39,8 +39,9 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
 		$tokens = $phpcsFile->getTokens();
 
 		// Check for global input variable
-		if ( ! in_array( $tokens[$stackPtr]['content'], array( '$_GET', '$_POST', '$_REQUEST' ) ) )
+		if ( ! in_array( $tokens[ $stackPtr ]['content'], WordPress_Sniff::$input_superglobals ) ) {
 			return;
+		}
 
 		$varName = $tokens[$stackPtr]['content'];
 

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Flag any non-validated/sanitized input ( _GET / _POST / _REQUEST / _SERVER )
+ * Flag any non-validated/sanitized input ( _GET / _POST / etc. )
  *
  * PHP version 5
  *
@@ -46,7 +46,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff
 	{
 		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();
-		$superglobals = array( '$_GET', '$_POST', '$_REQUEST', '$_SERVER' );
+		$superglobals = WordPress_Sniff::$input_superglobals;
 
 		// Handling string interpolation
 		if ( $tokens[ $stackPtr ]['code'] === T_DOUBLE_QUOTED_STRING ) {


### PR DESCRIPTION
This adds `$_COOKIE` and `$_FILE` to the list. `$_SERVER` was in the
list previously used by the `ValidatedSantizedInput` sniff, but not
that used by `SuperGlobalInputUsage` sniff. It is also now included for
both.

Fixes #354