### PR TITLE
Add intval() and boolval() to unslashing functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -281,6 +281,8 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	public static $unslashingSanitizingFunctions = array(
 		'absint' => true,
+		'boolval' => true,
+		'intval' => true,
 		'is_array' => true,
 		'sanitize_key' => true,
 	);


### PR DESCRIPTION
They implicitly unslash the data passed to them, so it doesn't need to be put through `wp_unslash()` as well.

Fixes #426