### PR TITLE
Add tests demonstrating ternary operator

### DIFF
--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -95,3 +95,6 @@ switch ( do_something( $_POST['foo'] ) ) {} // Bad
 // Sanitization is required even when the value is being escaped.
 echo esc_html( $_POST['foo'] ); // Bad
 echo esc_html( sanitize_text_field( $_POST['foo'] ) ); // OK
+
+$current_tax_slug = isset( $_GET['a'] ) ? sanitize_key( $_GET['a'] ) : false;
+$current_tax_slug = isset( $_GET['a'] ) ? $_GET['a'] : false;

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -39,6 +39,7 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			90 => 1,
 			93 => 1,
 			96 => 1,
+			100 => 1,
 			);
 
 	}//end getErrorList()


### PR DESCRIPTION
The validated/sanitized input sniff used not to handle super globals in
ternary conditions properly. Now it does, so I’ve added tests which
demonstrate this.

Closes #168