### PR TITLE
Have Travis CI test against multiple verions of PHPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,32 @@ php:
     - 5.4
     - 5.5
     - 5.6
-    - nightly
-    - hhvm
+
+env:
+  - PHPCS_BRANCH=master
+  - PHPCS_BRANCH=2.2.0
+  - PHPCS_BRANCH=2.1.0
+  - PHPCS_BRANCH=2.0.0
+  - PHPCS_BRANCH=3.0.0
 
 matrix:
+  include:
+    # Run against PHPCS 3.0.0. I just picked to run it against 5.6.
+    - php: 5.6
+      env: PHPCS_BRANCH=3.0.0
+    # Run against HHVM and PHP nightly.
+    - php: hhvm
+      env: PHPCS_BRANCH=master
+    - php: nightly
+      env: PHPCS_BRANCH=master
   allow_failures:
+    # Allow failures for unstable builds.
     - php: nightly
     - php: hhvm
+    - env: PHPCS_BRANCH=3.0.0
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
-    - export PHPCS_BRANCH=master
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $(pwd)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ matrix:
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
+    - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
-    - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $(pwd)
+    - $PHPCS_BIN --config-set installed_paths $(pwd)
 
 script:
     - find . \( -name '*.php' \) -exec php -lf {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,12 @@ env:
   - PHPCS_BRANCH=2.2.0
   - PHPCS_BRANCH=2.1.0
   - PHPCS_BRANCH=2.0.0
-  - PHPCS_BRANCH=3.0.0
 
 matrix:
   include:
-    # Run against PHPCS 3.0.0. I just picked to run it against 5.6.
+    # Run against PHPCS 3.0. I just picked to run it against 5.6.
     - php: 5.6
-      env: PHPCS_BRANCH=3.0.0
+      env: PHPCS_BRANCH=3.0
     # Run against HHVM and PHP nightly.
     - php: hhvm
       env: PHPCS_BRANCH=master
@@ -30,7 +29,7 @@ matrix:
     # Allow failures for unstable builds.
     - php: nightly
     - php: hhvm
-    - env: PHPCS_BRANCH=3.0.0
+    - env: PHPCS_BRANCH=3.0
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
 env:
   - PHPCS_BRANCH=master
   - PHPCS_BRANCH=2.2.0
-  - PHPCS_BRANCH=2.1.0
-  - PHPCS_BRANCH=2.0.0
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "~2.0"
+		"squizlabs/php_codesniffer": "~2.2"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
Right now we only test against PHPCS `master`. However, it is useful to test against older versions so that we know when we are breaking compatibility.

I changed the matrix to run against 2.0.0, 2.1.0, 2.2.0, and 3.0. Here is what I found:

We are incompatible with 2.0.0:

```
Fatal error: Call to undefined method PHP_CodeSniffer_File::findEndOfStatement() in /home/travis/build/WordPress-Coding-Standards/WordPress-Coding-Standards/WordPress/Sniffs/XSS/EscapeOutputSniff.php on line 347
```

We can run against 2.1.0, however, there are some oddities, possibly in the parser or something, that cause the tests for `WordPress.XSS.EscapeOutput` to fail.

So I've removed both those versions from the matrix. For more details you can see the travis build: https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards/builds/63017423

We are still compatible with 2.2.0, so I've updated the composer.json to specify `~2.2`.

Testing against 3.0 reveals that it is not backward compatible. Everything uses namespaces, so the tests can't even run because `AbstractSniffUnitTest` is now under a namespace. So, I guess there's not much point in running against 3.0, but I haven't removed it from the matrix yet.