### PR TITLE
Add in_array() to list of auto-escaped functions

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -90,6 +90,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		'get_the_term_list',
 		'get_the_title',
 		'has_post_thumbnail',
+		'in_array',
 		'is_attachment',
 		'next_comments_link',
 		'next_image_link',

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -91,6 +91,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		'get_the_title',
 		'has_post_thumbnail',
 		'in_array',
+		'is_array',
 		'is_attachment',
 		'next_comments_link',
 		'next_image_link',


### PR DESCRIPTION
Say you have code like this:

```php
if ( isset( $_REQUEST['foo'] ) && in_array( $_REQUEST['foo'], $array ) ) {
	$foo = sanitize_key( $_REQUEST['foo'] );
}
```
This is safe, but the use of the raw `$_REQUEST['foo']` value in `in_array()` would be flagged. Adding `in_array()` to the list of auto-escaped functions avoids this.