### PR TITLE
Add check for lowercase "as" in foreach

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -38,6 +38,14 @@
 	<rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
 		<severity>0</severity>
 	</rule>
+	
+	<!-- Added for lowercase "as" keyword check -->
+	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration">
+		<properties>
+			<property name="requiredSpacesAfterOpen" value="1"/>
+			<property name="requiredSpacesBeforeClose" value="1"/>
+		</properties>
+	</rule>
 
 	<rule ref="Generic.Files.LineEndings">
 		<properties>


### PR DESCRIPTION
Copied from https://github.com/Yoast/yoastcs/blob/master/Yoast/ruleset.xml#L55-L61

The Squiz sniff actually checks whitespace for foreach loops as well as "as" being lowercase. We already [check whitespace](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php#L66) for `foreach`, so this is very much duplicating a bunch of checks.

I'm happy for this PR to be rejected if we want to have a separate Sniff for checking case, though it may make more sense to switch to the Squiz sniff for all `foreach` checks, if it has enough properties for us to set what our standard should be.

Edit: Added to Core, but may be more suited as an Extra.