### PR TITLE
Require unlashing of input superglobals

### DIFF
--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -28,6 +28,15 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	public $customSanitizingFunctions = array();
 
 	/**
+	 * Custom sanitizing functions that implicitly unslash the values passed to them.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string[]
+	 */
+	public $customUnslashingSanitizingFunctions = array();
+
+	/**
 	 * Whether the custom list of functions has been added to the defaults yet.
 	 *
 	 * @since 0.5.0
@@ -65,6 +74,11 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			WordPress_Sniff::$sanitizingFunctions = array_merge(
 				WordPress_Sniff::$sanitizingFunctions,
 				array_flip( $this->customSanitizingFunctions )
+			);
+
+			WordPress_Sniff::$unslashingSanitizingFunctions = array_merge(
+				WordPress_Sniff::$unslashingSanitizingFunctions,
+				array_flip( $this->customUnslashingSanitizingFunctions )
 			);
 
 			self::$addedCustomFunctions = true;
@@ -123,7 +137,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 		}
 
 		// Now look for sanitizing functions
-		if ( ! $this->is_sanitized( $stackPtr ) ) {
+		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
 			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', array( $tokens[ $stackPtr ]['content'] ) );
 		}
 

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -2,12 +2,12 @@
 
 do_something( $_POST ); // OK
 
-do_something_with( $_POST['hello'] ); // Error for no validation, Error for no sanitizing
+do_something_with( $_POST['hello'] ); // Error for no validation, Error for no sanitizing, Error for no unslashing.
 
-echo sanitize_text_field( $_POST['foo1'] ); // Error for no validation
+echo sanitize_text_field( wp_unslash( $_POST['foo1'] ) ); // Error for no validation
 
 if ( isset( $_POST['foo2'] ) ) {
-	bar( $_POST['foo2'] ); // Error for no sanitizing
+	bar( wp_unslash( $_POST['foo2'] ) ); // Error for no sanitizing
 }
 
 // @TODO: Cover non-parenthesis'd conditions
@@ -16,9 +16,9 @@ if ( isset( $_POST['foo2'] ) ) {
 
 
 if ( isset( $_POST['foo3'] ) ) {
-	bar( sanitize_text_field( $_POST['foo3'] ) ); // Good, validated and sanitized
-	bar( $_POST['foo3'] ); // Error, validated but not sanitized
-	bar( sanitize_text_field( $_POST['foo3'] ) ); // Good, validated and sanitized
+	bar( sanitize_text_field( wp_unslash( $_POST['foo3'] ) ) ); // Good, validated and sanitized
+	bar( wp_unslash( $_POST['foo3'] ) ); // Error, validated but not sanitized
+	bar( sanitize_text_field( wp_unslash( $_POST['foo3'] ) ) ); // Good, validated and sanitized
 }
 
 // Should all be OK
@@ -30,17 +30,17 @@ $empty = (
 	empty( $_POST['foo4'] )
 );
 
-$foo = $_POST['bar']; // Bad x 2
+$foo = $_POST['bar']; // Bad x 3
 
 function foo() {
 	// Ok, if WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff::$check_validation_in_scope_only == false
-	if ( ! isset( $_REQUEST['bar1'] ) || ! foo( sanitize_text_field( $_REQUEST['bar1'] ) ) ) {
+	if ( ! isset( $_REQUEST['bar1'] ) || ! foo( sanitize_text_field( wp_unslash( $_REQUEST['bar1'] ) ) ) ) {
 		wp_die( 1 );
 	}
 }
 
 // Ok, if WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff::$check_validation_in_scope_only == false
-if ( ! isset( $_REQUEST['bar2'] ) || ! foo( sanitize_text_field( $_REQUEST['bar2'] ) ) ) { // Ok
+if ( ! isset( $_REQUEST['bar2'] ) || ! foo( sanitize_text_field( wp_unslash( $_REQUEST['bar2'] ) ) ) ) { // Ok
 	wp_die( 1 );
 }
 
@@ -48,7 +48,7 @@ function bar() {
 	if ( ! isset( $_GET['test'] ) ) {
 		return ;
 	}
-	echo sanitize_text_field( $_GET['test'] ); // Good
+	echo sanitize_text_field( wp_unslash( $_GET['test'] ) ); // Good
 }
 
 $_REQUEST['wp_customize'] = 'on'; // ok
@@ -69,17 +69,17 @@ some_func( $some_arg, (int) $_GET['test'] ); // ok
 
 function zebra() {
 	if ( isset( $_GET['foo'], $_POST['bar'] ) ) {
-		echo sanitize_text_field( $_POST['bar'] ); // ok
+		echo sanitize_text_field( wp_unslash( $_POST['bar'] ) ); // ok
 	}
 }
 
 echo $_GET['test']; // WPCS: sanitization OK.
 
-echo array_map( 'sanitize_text_field', $_GET['test'] ); // OK
-echo array_map( 'foo', $_GET['test'] ); // Bad
-echo array_map( $something, $_GET['test'] ); // Bad
-echo array_map( array( $obj, 'func' ), $_GET['test'] ); // Bad
-echo array_map( array( $obj, 'sanitize_text_field' ), $_GET['test'] ); // Bad
+echo array_map( 'sanitize_text_field', wp_unslash( $_GET['test'] ) ); // OK
+echo array_map( 'foo', wp_unslash( $_GET['test'] ) ); // Bad
+echo array_map( $something, wp_unslash( $_GET['test'] ) ); // Bad
+echo array_map( array( $obj, 'func' ), wp_unslash( $_GET['test'] ) ); // Bad
+echo array_map( array( $obj, 'sanitize_text_field' ), wp_unslash( $_GET['test'] ) ); // Bad
 
 // Sanitized but not validated.
 $foo = (int) $_POST['foo6']; // Bad
@@ -87,14 +87,25 @@ $foo = (int) $_POST['foo6']; // Bad
 // Non-assignment checks are OK.
 if ( 'bar' === $_POST['foo'] ) {} // OK
 if ( $_GET['test'] != 'a' ) {} // OK
-if ( 'bar' === do_something( $_POST['foo'] ) ) {} // Bad
+if ( 'bar' === do_something( wp_unslash( $_POST['foo'] ) ) ) {} // Bad
 
 switch ( $_POST['foo'] ) {} // OK
-switch ( do_something( $_POST['foo'] ) ) {} // Bad
+switch ( do_something( wp_unslash( $_POST['foo'] ) ) ) {} // Bad
 
 // Sanitization is required even when the value is being escaped.
-echo esc_html( $_POST['foo'] ); // Bad
-echo esc_html( sanitize_text_field( $_POST['foo'] ) ); // OK
+echo esc_html( wp_unslash( $_POST['foo'] ) ); // Bad
+echo esc_html( sanitize_text_field( wp_unslash( $_POST['foo'] ) ) ); // OK
 
-$current_tax_slug = isset( $_GET['a'] ) ? sanitize_key( $_GET['a'] ) : false;
-$current_tax_slug = isset( $_GET['a'] ) ? $_GET['a'] : false;
+$current_tax_slug = isset( $_GET['a'] ) ? sanitize_key( $_GET['a'] ) : false; // OK
+$current_tax_slug = isset( $_GET['a'] ) ? $_GET['a'] : false; // Bad x 2
+$current_tax_slug = isset( $_GET['a'] ) ? wp_unslash( $_GET['a'] ) : false; // Bad
+$current_tax_slug = isset( $_GET['a'] ) ? sanitize_text_field( wp_unslash( $_GET['a'] ) ) : false; // OK
+
+echo sanitize_text_field( $_POST['foo545'] ); // Error for no validation, unslashing
+echo array_map( 'sanitize_text_field', $_GET['test'] ); // Bad, no unslashing
+echo array_map( 'sanitize_key', $_GET['test'] ); // OK
+
+foo( absint( $_GET['foo'] ) ); // OK
+$ids = array_map( 'absint', $_GET['test'] ); // OK
+
+if ( is_array( $_GET['test'] ) ) {} // OK

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -25,11 +25,11 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 	public function getErrorList()
 	{
 		return array(
-			5 => 2,
+			5 => 3,
 			7 => 1,
 			10 => 1,
 			20 => 1,
-			33 => 2,
+			33 => 3,
 			65 => 1,
 			79 => 1,
 			80 => 1,
@@ -39,7 +39,10 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			90 => 1,
 			93 => 1,
 			96 => 1,
-			100 => 1,
+			100 => 2,
+			101 => 1,
+			104 => 2,
+			105 => 1,
 			);
 
 	}//end getErrorList()


### PR DESCRIPTION
This updates the validated/sanitized input sniff to also check for
slashing. This could have been made into another sniff instead,
however, it would have required lots of duplicated logic and this sniff
would need to be updated to accommodate the use of `wp_unslash()`
anyway.

Currently only `wp_unslash()` is recognized as an unlashing function,
but this can be changed in the future if needed.

The sniff currently requires that `wp_unslash()` be used *before* the
data is passed through a sanitizing function. Sanitizing first and then
wrapping that in `wp_unslash()` is not accepted.

The error for missing the use of `wp_unslash()` is independent of the
missing sanitizing function error, so an error will be given for
missing use of an unslashing function whether or not a sanitizing
function is used, and vice versa.

Unslashing is not required when sanitization is provided via casting,
or when certain sanitization functions are used which implicitly or
explicitly perform an unslash or for which unslashing isn’t necessary.
`absint()` implicitly unslashes, and `sanitize_key()` will remove
slashes explicitly. And unslashing isn’t necessary when testing a value
with `is_array()`. This list can be expanded in the future, and is
configurable via the `customUnslashingSanitizingFunctions` property.

See #172