### PR TITLE
Add support for error fixing to ArrayDeclaration

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -66,7 +66,9 @@
 		<severity>0</severity>
 	</rule>
 
-	<rule ref="WordPress.Arrays.ArrayDeclaration"/>
+	<rule ref="WordPress.Arrays.ArrayDeclaration">
+		<exclude name="WordPress.Arrays.ArrayDeclaration.SingleLineNotAllowed" />
+	</rule>
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 	<rule ref="WordPress.Classes.ValidClassName"/>
 	<rule ref="WordPress.Files.FileName"/>

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -40,7 +40,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 		if ( T_WHITESPACE !== $tokens[ $arrayStart + 1 ]['code'] ) {
 
 			$warning = 'Missing space after array opener.';
-			$fix = $phpcsFile->addFixableWarning( $warning, $arrayStart, 'NoSpaceAfterOpenParenthesis' );
+			$fix = $phpcsFile->addFixableError( $warning, $arrayStart, 'NoSpaceAfterOpenParenthesis' );
 
 			if ( $fix ) {
 				$phpcsFile->fixer->addContent( $arrayStart, ' ' );
@@ -48,7 +48,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 		} elseif ( ' ' !== $tokens[ $arrayStart + 1 ]['content'] ) {
 
-			$fix = $phpcsFile->addFixableWarning(
+			$fix = $phpcsFile->addFixableError(
 				'Expected 1 space after array opener, found %s.',
 				$arrayStart,
 				'SpaceAfterArrayOpener',
@@ -63,7 +63,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 		if ( T_WHITESPACE !== $tokens[ $arrayEnd - 1 ]['code'] ) {
 
 			$warning = 'Missing space before array closer.';
-			$fix = $phpcsFile->addFixableWarning( $warning, $arrayEnd, 'NoSpaceAfterOpenParenthesis' );
+			$fix = $phpcsFile->addFixableError( $warning, $arrayEnd, 'NoSpaceAfterOpenParenthesis' );
 
 			if ( $fix ) {
 				$phpcsFile->fixer->addContentBefore( $arrayEnd, ' ' );
@@ -71,7 +71,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 		} elseif ( ' ' !== $tokens[ $arrayEnd - 1 ]['content'] ) {
 
-			$fix = $phpcsFile->addFixableWarning(
+			$fix = $phpcsFile->addFixableError(
 				'Expected 1 space before array closer, found %s.',
 				$arrayEnd,
 				'SpaceAfterArrayCloser',

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -20,434 +20,650 @@
  * @author   Greg Sherwood <gsherwood@squiz.net>
  * @author   Marc McIntyre <mmcintyre@squiz.net>
  */
-class WordPress_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
-{
-
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(T_ARRAY);
-
-    }//end register()
-
-
-    /**
-     * Processes this sniff, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        // Array keyword should be lower case.
-        if (strtolower($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
-            $error = 'Array keyword should be lower case; expected "array" but found "%s"';
-            $data  = array($tokens[$stackPtr]['content']);
-            $phpcsFile->addError($error, $stackPtr, 'NotLowerCase', $data);
-        }
-
-        if ( ! isset( $tokens[$stackPtr]['parenthesis_opener'] ) ) {
-            $phpcsFile->addError('Missing parenthesis opener.', $stackPtr, 'NoParenthesis');
-            return;
-        }
-        $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
-        if ( ! isset( $tokens[$arrayStart]['parenthesis_closer'] ) ) {
-            $phpcsFile->addError('Missing parenthesis closer.', $arrayStart, 'NoParenthesis');
-            return;
-        }
-        $arrayEnd = $tokens[$arrayStart]['parenthesis_closer'];
-
-        $keywordStart = $tokens[$stackPtr]['column'];
-
-        if ($arrayStart != ($stackPtr + 1)) {
-            $error = 'There must be no space between the Array keyword and the opening parenthesis';
-            $phpcsFile->addError($error, $stackPtr, 'SpaceAfterKeyword');
-        }
-
-        // Check for empty arrays.
-        $content = $phpcsFile->findNext(array(T_WHITESPACE), ($arrayStart + 1), ($arrayEnd + 1), true);
-        if ($content === $arrayEnd) {
-            // Empty array, but if the brackets aren't together, there's a problem.
-            if (($arrayEnd - $arrayStart) !== 1) {
-                $error = 'Empty array declaration must have no space between the parentheses';
-                $phpcsFile->addError($error, $stackPtr, 'SpaceInEmptyArray');
-
-                // We can return here because there is nothing else to check. All code
-                // below can assume that the array is not empty.
-                return;
-            }
-        }
-
-        if ($tokens[$arrayStart]['line'] === $tokens[$arrayEnd]['line']) {
-            $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-            if ($tokens[($openBracket + 1)]['code'] !== T_WHITESPACE && $tokens[($openBracket + 1)]['code'] !== T_CLOSE_PARENTHESIS) {
-                // Checking this: $value = my_function([*]...).
-                $warning = 'No space after opening parenthesis of array is bad style';
-                $phpcsFile->addWarning($warning, $stackPtr, 'NoSpaceAfterOpenParenthesis');
-            }
-
-            $closer = $tokens[$openBracket]['parenthesis_closer'];
-
-            if ($tokens[($closer - 1)]['code'] !== T_WHITESPACE) {
-                // Checking this: $value = my_function(...[*]).
-                $between = $phpcsFile->findNext(T_WHITESPACE, ($openBracket + 1), null, true);
-
-                // Only throw an error if there is some content between the parenthesis.
-                // i.e., Checking for this: $value = my_function().
-                // If there is no content, then we would have thrown an error in the
-                // previous IF statement because it would look like this:
-                // $value = my_function( ).
-                if ($between !== $closer) {
-                    $warning = 'No space before closing parenthesis of array is bad style';
-                    $phpcsFile->addWarning($warning, $closer, 'NoSpaceBeforeCloseParenthesis');
-                }
-            }
-
-            // Single line array.
-            // Check if there are multiple values. If so, then it has to be multiple lines
-            // unless it is contained inside a function call or condition.
-            $nextComma  = $arrayStart;
-            $valueCount = 0;
-            $commas     = array();
-            while (($nextComma = $phpcsFile->findNext(array(T_COMMA), ($nextComma + 1), $arrayEnd)) !== false) {
-                $valueCount++;
-                $commas[] = $nextComma;
-            }
-
-            // Now check each of the double arrows (if any).
-            $nextArrow = $arrayStart;
-            while (($nextArrow = $phpcsFile->findNext(T_DOUBLE_ARROW, ($nextArrow + 1), $arrayEnd)) !== false) {
-                if ($tokens[($nextArrow - 1)]['code'] !== T_WHITESPACE) {
-                    $content = $tokens[($nextArrow - 1)]['content'];
-                    $error   = "Expected 1 space between \"$content\" and double arrow; 0 found";
-                    $phpcsFile->addError($error, $nextArrow, 'NoSpaceBeforeDoubleArrow');
-                } else {
-                    $spaceLength = strlen($tokens[($nextArrow - 1)]['content']);
-                    if ($spaceLength !== 1) {
-                        $content = $tokens[($nextArrow - 2)]['content'];
-                        $error   = "Expected 1 space between \"$content\" and double arrow; $spaceLength found";
-                        $phpcsFile->addError($error, $nextArrow, 'SpaceBeforeDoubleArrow');
-                    }
-                }
-
-                if ($tokens[($nextArrow + 1)]['code'] !== T_WHITESPACE) {
-                    $content = $tokens[($nextArrow + 1)]['content'];
-                    $error   = "Expected 1 space between double arrow and \"$content\"; 0 found";
-                    $phpcsFile->addError($error, $nextArrow, 'NoSpaceAfterDoubleArrow');
-                } else {
-                    $spaceLength = strlen($tokens[($nextArrow + 1)]['content']);
-                    if ($spaceLength !== 1) {
-                        $content = $tokens[($nextArrow + 2)]['content'];
-                        $error   = "Expected 1 space between double arrow and \"$content\"; $spaceLength found";
-                        $phpcsFile->addError($error, $nextArrow, 'SpaceAfterDoubleArrow');
-                    }
-                }
-            }//end while
-
-            if ($valueCount > 0) {
-                $conditionCheck = $phpcsFile->findPrevious(array(T_OPEN_PARENTHESIS, T_SEMICOLON), ($stackPtr - 1), null, false);
-
-                // We have a multiple value array that is inside a condition or
-                // function. Check its spacing is correct.
-                foreach ($commas as $comma) {
-                    if ($tokens[($comma + 1)]['code'] !== T_WHITESPACE) {
-                        $content = $tokens[($comma + 1)]['content'];
-                        $error   = "Expected 1 space between comma and \"$content\"; 0 found";
-                        $phpcsFile->addError($error, $comma, 'NoSpaceAfterComma');
-                    } else {
-                        $spaceLength = strlen($tokens[($comma + 1)]['content']);
-                        if ($spaceLength !== 1) {
-                            $content = $tokens[($comma + 2)]['content'];
-                            $error   = "Expected 1 space between comma and \"$content\"; $spaceLength found";
-                            $phpcsFile->addError($error, $comma, 'SpaceAfterComma');
-                        }
-                    }
-
-                    if ($tokens[($comma - 1)]['code'] === T_WHITESPACE) {
-                        $content     = $tokens[($comma - 2)]['content'];
-                        $spaceLength = strlen($tokens[($comma - 1)]['content']);
-                        $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                        $phpcsFile->addError($error, $comma, 'SpaceBeforeComma');
-                    }
-                }//end foreach
-            }//end if
-
-            return;
-        }//end if
-
-        $nextToken  = $stackPtr;
-        $lastComma  = $stackPtr;
-        $keyUsed    = false;
-        $lastToken  = '';
-        $indices    = array();
-        $maxLength  = 0;
-
-        // Find all the double arrows that reside in this scope.
-        while (($nextToken = $phpcsFile->findNext(array(T_DOUBLE_ARROW, T_COMMA, T_ARRAY), ($nextToken + 1), $arrayEnd)) !== false) {
-            $currentEntry = array();
-
-            if ($tokens[$nextToken]['code'] === T_ARRAY) {
-                // Let subsequent calls of this test handle nested arrays.
-                $indices[] = array( 'value' => $nextToken );
-                $nextToken = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
-                continue;
-            }
-
-            if ($tokens[$nextToken]['code'] === T_COMMA) {
-                $stackPtrCount = 0;
-                if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-                    $stackPtrCount = count($tokens[$stackPtr]['nested_parenthesis']);
-                }
-
-                if (isset($tokens[$nextToken]['nested_parenthesis']) && count($tokens[$nextToken]['nested_parenthesis']) > ($stackPtrCount + 1)) {
-                    // This comma is inside more parenthesis than the ARRAY keyword,
-                    // then there it is actually a comma used to seperate arguments
-                    // in a function call.
-                    continue;
-                }
-
-                if ($keyUsed === false) {
-                    if ($tokens[($nextToken - 1)]['code'] === T_WHITESPACE) {
-                        $content     = $tokens[($nextToken - 2)]['content'];
-                        $spaceLength = strlen($tokens[($nextToken - 1)]['content']);
-                        $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                        $phpcsFile->addError($error, $nextToken, 'SpaceBeforeComma');
-                    }
-
-                    // Find the value, which will be the first token on the line,
-                    // excluding the leading whitespace.
-                    $valueContent = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextToken - 1), null, true);
-                    while ($tokens[$valueContent]['line'] === $tokens[$nextToken]['line']) {
-                        if ($valueContent === $arrayStart) {
-                            // Value must have been on the same line as the array
-                            // parenthesis, so we have reached the start of the value.
-                            break;
-                        }
-
-                        $valueContent--;
-                    }
-
-                    $valueContent = $phpcsFile->findNext(T_WHITESPACE, ($valueContent + 1), $nextToken, true);
-                    $indices[]    = array('value' => $valueContent);
-                }//end if
-
-                $lastToken = T_COMMA;
-                continue;
-            }//end if
-
-            if ($tokens[$nextToken]['code'] === T_DOUBLE_ARROW) {
-                $currentEntry['arrow'] = $nextToken;
-                $keyUsed               = true;
-
-                // Find the start of index that uses this double arrow.
-                $indexEnd   = $phpcsFile->findPrevious(T_WHITESPACE, ($nextToken - 1), $arrayStart, true);
-                $indexStart = $phpcsFile->findPrevious(T_WHITESPACE, $indexEnd, $arrayStart);
-
-                if ($indexStart === false) {
-                    $index = $indexEnd;
-                } else {
-                    $index = ($indexStart + 1);
-                }
-
-                $currentEntry['index']         = $index;
-                $currentEntry['index_content'] = $phpcsFile->getTokensAsString($index, ($indexEnd - $index + 1));
-
-                $indexLength = strlen($currentEntry['index_content']);
-                if ($maxLength < $indexLength) {
-                    $maxLength = $indexLength;
-                }
-
-                // Find the value of this index.
-                $nextContent           = $phpcsFile->findNext(array(T_WHITESPACE), ($nextToken + 1), $arrayEnd, true);
-                $currentEntry['value'] = $nextContent;
-                $indices[]             = $currentEntry;
-                $lastToken             = T_DOUBLE_ARROW;
-            }//end if
-        }//end while
-
-        // Check for mutli-line arrays that should be single-line.
-        $singleValue = false;
-
-        if (empty($indices) === true) {
-            $singleValue = true;
-        } else if (count($indices) === 1) {
-            if ($lastToken === T_COMMA) {
-                // There may be another array value without a comma.
-                $exclude     = PHP_CodeSniffer_Tokens::$emptyTokens;
-                $exclude[]   = T_COMMA;
-                $nextContent = $phpcsFile->findNext($exclude, ($indices[0]['value'] + 1), $arrayEnd, true);
-                if ($nextContent === false) {
-                    $singleValue = true;
-                }
-            }
-
-            if ($singleValue === false && isset($indices[0]['arrow']) === false) {
-                // A single nested array as a value is fine.
-                if ($tokens[$indices[0]['value']]['code'] !== T_ARRAY) {
-                    $singleValue === true;
-                }
-            }
-        }
-
-        /*
-            This section checks for arrays that don't specify keys.
-
-            Arrays such as:
-               array(
-                'aaa',
-                'bbb',
-                'd',
-               );
-        */
-
-        if ($keyUsed === false && empty($indices) === false) {
-            $count     = count($indices);
-            $lastIndex = $indices[($count - 1)]['value'];
-
-            $trailingContent = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($arrayEnd - 1), $lastIndex, true);
-            if ($tokens[$trailingContent]['code'] !== T_COMMA) {
-                $error = 'Comma required after last value in array declaration';
-                $phpcsFile->addError($error, $trailingContent, 'NoCommaAfterLast');
-            }
-
-            foreach ($indices as $value) {
-                if (empty($value['value']) === true) {
-                    // Array was malformed and we couldn't figure out
-                    // the array value correctly, so we have to ignore it.
-                    // Other parts of this sniff will correct the error.
-                    continue;
-                }
-
-                /*
-                    if ($tokens[($value['value'] - 1)]['code'] === T_WHITESPACE) {
-                        // A whitespace token before this value means that the value
-                        // was indented and not flush with the opening parenthesis.
-                        if ($tokens[$value['value']]['column'] !== ($keywordStart + 1)) {
-                            $error = 'Array value not aligned correctly; expected '.($keywordStart + 1).' spaces but found '.$tokens[$value['value']]['column'];
-                            $phpcsFile->addError($error, $value['value'], 'ValueNotAligned');
-                        }
-                    }
-                */
-
-            }
-        }//end if
-
-        /*
-            Below the actual indentation of the array is checked.
-            Errors will be thrown when a key is not aligned, when
-            a double arrow is not aligned, and when a value is not
-            aligned correctly.
-            If an error is found in one of the above areas, then errors
-            are not reported for the rest of the line to avoid reporting
-            spaces and columns incorrectly. Often fixing the first
-            problem will fix the other 2 anyway.
-
-            For example:
-
-            $a = array(
-                  'index'  => '2',
-                 );
-
-            In this array, the double arrow is indented too far, but this
-            will also cause an error in the value's alignment. If the arrow were
-            to be moved back one space however, then both errors would be fixed.
-        */
-
-        $numValues = count($indices);
-
-        $indicesStart = ($keywordStart + 1);
-        $arrowStart   = ($indicesStart + $maxLength + 1);
-        $valueStart   = ($arrowStart + 3);
-        foreach ($indices as $index) {
-            if (isset($index['index']) === false) {
-                // Array value only.
-                if (($tokens[$index['value']]['line'] === $tokens[$stackPtr]['line']) && ($numValues > 1)) {
-                    $phpcsFile->addError('The first value in a multi-value array must be on a new line', $stackPtr, 'FirstValueNoNewline');
-                }
-
-                continue;
-            }
-
-            if (($tokens[$index['index']]['line'] === $tokens[$stackPtr]['line'])) {
-                $phpcsFile->addError('The first index in a multi-value array must be on a new line', $stackPtr, 'FirstIndexNoNewline');
-                continue;
-            }
-
-            /*
-                if ($tokens[$index['index']]['column'] !== $indicesStart) {
-                    $phpcsFile->addError('Array key not aligned correctly; expected '.$indicesStart.' spaces but found '.$tokens[$index['index']]['column'], $index['index'], 'KeyNotAligned');
-                    continue;
-                }
-
-                if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
-                    $expected  = ($arrowStart - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
-                    $expected .= ($expected === 1) ? ' space' : ' spaces';
-                    $found     = ($tokens[$index['arrow']]['column'] - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
-                    $phpcsFile->addError("Array double arrow not aligned correctly; expected $expected but found $found", $index['arrow'], 'DoubleArrowNotAligned');
-                    continue;
-                }
-
-                if ($tokens[$index['value']]['column'] !== $valueStart) {
-                    $expected  = ($valueStart - (strlen($tokens[$index['arrow']]['content']) + $tokens[$index['arrow']]['column']));
-                    $expected .= ($expected === 1) ? ' space' : ' spaces';
-                    $found     = ($tokens[$index['value']]['column'] - (strlen($tokens[$index['arrow']]['content']) + $tokens[$index['arrow']]['column']));
-                    $phpcsFile->addError("Array value not aligned correctly; expected $expected but found $found", $index['arrow'], 'ValueNotAligned');
-                }
-            */
-
-            // Make sure that we can end lines in brackets and not commas
-            $nextBracket = $phpcsFile->findNext(array(T_OPEN_CURLY_BRACKET, T_OPEN_PARENTHESIS), ($index['value'] + 1));
-            $lineEndsWithOpenBracket = (
-                $nextBracket !== false
-                &&
-                $tokens[$nextBracket]['line'] === $tokens[$index['value']]['line']
-            );
-
-            // Check each line ends in a comma.
-            if ( ! in_array( $tokens[$index['value']]['code'], array( T_ARRAY, T_CLOSURE ) ) && ! $lineEndsWithOpenBracket ) {
-                $nextComma = $phpcsFile->findNext(array(T_COMMA), ($index['value'] + 1));
-                if (($nextComma === false) || ($nextComma != $index['value']+1) ) {
-                    $fail = true;
-                    // Check if the value token is extending over multiple lines
-                    for ( $i = $index['value']; $i < $nextComma; $i++ ) {
-                        // If the same token code continues ( over multiple lines ), then it is probably the same token
-                        if ( $tokens[$i]['code'] != $tokens[$index['value']]['code'] && $tokens[$nextComma]['line'] != $tokens[$i]['line'] ) {
-                            // Fail if a token between the value and the comma is not of the same code
-                            $fail = true;
-                            break;
-                        } else {
-                            $fail = false;
-                        }
-                    }
-                    if ( $fail ) {
-                        $error = 'Each line in an array declaration must end in a comma';
-                        $phpcsFile->addError($error, $index['value'], 'NoComma');
-                    }
-                }
-
-                // Check that there is no space before the comma.
-                if ($nextComma !== false && $tokens[($nextComma - 1)]['code'] === T_WHITESPACE) {
-                    $content     = $tokens[($nextComma - 2)]['content'];
-                    $spaceLength = strlen($tokens[($nextComma - 1)]['content']);
-                    $error       = "Expected 0 spaces between \"$content\" and comma; $spaceLength found";
-                    $phpcsFile->addError($error, $nextComma, 'SpaceBeforeComma');
-                }
-            }
-        }//end foreach
-
-    }//end process()
-
+class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_ArrayDeclarationSniff {
+
+	/**
+	 * @since 0.5.0
+	 */
+	public function processSingleLineArray( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd ) {
+
+		parent::processSingleLineArray( $phpcsFile, $stackPtr, $arrayStart, $arrayEnd );
+
+		// This array is empty, so the below checks aren't necesary.
+		if ( $arrayStart + 1 === $arrayEnd ) {
+			return;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		// Check that there is a single space after the array opener.
+		if ( T_WHITESPACE !== $tokens[ $arrayStart + 1 ]['code'] ) {
+
+			$warning = 'Missing space after array opener.';
+			$fix = $phpcsFile->addFixableWarning( $warning, $arrayStart, 'NoSpaceAfterOpenParenthesis' );
+
+			if ( $fix ) {
+				$phpcsFile->fixer->addContent( $arrayStart, ' ' );
+			}
+
+		} elseif ( ' ' !== $tokens[ $arrayStart + 1 ]['content'] ) {
+
+			$fix = $phpcsFile->addFixableWarning(
+				'Expected 1 space after array opener, found %s.',
+				$arrayStart,
+				'SpaceAfterArrayOpener',
+				strlen( $tokens[ $arrayStart + 1 ]['content'] )
+			);
+
+			if ( $fix ) {
+				$phpcsFile->fixer->replaceToken( $arrayStart + 1, ' ' );
+			}
+		}
+
+		if ( T_WHITESPACE !== $tokens[ $arrayEnd - 1 ]['code'] ) {
+
+			$warning = 'Missing space before array closer.';
+			$fix = $phpcsFile->addFixableWarning( $warning, $arrayEnd, 'NoSpaceAfterOpenParenthesis' );
+
+			if ( $fix ) {
+				$phpcsFile->fixer->addContentBefore( $arrayEnd, ' ' );
+			}
+
+		} elseif ( ' ' !== $tokens[ $arrayEnd - 1 ]['content'] ) {
+
+			$fix = $phpcsFile->addFixableWarning(
+				'Expected 1 space before array closer, found %s.',
+				$arrayEnd,
+				'SpaceAfterArrayCloser',
+				strlen( $tokens[ $arrayEnd - 1 ]['content'] )
+			);
+
+			if ( $fix ) {
+				$phpcsFile->fixer->replaceToken( $arrayEnd - 1, ' ' );
+			}
+		}
+	}
+
+
+	/**
+	 * @since 0.5.0
+	 */
+	public function processMultiLineArray( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd ) {
+		$tokens       = $phpcsFile->getTokens();
+		$keywordStart = $tokens[$stackPtr]['column'];
+
+		// Check the closing bracket is on a new line.
+		$lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($arrayEnd - 1), $arrayStart, true);
+		if ($tokens[$lastContent]['line'] === $tokens[$arrayEnd]['line']) {
+			$error = 'Closing parenthesis of array declaration must be on a new line';
+			$fix   = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceNewLine');
+			if ($fix === true) {
+				$phpcsFile->fixer->addNewlineBefore($arrayEnd);
+			}
+			/*
+		} else if ($tokens[$arrayEnd]['column'] !== $keywordStart) {
+			// Check the closing bracket is lined up under the "a" in array.
+			$expected = ($keywordStart - 1);
+			$found    = ($tokens[$arrayEnd]['column'] - 1);
+			$error    = 'Closing parenthesis not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected,
+				$found,
+			);
+
+			$fix = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceNotAligned', $data);
+			if ($fix === true) {
+				if ($found === 0) {
+					$phpcsFile->fixer->addContent(($arrayEnd - 1), str_repeat(' ', $expected));
+				} else {
+					$phpcsFile->fixer->replaceToken(($arrayEnd - 1), str_repeat(' ', $expected));
+				}
+			}
+			*/
+		}//end if
+
+		$nextToken  = $stackPtr;
+		$keyUsed    = false;
+		$singleUsed = false;
+		$indices    = array();
+		$maxLength  = 0;
+
+		if ($tokens[$stackPtr]['code'] === T_ARRAY) {
+			$lastToken = $tokens[$stackPtr]['parenthesis_opener'];
+		} else {
+			$lastToken = $stackPtr;
+		}
+
+		// Find all the double arrows that reside in this scope.
+		for ($nextToken = ($stackPtr + 1); $nextToken < $arrayEnd; $nextToken++) {
+			// Skip bracketed statements, like function calls.
+			if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS
+			    && (isset($tokens[$nextToken]['parenthesis_owner']) === false
+			        || $tokens[$nextToken]['parenthesis_owner'] !== $stackPtr)
+			) {
+				$nextToken = $tokens[$nextToken]['parenthesis_closer'];
+				continue;
+			}
+
+			if ($tokens[$nextToken]['code'] === T_ARRAY) {
+				// Let subsequent calls of this test handle nested arrays.
+				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
+					$indices[] = array('value' => $nextToken);
+					$lastToken = $nextToken;
+				}
+
+				$nextToken = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
+				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
+				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+					$nextToken--;
+				} else {
+					$lastToken = $nextToken;
+				}
+
+				continue;
+			}
+
+			if ($tokens[$nextToken]['code'] === T_OPEN_SHORT_ARRAY) {
+				// Let subsequent calls of this test handle nested arrays.
+				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
+					$indices[] = array('value' => $nextToken);
+					$lastToken = $nextToken;
+				}
+
+				$nextToken = $tokens[$nextToken]['bracket_closer'];
+				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
+				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+					$nextToken--;
+				} else {
+					$lastToken = $nextToken;
+				}
+
+				continue;
+			}
+
+			if ($tokens[$nextToken]['code'] === T_CLOSURE) {
+				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
+					$indices[] = array('value' => $nextToken);
+					$lastToken = $nextToken;
+				}
+
+				$nextToken = $tokens[$nextToken]['scope_closer'];
+				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
+				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+					$nextToken--;
+				} else {
+					$lastToken = $nextToken;
+				}
+
+				continue;
+			}
+
+			if ($tokens[$nextToken]['code'] !== T_DOUBLE_ARROW
+			    && $tokens[$nextToken]['code'] !== T_COMMA
+			) {
+				continue;
+			}
+
+			$currentEntry = array();
+
+			if ($tokens[$nextToken]['code'] === T_COMMA) {
+				$stackPtrCount = 0;
+				if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+					$stackPtrCount = count($tokens[$stackPtr]['nested_parenthesis']);
+				}
+
+				$commaCount = 0;
+				if (isset($tokens[$nextToken]['nested_parenthesis']) === true) {
+					$commaCount = count($tokens[$nextToken]['nested_parenthesis']);
+					if ($tokens[$stackPtr]['code'] === T_ARRAY) {
+						// Remove parenthesis that are used to define the array.
+						$commaCount--;
+					}
+				}
+
+				if ($commaCount > $stackPtrCount) {
+					// This comma is inside more parenthesis than the ARRAY keyword,
+					// then there it is actually a comma used to separate arguments
+					// in a function call.
+					continue;
+				}
+
+				/*
+				if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
+					$error = 'No key specified for array entry; first entry specifies key';
+					$phpcsFile->addError($error, $nextToken, 'NoKeySpecified');
+					return;
+				}
+				*/
+
+				if ($keyUsed === false) {
+					if ($tokens[($nextToken - 1)]['code'] === T_WHITESPACE) {
+						$content = $tokens[($nextToken - 2)]['content'];
+						if ($tokens[($nextToken - 1)]['content'] === $phpcsFile->eolChar) {
+							$spaceLength = 'newline';
+						} else {
+							$spaceLength = $tokens[($nextToken - 1)]['length'];
+						}
+
+						$error = 'Expected 0 spaces between "%s" and comma; %s found';
+						$data  = array(
+							$content,
+							$spaceLength,
+						);
+
+						$fix = $phpcsFile->addFixableError($error, $nextToken, 'SpaceBeforeComma', $data);
+						if ($fix === true) {
+							$phpcsFile->fixer->replaceToken(($nextToken - 1), '');
+						}
+					}
+
+					$valueContent = $phpcsFile->findNext(
+						PHP_CodeSniffer_Tokens::$emptyTokens,
+						($lastToken + 1),
+						$nextToken,
+						true
+					);
+
+					$indices[]  = array('value' => $valueContent);
+					$singleUsed = true;
+				}//end if
+
+				$lastToken = $nextToken;
+				continue;
+			}//end if
+
+
+			if ($tokens[$nextToken]['code'] === T_DOUBLE_ARROW) {
+				/*
+				if ($singleUsed === true) {
+					$error = 'Key specified for array entry; first entry has no key';
+					$phpcsFile->addError($error, $nextToken, 'KeySpecified');
+					return;
+				}
+				*/
+
+				$currentEntry['arrow'] = $nextToken;
+				$keyUsed = true;
+
+				// Find the start of index that uses this double arrow.
+				$indexEnd   = $phpcsFile->findPrevious(T_WHITESPACE, ($nextToken - 1), $arrayStart, true);
+				$indexStart = $phpcsFile->findStartOfStatement($indexEnd);
+
+				if ($indexStart === $indexEnd) {
+					$currentEntry['index']         = $indexEnd;
+					$currentEntry['index_content'] = $tokens[$indexEnd]['content'];
+				} else {
+					$currentEntry['index']         = $indexStart;
+					$currentEntry['index_content'] = $phpcsFile->getTokensAsString($indexStart, ($indexEnd - $indexStart + 1));
+				}
+
+				$indexLength = strlen($currentEntry['index_content']);
+				if ($maxLength < $indexLength) {
+					$maxLength = $indexLength;
+				}
+
+				// Find the value of this index.
+				$nextContent = $phpcsFile->findNext(
+					PHP_CodeSniffer_Tokens::$emptyTokens,
+					($nextToken + 1),
+					$arrayEnd,
+					true
+				);
+
+				$currentEntry['value'] = $nextContent;
+				$indices[] = $currentEntry;
+				$lastToken = $nextToken;
+			}//end if
+		}//end for
+
+		// Check for mutli-line arrays that should be single-line.
+		$singleValue = false;
+
+		if (empty($indices) === true) {
+			$singleValue = true;
+		} else if (count($indices) === 1 && $tokens[$lastToken]['code'] === T_COMMA) {
+			// There may be another array value without a comma.
+			$exclude     = PHP_CodeSniffer_Tokens::$emptyTokens;
+			$exclude[]   = T_COMMA;
+			$nextContent = $phpcsFile->findNext($exclude, ($indices[0]['value'] + 1), $arrayEnd, true);
+			if ($nextContent === false) {
+				$singleValue = true;
+			}
+		}
+
+		/*
+		if ($singleValue === true) {
+			// Array cannot be empty, so this is a multi-line array with
+			// a single value. It should be defined on single line.
+			$error = 'Multi-line array contains a single value; use single-line array instead';
+			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MultiLineNotAllowed');
+
+			if ($fix === true) {
+				$phpcsFile->fixer->beginChangeset();
+				for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
+					if ($tokens[$i]['code'] !== T_WHITESPACE) {
+						break;
+					}
+
+					$phpcsFile->fixer->replaceToken($i, '');
+				}
+
+				for ($i = ($arrayEnd - 1); $i > $arrayStart; $i--) {
+					if ($tokens[$i]['code'] !== T_WHITESPACE) {
+						break;
+					}
+
+					$phpcsFile->fixer->replaceToken($i, '');
+				}
+
+				$phpcsFile->fixer->endChangeset();
+			}
+
+			return;
+		}//end if
+		*/
+
+		/*
+			This section checks for arrays that don't specify keys.
+
+			Arrays such as:
+			   array(
+				'aaa',
+				'bbb',
+				'd',
+			   );
+		*/
+
+		if ($keyUsed === false && empty($indices) === false) {
+			$count     = count($indices);
+			$lastIndex = $indices[($count - 1)]['value'];
+
+			$trailingContent = $phpcsFile->findPrevious(
+				PHP_CodeSniffer_Tokens::$emptyTokens,
+				($arrayEnd - 1),
+				$lastIndex,
+				true
+			);
+
+			if ($tokens[$trailingContent]['code'] !== T_COMMA) {
+				$phpcsFile->recordMetric($stackPtr, 'Array end comma', 'no');
+				$error = 'Comma required after last value in array declaration';
+				$fix   = $phpcsFile->addFixableError($error, $trailingContent, 'NoCommaAfterLast');
+				if ($fix === true) {
+					$phpcsFile->fixer->addContent($trailingContent, ',');
+				}
+			} else {
+				$phpcsFile->recordMetric($stackPtr, 'Array end comma', 'yes');
+			}
+
+			$lastValueLine = false;
+			foreach ($indices as $value) {
+				if (empty($value['value']) === true) {
+					// Array was malformed and we couldn't figure out
+					// the array value correctly, so we have to ignore it.
+					// Other parts of this sniff will correct the error.
+					continue;
+				}
+
+				if ($lastValueLine !== false && $tokens[$value['value']]['line'] === $lastValueLine) {
+					$error = 'Each value in a multi-line array must be on a new line';
+					$fix   = $phpcsFile->addFixableError($error, $value['value'], 'ValueNoNewline');
+					if ($fix === true) {
+						if ($tokens[($value['value'] - 1)]['code'] === T_WHITESPACE) {
+							$phpcsFile->fixer->replaceToken(($value['value'] - 1), '');
+						}
+
+						$phpcsFile->fixer->addNewlineBefore($value['value']);
+					}
+					/*
+				} else if ($tokens[($value['value'] - 1)]['code'] === T_WHITESPACE) {
+					$expected = $keywordStart;
+
+					$first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $value['value'], true);
+					$found = ($tokens[$first]['column'] - 1);
+					if ($found !== $expected) {
+						$error = 'Array value not aligned correctly; expected %s spaces but found %s';
+						$data  = array(
+							$expected,
+							$found,
+						);
+
+						$fix = $phpcsFile->addFixableError($error, $value['value'], 'ValueNotAligned', $data);
+						if ($fix === true) {
+							if ($found === 0) {
+								$phpcsFile->fixer->addContent(($value['value'] - 1), str_repeat(' ', $expected));
+							} else {
+								$phpcsFile->fixer->replaceToken(($value['value'] - 1), str_repeat(' ', $expected));
+							}
+						}
+					}
+					*/
+				}//end if
+
+				$lastValueLine = $tokens[$value['value']]['line'];
+			}//end foreach
+		}//end if
+
+		/*
+			Below the actual indentation of the array is checked.
+			Errors will be thrown when a key is not aligned, when
+			a double arrow is not aligned, and when a value is not
+			aligned correctly.
+			If an error is found in one of the above areas, then errors
+			are not reported for the rest of the line to avoid reporting
+			spaces and columns incorrectly. Often fixing the first
+			problem will fix the other 2 anyway.
+
+			For example:
+
+			$a = array(
+				  'index'  => '2',
+				 );
+
+			or
+
+			$a = [
+				  'index'  => '2',
+				 ];
+
+			In this array, the double arrow is indented too far, but this
+			will also cause an error in the value's alignment. If the arrow were
+			to be moved back one space however, then both errors would be fixed.
+		*/
+
+		$numValues = count($indices);
+
+		$indicesStart  = ($keywordStart + 1);
+		$arrowStart    = ($indicesStart + $maxLength + 1);
+		$valueStart    = ($arrowStart + 3);
+		$indexLine     = $tokens[$stackPtr]['line'];
+		$lastIndexLine = null;
+		foreach ($indices as $index) {
+			if (isset($index['index']) === false) {
+				// Array value only.
+				if ($tokens[$index['value']]['line'] === $tokens[$stackPtr]['line'] && $numValues > 1) {
+					$error = 'The first value in a multi-value array must be on a new line';
+					$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstValueNoNewline');
+					if ($fix === true) {
+						$phpcsFile->fixer->addNewlineBefore($index['value']);
+					}
+				}
+
+				continue;
+			}
+
+			$lastIndexLine = $indexLine;
+			$indexLine     = $tokens[$index['index']]['line'];
+
+			if ($indexLine === $tokens[$stackPtr]['line']) {
+				$error = 'The first index in a multi-value array must be on a new line';
+				$fix   = $phpcsFile->addFixableError($error, $index['index'], 'FirstIndexNoNewline');
+				if ($fix === true) {
+					$phpcsFile->fixer->addNewlineBefore($index['index']);
+				}
+
+				continue;
+			}
+
+			if ($indexLine === $lastIndexLine) {
+				$error = 'Each index in a multi-line array must be on a new line';
+				$fix   = $phpcsFile->addFixableError($error, $index['index'], 'IndexNoNewline');
+				if ($fix === true) {
+					if ($tokens[($index['index'] - 1)]['code'] === T_WHITESPACE) {
+						$phpcsFile->fixer->replaceToken(($index['index'] - 1), '');
+					}
+
+					$phpcsFile->fixer->addNewlineBefore($index['index']);
+				}
+
+				continue;
+			}
+
+			/*
+			if ($tokens[$index['index']]['column'] !== $indicesStart) {
+				$expected = ($indicesStart - 1);
+				$found    = ($tokens[$index['index']]['column'] - 1);
+				$error    = 'Array key not aligned correctly; expected %s spaces but found %s';
+				$data     = array(
+					$expected,
+					$found,
+				);
+
+				$fix = $phpcsFile->addFixableError($error, $index['index'], 'KeyNotAligned', $data);
+				if ($fix === true) {
+					if ($found === 0) {
+						$phpcsFile->fixer->addContent(($index['index'] - 1), str_repeat(' ', $expected));
+					} else {
+						$phpcsFile->fixer->replaceToken(($index['index'] - 1), str_repeat(' ', $expected));
+					}
+				}
+
+				continue;
+			}
+
+			if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
+				$expected = ($arrowStart - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
+				$found    = ($tokens[$index['arrow']]['column'] - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
+				$error    = 'Array double arrow not aligned correctly; expected %s space(s) but found %s';
+				$data     = array(
+					$expected,
+					$found,
+				);
+
+				$fix = $phpcsFile->addFixableError($error, $index['arrow'], 'DoubleArrowNotAligned', $data);
+				if ($fix === true) {
+					if ($found === 0) {
+						$phpcsFile->fixer->addContent(($index['arrow'] - 1), str_repeat(' ', $expected));
+					} else {
+						$phpcsFile->fixer->replaceToken(($index['arrow'] - 1), str_repeat(' ', $expected));
+					}
+				}
+
+				continue;
+			}
+
+			if ($tokens[$index['value']]['column'] !== $valueStart) {
+				$expected = ($valueStart - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));
+				$found    = ($tokens[$index['value']]['column'] - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));
+				if ($found < 0) {
+					$found = 'newline';
+				}
+
+				$error = 'Array value not aligned correctly; expected %s space(s) but found %s';
+				$data  = array(
+					$expected,
+					$found,
+				);
+
+				$fix = $phpcsFile->addFixableError($error, $index['arrow'], 'ValueNotAligned', $data);
+				if ($fix === true) {
+					if ($found === 'newline') {
+						$prev = $phpcsFile->findPrevious(T_WHITESPACE, ($index['value'] - 1), null, true);
+						$phpcsFile->fixer->beginChangeset();
+						for ($i = ($prev + 1); $i < $index['value']; $i++) {
+							$phpcsFile->fixer->replaceToken($i, '');
+						}
+
+						$phpcsFile->fixer->replaceToken(($index['value'] - 1), str_repeat(' ', $expected));
+						$phpcsFile->fixer->endChangeset();
+					} else if ($found === 0) {
+						$phpcsFile->fixer->addContent(($index['value'] - 1), str_repeat(' ', $expected));
+					} else {
+						$phpcsFile->fixer->replaceToken(($index['value'] - 1), str_repeat(' ', $expected));
+					}
+				}
+			}//end if
+			*/
+
+			// Check each line ends in a comma.
+			$valueLine = $tokens[$index['value']]['line'];
+			$nextComma = false;
+			for ($i = $index['value']; $i < $arrayEnd; $i++) {
+				// Skip bracketed statements, like function calls.
+				if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
+					$i         = $tokens[$i]['parenthesis_closer'];
+					$valueLine = $tokens[$i]['line'];
+					continue;
+				}
+
+				if ($tokens[$i]['code'] === T_ARRAY) {
+					$i         = $tokens[$tokens[$i]['parenthesis_opener']]['parenthesis_closer'];
+					$valueLine = $tokens[$i]['line'];
+					continue;
+				}
+
+				if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+					$i         = $tokens[$i]['bracket_closer'];
+					$valueLine = $tokens[$i]['line'];
+					continue;
+				}
+
+				if ($tokens[$i]['code'] === T_CLOSURE) {
+					$i         = $tokens[$i]['scope_closer'];
+					$valueLine = $tokens[$i]['line'];
+					continue;
+				}
+
+				if ($tokens[$i]['code'] === T_COMMA) {
+					$nextComma = $i;
+					break;
+				}
+			}//end for
+
+			//if ($nextComma === false || ($tokens[$nextComma]['line'] !== $valueLine)) {
+			if ( $nextComma === false ) {
+				$error = 'Each line in an array declaration must end in a comma';
+				$fix   = $phpcsFile->addFixableError($error, $index['value'], 'NoComma');
+
+				if ($fix === true) {
+					// Find the end of the line and put a comma there.
+					for ($i = ($index['value'] + 1); $i < $phpcsFile->numTokens; $i++) {
+						if ($tokens[$i]['line'] > $valueLine) {
+							break;
+						}
+					}
+
+					$phpcsFile->fixer->addContentBefore(($i - 1), ',');
+				}
+			}
+
+			// Check that there is no space before the comma.
+			if ($nextComma !== false && $tokens[($nextComma - 1)]['code'] === T_WHITESPACE) {
+				$content     = $tokens[($nextComma - 2)]['content'];
+				$spaceLength = $tokens[($nextComma - 1)]['length'];
+				$error       = 'Expected 0 spaces between "%s" and comma; %s found';
+				$data        = array(
+					$content,
+					$spaceLength,
+				);
+
+				$fix = $phpcsFile->addFixableError($error, $nextComma, 'SpaceBeforeComma', $data);
+				if ($fix === true) {
+					$phpcsFile->fixer->replaceToken(($nextComma - 1), '');
+				}
+			}
+		}//end foreach
+
+	}//end processMultiLineArray()
 
 }//end class
-
-?>

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc.fixed
@@ -1,19 +1,19 @@
 <?php
 
-$array_keyword_capitalize_first = Array(); // Bad
+$array_keyword_capitalize_first = array(); // Bad
 
 $array_keyword_must_be_lower_case = array(); // Good
 
-$array_declaration_with_space_after_keyword = array (); // Bad
+$array_declaration_with_space_after_keyword = array(); // Bad
 
-$space_between_parantheses_on_empty_array = array( ); // Bad
+$space_between_parantheses_on_empty_array = array(); // Bad
 
 $query_vars = array_merge(
-	array('post_type' => 'food'), // Bad, no spaces after opening and befoer closing paranthesis
+	array( 'post_type' => 'food' ), // Bad, no spaces after opening and befoer closing paranthesis
 	// ...
 	array(
 		'post_status' => 'private',
-		'orderby' => 'title' // Bad, no comma at the ending
+		'orderby' => 'title',// Bad, no comma at the ending
 	)
 );
 $query = new WP_Query( $query_vars );
@@ -37,7 +37,7 @@ $query_vars = array_merge(
 );
 $query = new WP_Query( $query_vars );
 
-$defaults = array( 'type'=>'post' ); // Bad, no spaces before and after double arrow
+$defaults = array( 'type' => 'post' ); // Bad, no spaces before and after double arrow
 wp_parse_args( $args, $defaults );
 
 class Foo {
@@ -205,4 +205,4 @@ array(
 array( 1, 2 );
 
 // Test for fixing of extra whitespace.
-array(   1, 2     );
+array( 1, 2 );

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -65,6 +65,7 @@ class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitT
     {
         return array(
                 12 => 2,
+	            208 => 2,
                 );
 
     }//end getWarningList()

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -46,8 +46,10 @@ class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitT
                 3 => 1,
                 7 => 1,
                 9 => 1,
+                12 => 2,
                 16 => 1,
                 40 => 2,
+                208 => 2,
                );
 
     }//end getErrorList()
@@ -64,8 +66,6 @@ class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitT
     public function getWarningList()
     {
         return array(
-                12 => 2,
-	            208 => 2,
                 );
 
     }//end getWarningList()


### PR DESCRIPTION
This basically synchronizes it with `Squiz.Arrays.ArrayDeclaration`.
The upstream version is similar, except that we exclude a few errors.
Unfortunately we have to actually comment out the code rather than just
using the upstream sniff and `<exclude>` in our ruleset, due to a bug
(squizlabs/PHP_CodeSniffer#582). (I’ve also included a fix for another
bug, squizlabs/PHP_CodeSniffer#584.) Because of this, we cannot yet
eliminate duplicated logic from this child sniff.

I think this pretty much maintains the previous behavior, except that I
have added a warning for extra whitespace at the edges of multiline
arrays.

Another note, the whitespace messages are warnings:

```php
array(1, 2); // missing spaces
array(      1, 2        ) // extra spaces
```
Maybe these should be converted to errors? I'm not sure why they are just warnings (it goes all the way back to Urban Giraffe).