### PR TITLE
Remove non-rules from VIP ruleset

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -4,10 +4,6 @@
 
 	<rule ref="WordPress-Core"/>
 
-	<!-- the following are inherited by other sniffs -->
-	<rule ref="WordPress.Functions.FunctionRestrictions"/>
-	<rule ref="WordPress.Variables.VariableRestrictions"/>
-
 	<rule ref="WordPress.VIP"/>
 
 	<rule ref="WordPress.XSS.EscapeOutput"/>

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -93,7 +93,7 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			return;
+			return count( $tokens ) + 1;
 		}
 
 		foreach ( $groups as $groupName => $group ) {

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -86,7 +86,7 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			return;
+			return count( $tokens ) + 1;
 		}
 
 		// Check if it is a function not a variable


### PR DESCRIPTION
These rules are not really rules at all. Instead, they are parent
classes extended by other sniffs. They don’t do anything on their own,
and since the classes will be auto-loaded, we don’t need to include
them in the ruleset.

I’ve also updated each of these classes to skip over a file if there
are no tests to run. This will improve performance when running the
`WordPress` ruleset.

The function restrictions class could possibly be made abstract in the
future, if we wanted to do that. However, the variable restrictions
sniff has its own tests, and so it can’t be abstract.

Related: #345