### PR TITLE
Separate sanitizing and escaping functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -29,9 +29,292 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $nonceVerificationFunctions = array(
-		'wp_verify_nonce',
-		'check_admin_referer',
-		'check_ajax_referer',
+		'wp_verify_nonce' => true,
+		'check_admin_referer' => true,
+		'check_ajax_referer' => true,
+	);
+
+	/**
+	 * Functions that escape values for display.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var array
+	 */
+	public static $escapingFunctions = array(
+		'absint' => true,
+		'esc_attr__' => true,
+		'esc_attr_e' => true,
+		'esc_attr_x' => true,
+		'esc_attr' => true,
+		'esc_html__' => true,
+		'esc_html_e' => true,
+		'esc_html_x' => true,
+		'esc_html' => true,
+		'esc_js' => true,
+		'esc_sql' => true,
+		'esc_textarea' => true,
+		'esc_url_raw' => true,
+		'esc_url' => true,
+		'filter_input' => true,
+		'filter_var' => true,
+		'intval' => true,
+		'json_encode' => true,
+		'like_escape' => true,
+		'number_format' => true,
+		'rawurlencode' => true,
+		'sanitize_html_class' => true,
+		'sanitize_user_field' => true,
+		'tag_escape' => true,
+		'urlencode_deep' => true,
+		'urlencode' => true,
+		'wp_json_encode' => true,
+		'wp_kses_allowed_html' => true,
+		'wp_kses_data' => true,
+		'wp_kses_post' => true,
+		'wp_kses' => true,
+	);
+
+	/**
+	 * Functions whose output is automatically escaped for display.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var array
+	 */
+	public static $autoEscapedFunctions = array(
+		'allowed_tags' => true,
+		'bloginfo' => true,
+		'body_class' => true,
+		'calendar_week_mod' => true,
+		'cancel_comment_reply_link' => true,
+		'category_description' => true,
+		'checked' => true,
+		'comment_author_email_link' => true,
+		'comment_author_email' => true,
+		'comment_author_IP' => true,
+		'comment_author_link' => true,
+		'comment_author_rss' => true,
+		'comment_author_url_link' => true,
+		'comment_author_url' => true,
+		'comment_author' => true,
+		'comment_class' => true,
+		'comment_date' => true,
+		'comment_excerpt' => true,
+		'comment_form_title' => true,
+		'comment_form' => true,
+		'comment_id_fields' => true,
+		'comment_ID' => true,
+		'comment_reply_link' => true,
+		'comment_text_rss' => true,
+		'comment_text' => true,
+		'comment_time' => true,
+		'comment_type' => true,
+		'comments_link' => true,
+		'comments_number' => true,
+		'comments_popup_link' => true,
+		'comments_popup_script' => true,
+		'comments_rss_link' => true,
+		'delete_get_calendar_cache' => true,
+		'disabled' => true,
+		'do_shortcode_tag' => true,
+		'edit_bookmark_link' => true,
+		'edit_comment_link' => true,
+		'edit_post_link' => true,
+		'edit_tag_link' => true,
+		'get_archives_link' => true,
+		'get_attachment_link' => true,
+		'get_avatar' => true,
+		'get_bookmark_field' => true,
+		'get_bookmark' => true,
+		'get_calendar' => true,
+		'get_comment_author_link' => true,
+		'get_comment_date' => true,
+		'get_comment_time' => true,
+		'get_current_blog_id' => true,
+		'get_delete_post_link' => true,
+		'get_footer' => true,
+		'get_header' => true,
+		'get_search_form' => true,
+		'get_search_query' => true,
+		'get_sidebar' => true,
+		'get_template_part' => true,
+		'get_the_author_link' => true,
+		'get_the_author' => true,
+		'get_the_date' => true,
+		'get_the_post_thumbnail' => true,
+		'get_the_term_list' => true,
+		'get_the_title' => true,
+		'has_post_thumbnail' => true,
+		'is_attachment' => true,
+		'next_comments_link' => true,
+		'next_image_link' => true,
+		'next_post_link' => true,
+		'next_posts_link' => true,
+		'paginate_comments_links' => true,
+		'permalink_anchor' => true,
+		'post_class' => true,
+		'post_password_required' => true,
+		'post_type_archive_title' => true,
+		'posts_nav_link' => true,
+		'previous_comments_link' => true,
+		'previous_image_link' => true,
+		'previous_post_link' => true,
+		'previous_posts_link' => true,
+		'selected' => true,
+		'single_cat_title' => true,
+		'single_month_title' => true,
+		'single_post_title' => true,
+		'single_tag_title' => true,
+		'single_term_title' => true,
+		'sticky_class' => true,
+		'tag_description' => true,
+		'term_description' => true,
+		'the_attachment_link' => true,
+		'the_author_link' => true,
+		'the_author_meta' => true,
+		'the_author_posts_link' => true,
+		'the_author_posts' => true,
+		'the_author' => true,
+		'the_category_rss' => true,
+		'the_category' => true,
+		'the_content_rss' => true,
+		'the_content' => true,
+		'the_date_xml' => true,
+		'the_date' => true,
+		'the_excerpt_rss' => true,
+		'the_excerpt' => true,
+		'the_feed_link' => true,
+		'the_ID' => true,
+		'the_meta' => true,
+		'the_modified_author' => true,
+		'the_modified_date' => true,
+		'the_modified_time' => true,
+		'the_permalink' => true,
+		'the_post_thumbnail' => true,
+		'the_search_query' => true,
+		'the_shortlink' => true,
+		'the_tags' => true,
+		'the_taxonomies' => true,
+		'the_terms' => true,
+		'the_time' => true,
+		'the_title_attribute' => true,
+		'the_title_rss' => true,
+		'the_title' => true,
+		'vip_powered_wpcom' => true,
+		'walk_nav_menu_tree' => true,
+		'wp_attachment_is_image' => true,
+		'wp_dropdown_categories' => true,
+		'wp_dropdown_users' => true,
+		'wp_enqueue_script' => true,
+		'wp_generate_tag_cloud' => true,
+		'wp_get_archives' => true,
+		'wp_get_attachment_image' => true,
+		'wp_get_attachment_link' => true,
+		'wp_link_pages' => true,
+		'wp_list_authors' => true,
+		'wp_list_bookmarks' => true,
+		'wp_list_categories' => true,
+		'wp_list_comments' => true,
+		'wp_login_form' => true,
+		'wp_loginout' => true,
+		'wp_meta' => true,
+		'wp_nav_menu' => true,
+		'wp_register' => true,
+		'wp_shortlink_header' => true,
+		'wp_shortlink_wp_head' => true,
+		'wp_tag_cloud' => true,
+		'wp_title' => true,
+	);
+
+	/**
+	 * Functions that sanitize values.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var array
+	 */
+	public static $sanitizingFunctions = array(
+		'absint' => true,
+		'filter_input' => true,
+		'filter_var' => true,
+		'in_array' => true,
+		'intval' => true,
+		'is_array' => true,
+		'is_email' => true,
+		'number_format' => true,
+		'sanitize_bookmark_field' => true,
+		'sanitize_bookmark' => true,
+		'sanitize_email' => true,
+		'sanitize_file_name' => true,
+		'sanitize_html_class' => true,
+		'sanitize_key' => true,
+		'sanitize_meta' => true,
+		'sanitize_mime_type' => true,
+		'sanitize_option' => true,
+		'sanitize_sql_orderby' => true,
+		'sanitize_term_field' => true,
+		'sanitize_term' => true,
+		'sanitize_text_field' => true,
+		'sanitize_title_for_query' => true,
+		'sanitize_title_with_dashes' => true,
+		'sanitize_title' => true,
+		'sanitize_user_field' => true,
+		'sanitize_user' => true,
+		'validate_file' => true,
+		'wp_kses_allowed_html' => true,
+		'wp_kses_data' => true,
+		'wp_kses_post' => true,
+		'wp_kses' => true,
+		'wp_parse_id_list' => true,
+		'wp_redirect' => true,
+		'wp_safe_redirect' => true,
+	);
+
+	/**
+	 * Functions that format strings.
+	 *
+	 * These functions are often used for formatting values just before output, and
+	 * it is common practice to escape the individual parameters passed to them as
+	 * needed instead of escaping the entire result. This is especially true when the
+	 * string being formatted contains HTML, which makes escaping the full result
+	 * more difficult.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var array
+	 */
+	public static $formattingFunctions = array(
+		'ent2ncr' => true,
+		'sprintf' => true,
+		'vsprintf' => true,
+		'wp_sprintf' => true,
+	);
+
+
+	/**
+	 * Functions which print output incorporating the values passed to them.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var array
+	 */
+	public static $printingFunctions = array(
+		'_deprecated_argument' => true,
+		'_deprecated_file' => true,
+		'_deprecated_function' => true,
+		'_doing_it_wrong' => true,
+		'_e' => true,
+		'_ex' => true,
+		'die' => true,
+		'echo' => true,
+		'exit' => true,
+		'print' => true,
+		'printf' => true,
+		'trigger_error' => true,
+		'user_error' => true,
+		'vprintf' => true,
+		'wp_die' => true,
 	);
 
 	/**
@@ -294,7 +577,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 
 			// If this is one of the nonce verification functions, we can bail out.
-			if ( in_array( $tokens[ $i ]['content'], self::$nonceVerificationFunctions ) ) {
+			if ( isset( self::$nonceVerificationFunctions[ $tokens[ $i ]['content'] ] ) ) {
 				$last['nonce_check'] = $i;
 				return true;
 			}
@@ -444,7 +727,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// Check if this is a sanitizing function.
-		return in_array( $functionName, WordPress_Sniffs_XSS_EscapeOutputSniff::$sanitizingFunctions );
+		return isset( self::$sanitizingFunctions[ $functionName ] );
 	}
 
 	/**

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -88,7 +88,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 		if ( ! self::$addedCustomFunctions ) {
 			self::$nonceVerificationFunctions = array_merge(
 				self::$nonceVerificationFunctions
-				, $this->customNonceVerificationFunctions
+				, array_flip( $this->customNonceVerificationFunctions )
 			);
 
 			self::$addedCustomFunctions = true;

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -19,6 +19,24 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	public $check_validation_in_scope_only = false;
 
 	/**
+	 * Custom list of functions that sanitize the values passed to them.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string[]
+	 */
+	public $customSanitizingFunctions = array();
+
+	/**
+	 * Whether the custom list of functions has been added to the defaults yet.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var bool
+	 */
+	protected static $addedCustomFunctions = false;
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -40,6 +58,17 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	 * @return void
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		// Merge any custom functions with the defaults, if we haven't already.
+		if ( ! self::$addedCustomFunctions ) {
+
+			WordPress_Sniff::$sanitizingFunctions = array_merge(
+				WordPress_Sniff::$sanitizingFunctions,
+				array_flip( $this->customSanitizingFunctions )
+			);
+
+			self::$addedCustomFunctions = true;
+		}
 
 		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -20,264 +20,53 @@
 class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 {
 
-	public $customAutoEscapedFunctions = array();
-
-	public $customSanitizingFunctions = array();
-
-	public $customPrintingFunctions = array();
-
-	public static $autoEscapedFunctions = array(
-		'allowed_tags',
-		'bloginfo',
-		'body_class',
-		'calendar_week_mod',
-		'cancel_comment_reply_link',
-		'category_description',
-		'checked',
-		'comment_ID',
-		'comment_author',
-		'comment_author_IP',
-		'comment_author_email',
-		'comment_author_email_link',
-		'comment_author_link',
-		'comment_author_rss',
-		'comment_author_url',
-		'comment_author_url_link',
-		'comment_class',
-		'comment_date',
-		'comment_excerpt',
-		'comment_form',
-		'comment_form_title',
-		'comment_id_fields',
-		'comment_reply_link',
-		'comment_text',
-		'comment_text_rss',
-		'comment_time',
-		'comment_type',
-		'comments_link',
-		'comments_number',
-		'comments_popup_link',
-		'comments_popup_script',
-		'comments_rss_link',
-		'delete_get_calendar_cache',
-		'disabled',
-		'do_shortcode_tag',
-		'edit_bookmark_link',
-		'edit_comment_link',
-		'edit_post_link',
-		'edit_tag_link',
-		'get_archives_link',
-		'get_attachment_link',
-		'get_avatar',
-		'get_bookmark',
-		'get_bookmark_field',
-		'get_calendar',
-		'get_comment_author_link',
-		'get_comment_date',
-		'get_comment_time',
-		'get_current_blog_id',
-		'get_delete_post_link',
-		'get_footer',
-		'get_header',
-		'get_search_form',
-		'get_search_query',
-		'get_sidebar',
-		'get_template_part',
-		'get_the_author',
-		'get_the_author_link',
-		'get_the_date',
-		'get_the_post_thumbnail',
-		'get_the_term_list',
-		'get_the_title',
-		'has_post_thumbnail',
-		'in_array',
-		'is_array',
-		'is_attachment',
-		'next_comments_link',
-		'next_image_link',
-		'next_post_link',
-		'next_posts_link',
-		'paginate_comments_links',
-		'permalink_anchor',
-		'post_class',
-		'post_password_required',
-		'post_type_archive_title',
-		'posts_nav_link',
-		'previous_comments_link',
-		'previous_image_link',
-		'previous_post_link',
-		'previous_posts_link',
-		'selected',
-		'single_cat_title',
-		'single_month_title',
-		'single_post_title',
-		'single_tag_title',
-		'single_term_title',
-		'sticky_class',
-		'tag_description',
-		'term_description',
-		'the_ID',
-		'the_attachment_link',
-		'the_author',
-		'the_author_link',
-		'the_author_meta',
-		'the_author_posts',
-		'the_author_posts_link',
-		'the_category',
-		'the_category_rss',
-		'the_content',
-		'the_content_rss',
-		'the_date',
-		'the_date_xml',
-		'the_excerpt',
-		'the_excerpt_rss',
-		'the_feed_link',
-		'the_meta',
-		'the_modified_author',
-		'the_modified_date',
-		'the_modified_time',
-		'the_permalink',
-		'the_post_thumbnail',
-		'the_search_query',
-		'the_shortlink',
-		'the_tags',
-		'the_taxonomies',
-		'the_terms',
-		'the_time',
-		'the_title',
-		'the_title_attribute',
-		'the_title_rss',
-		'vip_powered_wpcom',
-		'walk_nav_menu_tree',
-		'wp_attachment_is_image',
-		'wp_dropdown_categories',
-		'wp_dropdown_users',
-		'wp_enqueue_script',
-		'wp_generate_tag_cloud',
-		'wp_get_archives',
-		'wp_get_attachment_image',
-		'wp_get_attachment_link',
-		'wp_link_pages',
-		'wp_list_authors',
-		'wp_list_bookmarks',
-		'wp_list_categories',
-		'wp_list_comments',
-		'wp_login_form',
-		'wp_loginout',
-		'wp_meta',
-		'wp_nav_menu',
-		'wp_register',
-		'wp_shortlink_header',
-		'wp_shortlink_wp_head',
-		'wp_tag_cloud',
-		'wp_title',
-		'checked',
-	);
-
-	public static $sanitizingFunctions = array(
-		'absint',
-		'balanceTags',
-		'esc_attr',
-		'esc_attr__',
-		'esc_attr_e',
-		'esc_attr_x',
-		'esc_html',
-		'esc_html__',
-		'esc_html_e',
-		'esc_html_x',
-		'esc_js',
-		'esc_sql',
-		'esc_textarea',
-		'esc_url',
-		'esc_url_raw',
-		'filter_input',
-		'filter_var',
-		'intval',
-		'is_email',
-		'json_encode',
-		'like_escape',
-		'rawurlencode',
-		'sanitize_bookmark',
-		'sanitize_bookmark_field',
-		'sanitize_email',
-		'sanitize_file_name',
-		'sanitize_html_class',
-		'sanitize_key',
-		'sanitize_meta',
-		'sanitize_mime_type',
-		'sanitize_option',
-		'sanitize_sql_orderby',
-		'sanitize_term',
-		'sanitize_term_field',
-		'sanitize_text_field',
-		'sanitize_title',
-		'sanitize_title_for_query',
-		'sanitize_title_with_dashes',
-		'sanitize_user',
-		'sanitize_user_field',
-		'tag_escape',
-		'urlencode',
-		'urlencode_deep',
-		'validate_file',
-		'wp_json_encode',
-		'wp_kses',
-		'wp_kses_allowed_html',
-		'wp_kses_data',
-		'wp_kses_post',
-		'wp_parse_id_list',
-		'wp_redirect',
-		'wp_rel_nofollow',
-		'wp_safe_redirect',
-		'number_format',
-		'ent2ncr',
-	);
+	/**
+	 * Custom list of functions which escape values for output.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string[]
+	 */
+	public $customEscapingFunctions = array();
 
 	/**
-	 * Functions which print output incorporating the values passed to them.
+	 * Custom list of functions whose return values are pre-escaped for output.
 	 *
-	 * @var array
+	 * @since 0.3.0
+	 *
+	 * @var string[]
 	 */
-	public static $printingFunctions = array(
-		'_deprecated_argument',
-		'_deprecated_function',
-		'_deprecated_file',
-		'_doing_it_wrong',
-		'_e',
-		'_ex',
-		'printf',
-		'vprintf',
-		'trigger_error',
-		'user_error',
-		'wp_die',
-	);
+	public $customAutoEscapedFunctions = array();
+
+	/**
+	 * Custom list of functions which escape values for output.
+	 *
+	 * @since 0.3.0
+	 * @deprecated 0.5.0 Use $customEscapingFunctions instead.
+	 *
+	 * @var string[]
+	 */
+	public $customSanitizingFunctions = array();
+
+	/**
+	 * Custom list of functions which print output incorporating the passed values.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var string[]
+	 */
+	public $customPrintingFunctions = array();
 
 	/**
 	 * Printing functions that incorporate unsafe values.
+	 *
+	 * @since 0.4.0
 	 *
 	 * @var array
 	 */
 	public static $unsafePrintingFunctions = array(
 		'_e' => 'esc_html_e() or esc_attr_e()',
 		'_ex' => 'esc_html_ex() or esc_attr_ex()',
-	);
-
-	/**
-	 * Functions that format strings.
-	 *
-	 * These functions are often used for formatting translation strings, and it is
-	 * common practice to escape the individual parameters passed to them as needed
-	 * instead of escaping the entire result. This is especially true when the string
-	 * being formatted contains HTML, which makes escaping the full result more
-	 * difficult.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @var array
-	 */
-	public static $formattingFunctions = array(
-		'sprintf',
-		'vsprintf',
-		'wp_sprintf',
 	);
 
 	/**
@@ -317,9 +106,15 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	{
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
-			self::$sanitizingFunctions = array_merge( self::$sanitizingFunctions, $this->customSanitizingFunctions );
-			self::$autoEscapedFunctions = array_merge( self::$autoEscapedFunctions, $this->customAutoEscapedFunctions );
-			self::$printingFunctions = array_merge( self::$printingFunctions, $this->customPrintingFunctions );
+			WordPress_Sniff::$escapingFunctions = array_merge( WordPress_Sniff::$escapingFunctions, array_flip( $this->customEscapingFunctions ) );
+			WordPress_Sniff::$autoEscapedFunctions = array_merge( WordPress_Sniff::$autoEscapedFunctions, array_flip( $this->customAutoEscapedFunctions ) );
+			WordPress_Sniff::$printingFunctions = array_merge( WordPress_Sniff::$printingFunctions, array_flip( $this->customPrintingFunctions ) );
+
+			if ( ! empty( $this->customSanitizingFunctions ) ) {
+				WordPress_Sniff::$escapingFunctions = array_merge( WordPress_Sniff::$escapingFunctions, array_flip( $this->customSanitizingFunctions ) );
+				$phpcsFile->addWarning( 'The customSanitizingFunctions property is deprecated in favor of customEscapingFunctions.', 0, 'DeprecatedCustomSanitizingFunctions' );
+			}
+
 			self::$addedCustomFunctions = true;
 		}
 
@@ -333,8 +128,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 		// If function, not T_ECHO nor T_PRINT
 		if ( $tokens[$stackPtr]['code'] == T_STRING ) {
-			// Skip if it is a function but is not of the printing functions ( self::printingFunctions )
-			if ( ! in_array( $tokens[$stackPtr]['content'], self::$printingFunctions ) ) {
+			// Skip if it is a function but is not of the printing functions.
+			if ( ! isset( self::$printingFunctions[ $tokens[ $stackPtr ]['content'] ] ) ) {
 				return;
 			}
 
@@ -485,42 +280,40 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			}
 
 			// Now check that next token is a function call.
-			if ( in_array( $tokens[$i]['code'], array( T_STRING ) ) === false ) {
-				$phpcsFile->addError( "Expected next thing to be a escaping function, not '%s'", $i, 'OutputNotEscaped', $tokens[$i]['content'] );
-				continue;
-			}
+			if ( T_STRING === $this->tokens[ $i ]['code'] ) {
 
-			// This is a function
-			else {
-				$functionName = $tokens[$i]['content'];
+				$functionName = $this->tokens[ $i ]['content'];
+				$is_formatting_function = isset( self::$formattingFunctions[ $functionName ] );
 
-				$is_formatting_function = in_array( $functionName, self::$formattingFunctions );
-
-				if (
-					! $is_formatting_function
-					&&
-					in_array( $functionName, self::$autoEscapedFunctions ) === false
-					&&
-					in_array( $functionName, self::$sanitizingFunctions ) === false
-					) {
-
-					$phpcsFile->addError( "Expected a sanitizing function (see Codex for 'Data Validation'), but instead saw '%s'", $i, 'OutputNotSanitized', $tokens[$i]['content'] );
-				}
-
-				// Skip pointer to after the function
-				if ( $_pos = $phpcsFile->findNext( array( T_OPEN_PARENTHESIS ), $i, null, null, null, true ) ) {
+				// Skip pointer to after the function.
+				if ( $_pos = $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS ), $i, null, null, null, true ) ) {
 
 					// If this is a formatting function we just skip over the opening
 					// parenthesis. Otherwise we skip all the way to the closing.
 					if ( $is_formatting_function ) {
-						$i = $_pos + 1;
+						$i     = $_pos + 1;
 						$watch = true;
 					} else {
-						$i = $tokens[ $_pos ]['parenthesis_closer'];
+						$i = $this->tokens[ $_pos ]['parenthesis_closer'];
 					}
 				}
-				continue;
+
+				// If this is a safe function, we don't flag it.
+				if (
+					$is_formatting_function
+					|| isset( self::$autoEscapedFunctions[ $functionName ] )
+					|| isset( self::$escapingFunctions[ $functionName ] )
+				) {
+					continue;
+				}
 			}
+
+			$this->phpcsFile->addError(
+				"Expected next thing to be an escaping function (see Codex for 'Data Validation'), not '%s'",
+				$i,
+				'OutputNotEscaped',
+				$this->tokens[ $i ]['content']
+			);
 		}
 
 		return $end_of_statement;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -10,7 +10,7 @@
  */
 
 /**
- * Verifies that all outputted strings are sanitized
+ * Verifies that all outputted strings are escaped.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -4,7 +4,7 @@ do_something( $_POST ); // OK
 
 do_something_with( $_POST['hello'] ); // Error for no validation, Error for no sanitizing
 
-echo esc_html( $_POST['foo1'] ); // Error for no validation
+echo sanitize_text_field( $_POST['foo1'] ); // Error for no validation
 
 if ( isset( $_POST['foo2'] ) ) {
 	bar( $_POST['foo2'] ); // Error for no sanitizing
@@ -48,7 +48,7 @@ function bar() {
 	if ( ! isset( $_GET['test'] ) ) {
 		return ;
 	}
-	echo esc_html( $_GET['test'] ); // Good
+	echo sanitize_text_field( $_GET['test'] ); // Good
 }
 
 $_REQUEST['wp_customize'] = 'on'; // ok
@@ -69,7 +69,7 @@ some_func( $some_arg, (int) $_GET['test'] ); // ok
 
 function zebra() {
 	if ( isset( $_GET['foo'], $_POST['bar'] ) ) {
-		echo esc_html( $_POST['bar'] ); // ok
+		echo sanitize_text_field( $_POST['bar'] ); // ok
 	}
 }
 
@@ -91,3 +91,7 @@ if ( 'bar' === do_something( $_POST['foo'] ) ) {} // Bad
 
 switch ( $_POST['foo'] ) {} // OK
 switch ( do_something( $_POST['foo'] ) ) {} // Bad
+
+// Sanitization is required even when the value is being escaped.
+echo esc_html( $_POST['foo'] ); // Bad
+echo esc_html( sanitize_text_field( $_POST['foo'] ) ); // OK

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -16,9 +16,9 @@ if ( isset( $_POST['foo2'] ) ) {
 
 
 if ( isset( $_POST['foo3'] ) ) {
-	bar( esc_html( $_POST['foo3'] ) ); // Good, validated and sanitized
+	bar( sanitize_text_field( $_POST['foo3'] ) ); // Good, validated and sanitized
 	bar( $_POST['foo3'] ); // Error, validated but not sanitized
-	bar( esc_html( $_POST['foo3'] ) ); // Good, validated and sanitized
+	bar( sanitize_text_field( $_POST['foo3'] ) ); // Good, validated and sanitized
 }
 
 // Should all be OK
@@ -34,13 +34,13 @@ $foo = $_POST['bar']; // Bad x 2
 
 function foo() {
 	// Ok, if WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff::$check_validation_in_scope_only == false
-	if ( ! isset( $_REQUEST['bar1'] ) || ! foo( esc_attr( $_REQUEST['bar1'] ) ) ) {
+	if ( ! isset( $_REQUEST['bar1'] ) || ! foo( sanitize_text_field( $_REQUEST['bar1'] ) ) ) {
 		wp_die( 1 );
 	}
 }
 
 // Ok, if WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff::$check_validation_in_scope_only == false
-if ( ! isset( $_REQUEST['bar2'] ) || ! foo( esc_attr( $_REQUEST['bar2'] ) ) ) { // Ok
+if ( ! isset( $_REQUEST['bar2'] ) || ! foo( sanitize_text_field( $_REQUEST['bar2'] ) ) ) { // Ok
 	wp_die( 1 );
 }
 

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -38,7 +38,7 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			85 => 1,
 			90 => 1,
 			93 => 1,
-			95 => 1,
+			96 => 1,
 			);
 
 	}//end getErrorList()

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -38,6 +38,7 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			85 => 1,
 			90 => 1,
 			93 => 1,
+			95 => 1,
 			);
 
 	}//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -6,7 +6,7 @@ while ( have_posts() ) {
 
 	// OK
 	?>
-	<a href="<?php the_permalink(); ?>" alt="<?php the_title_attribute(); ?>"><?php the_title(); ?></a>
+	<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a>
 	<?php
 
 	the_content(); // OK
@@ -16,7 +16,7 @@ while ( have_posts() ) {
 
 <h2><?php echo $title; // Bad ?></h2>
 <h2><?php echo esc_html( $title ); // OK ?></h2>
-<h2><?php echo apply_filters( 'the_title', $title ); // Bad, no sanitizing function ?></h2>
+<h2><?php echo apply_filters( 'the_title', $title ); // Bad, no escaping function ?></h2>
 
 <?php
 // issue:#53
@@ -50,9 +50,9 @@ echo filter_input( INPUT_GET, $bar, FILTER_SANITIZE_SPECIAL_CHARS );
 
 echo '<input type="checkbox" name="' . esc_attr( 'field[' . $id . ']' ) . '" value="on" ' . checked( $current, 'on', false ) . '> ';
 
-echo ent2ncr( $text );
+echo ent2ncr( $text ); // Bad
 
-echo number_format ( 1024 );
+echo number_format( 1024 );
 
 echo ent2ncr( esc_html( $_data ) );
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -51,6 +51,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			41 => 1,
 			43 => 1,
 			46 => 1,
+			53 => 1,
 			59 => 1,
 			60 => 1,
 			65 => 1,


### PR DESCRIPTION
Historically there has a been a list of “sanitizing” functions in the
XSS sniff. This list could be added to via the
`customSanitizingFunctions` property. This list of functions was also
used by the `ValidatedSanitizedInput` sniff.

However, what the XSS sniff is really checking for is that the output
is *escaped*. This is slightly different from *sanitization*, and is
(usually) performed by different functions.

In this commit, I’ve split the `sanitizingFunctions` list in the XSS
sniff, and moved it to the main sniff. This will allow the list to be
accessed from all sniffs more easily. I’ve also flipped the list so
that the functions are the keys instead of values, because this allows
for quicker lookup with `isset()` instead of having to use
`in_array()`. The values currently have no meaning, though it’s
possible we’ll use them for something in the future. (I’ve also done
this for the other function lists from the XSS sniff, and the list of
nonce verification functions.)

I’ve split the list of “sanitizing” functions into the
`sanitizingFunctions` and `escapingFunctions` properties. A few
functions are found on both lists, but for the most part there is
pretty clear separation. We will tweak this in the future as needed.

I’ve completely removed the `balanceTags()` function from both lists,
because it doesn’t actually strip scripts or anything like that. There
may be a case for adding it back to the sanitizing functions list, and
you’re welcome to make it.

I’ve also moved `ent2ncr()` to the list of formatting functions, since
it doesn't actually escape things, just format them. (It was added in
#189.)

The `customSanitizingFunctions` property of the XSS sniff has been
deprecated, and a `customEscapingFunctions` property has been added in
its place. When the deprecated property is used, a warning will be
given.

I’ve also added a `customSanitizingFunctions` property to the
`ValidatedSanitizedInput` sniff. This is where custom sanitizing
functions should be added now. Adding them to either of the properties
of the XSS sniff won’t have the desired effect.

Finally, there is one issue yet to be resolved, so the tests are
intentionally failing. There is currently no provision made for code
like this, which takes user input and directly escapes it for display:

```php
echo esc_html( $_POST[‘foo’] );
```

With a little work, we could make this permissible. But perhaps there
is a case to be made that sanitization should still be applied even in
a case like this. Please let your opinion be known.

Fixes #343 