### PR TITLE
Sniff whitespace around braces of control structures

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -3,7 +3,11 @@
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#brace-style -->
-	<rule ref="Generic.ControlStructures.InlineControlStructure" />
+    <rule ref="Generic.ControlStructures.InlineControlStructure" />
+    <rule ref="Squiz.ControlStructures.ControlSignature" />
+	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
+		<severity>0</severity>
+	</rule>
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#remove-trailing-spaces -->
 	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -3,8 +3,8 @@
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#brace-style -->
-    <rule ref="Generic.ControlStructures.InlineControlStructure" />
-    <rule ref="Squiz.ControlStructures.ControlSignature" />
+	<rule ref="Generic.ControlStructures.InlineControlStructure" />
+	<rule ref="Squiz.ControlStructures.ControlSignature" />
 	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
 		<severity>0</severity>
 	</rule>


### PR DESCRIPTION
The reason that the `NewlineAfterOpenBrace` check is disabled is that
it is too finicky, and isn’t a part of the WordPress standards. It
would flag having two newlines at the top of a control structure
(something I do a lot), and would also flag this:

```php
if ( $var ) { // This comment would be flagged.

}
```

Fixes #355, #17