### PR TITLE
DB query sniff: support custom cache functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -330,6 +330,40 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	);
 
 	/**
+	 * A list of functions that get data from the cache.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var array
+	 */
+	public static $cacheGetFunctions = array(
+		'wp_cache_get' => true,
+	);
+
+	/**
+	 * A list of functions that set data in the cache.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var array
+	 */
+	public static $cacheSetFunctions = array(
+		'wp_cache_set' => true,
+		'wp_cache_add' => true,
+	);
+
+	/**
+	 * A list of functions that delete data from the cache.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var array
+	 */
+	public static $cacheDeleteFunctions = array(
+		'wp_cache_delete' => true,
+	);
+
+	/**
 	 * The current file being sniffed.
 	 *
 	 * @since 0.4.0

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -13,6 +13,33 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 {
 
 	/**
+	 * List of custom cache get functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string[]
+	 */
+	public $customCacheGetFunctions = array();
+
+	/**
+	 * List of custom cache set functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string[]
+	 */
+	public $customCacheSetFunctions = array();
+
+	/**
+	 * List of custom cache delete functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string[]
+	 */
+	public $customCacheDeleteFunctions = array();
+
+	/**
 	 * The lists of $wpdb methods.
 	 *
 	 * @since 0.6.0
@@ -62,6 +89,21 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 	{
 		if ( ! isset( self::$methods['all'] ) ) {
 			self::$methods['all'] = array_merge( self::$methods['cachable'], self::$methods['noncachable'] );
+
+			WordPress_Sniff::$cacheGetFunctions = array_merge(
+				WordPress_Sniff::$cacheGetFunctions,
+				array_flip( $this->customCacheGetFunctions )
+			);
+
+			WordPress_Sniff::$cacheSetFunctions = array_merge(
+				WordPress_Sniff::$cacheSetFunctions,
+				array_flip( $this->customCacheSetFunctions )
+			);
+
+			WordPress_Sniff::$cacheDeleteFunctions = array_merge(
+				WordPress_Sniff::$cacheDeleteFunctions,
+				array_flip( $this->customCacheDeleteFunctions )
+			);
 		}
 
 		$tokens = $phpcsFile->getTokens();
@@ -132,18 +174,18 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 				for ( $i = $scopeStart + 1; $i < $scopeEnd; $i++ ) {
 					if ( T_STRING === $tokens[ $i ]['code'] ) {
 
-						if ( 'wp_cache_delete' === $tokens[ $i ]['content'] ) {
+						if ( isset( WordPress_Sniff::$cacheDeleteFunctions[ $tokens[ $i ]['content'] ] ) ) {
 
 							if ( in_array( $method, array( 'query', 'update', 'replace', 'delete' ) ) ) {
 								$cached = true;
 								break;
 							}
 
-						} elseif ( 'wp_cache_get' === $tokens[ $i ]['content'] ) {
+						} elseif ( isset( WordPress_Sniff::$cacheGetFunctions[ $tokens[ $i ]['content'] ] ) ) {
 
 							$wp_cache_get = true;
 
-						} elseif ( in_array( $tokens[ $i ]['content'], array( 'wp_cache_set', 'wp_cache_add' ) ) ) {
+						} elseif ( isset( WordPress_Sniff::$cacheSetFunctions[ $tokens[ $i ]['content'] ] ) ) {
 
 							if ( $wp_cache_get ) {
 								$cached = true;


### PR DESCRIPTION
Sometimes one might use custom caching functions that wrap the
functions which WordPress uses. In that case, they should be able to
add them to the list used in this sniff using their XML config file.