### PR TITLE
Correct the syntax error detection on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,5 @@ before_script:
     - $PHPCS_BIN --config-set installed_paths $(pwd)
 
 script:
-    - find . \( -name '*.php' \) -exec php -lf {} \;
+    - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     - phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php


### PR DESCRIPTION
The `.travis.yml` file includes the following line which is intended to check for syntax errors:

`find . \( -name '*.php' \) -exec php -lf {} \;`

While it does indeed do this, it's not of any use because its output doesn't cause Travis to report the failure.

You can see [my recent efforts](https://travis-ci.org/johnbillion/user-switching/builds) to get this to work in my User Switching plugin. This is compatible with PHP and HHVM.

If you actually want to test it, you'll need to commit a file with a syntax error in it and wait for the Travis tests to run on the branch.