### PR TITLE
Add hash_equals() to list of sanitizing functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -240,6 +240,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'esc_url_raw' => true,
 		'filter_input' => true,
 		'filter_var' => true,
+		'hash_equals' => true,
 		'in_array' => true,
 		'intval' => true,
 		'is_array' => true,


### PR DESCRIPTION
`hash_equals()` returns a boolean value, and does not print anything directly, so it is safe to pass unsanitized data to it.