### PR TITLE
Only check T_USE tokens associated with closures

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1041,6 +1041,40 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		return false;
 	}
+
+	/**
+	 * Check what type of 'use' statement a token is part of.
+	 *
+	 * The T_USE token has multiple different uses:
+	 *
+	 * 1. In a closure: function () use ( $var ) {}
+	 * 2. In a class, to import a trait: use Trait_Name
+	 * 3. In a namespace, to import a class: use Some\Class;
+	 *
+	 * This function will check the token and return 'closure', 'trait', or 'class',
+	 * based on which of these uses the use is being used for.
+	 *
+	 * @param int $stackPtr The position of the token to check.
+	 *
+	 * @return string The type of use.
+	 */
+	protected function get_use_type( $stackPtr ) {
+
+		// USE keywords inside closures.
+		$next = $this->phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
+
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
+			return 'closure';
+		}
+
+		// USE keywords for traits.
+		if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_CLASS, T_TRAIT ) ) ) {
+			return 'trait';
+		}
+
+		// USE keywords for classes to import to a namespace.
+		return 'class';
+	}
 }
 
 // EOF

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -22,8 +22,7 @@
  * @author   Greg Sherwood <gsherwood@squiz.net>
  * @author   Marc McIntyre <mmcintyre@squiz.net>
  */
-class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress_Sniff {
 
     /**
      * A list of tokenizers this sniff supports.
@@ -103,6 +102,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
 
         $tokens = $phpcsFile->getTokens();
 
+        $this->init( $phpcsFile );
+
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
             && ! ( $tokens[$stackPtr]['code'] === T_ELSE && $tokens[($stackPtr + 1)]['code'] === T_COLON )
             && ! ( T_CLOSURE === $tokens[ $stackPtr ]['code'] && 0 === (int) $this->spaces_before_closure_open_paren )
@@ -122,7 +123,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Co
 
         if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) === false ) {
 
-            if ( T_USE === $tokens[ $stackPtr ]['code'] ) {
+            if ( T_USE === $tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
                 $scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, $stackPtr + 1 );
                 $scopeCloser = $tokens[ $scopeOpener ]['scope_closer'];
             } else {

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -96,3 +96,6 @@ $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 )  {}; //
 
 $closureWithArgsAndVars = function ( $arg1, $arg2 )use ( $var1, $var2 ) {}; // Bad, expected exactly one space between closing parenthesis and control structure.
 $closureWithArgsAndVars = function ( $arg1, $arg2 )  use ( $var1, $var2 ) {}; // Bad, expected exactly one space between closing parenthesis and control structure.
+
+// Namespaces.
+use Foo\Admin;

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -92,3 +92,6 @@ $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // 
 
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad, expected exactly one space between closing parenthesis and control structure.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad, expected exactly one space between closing parenthesis and control structure.
+
+// Namespaces.
+use Foo\Admin;


### PR DESCRIPTION
The `T_USE` token is also used to import traits to classes, and to
import classes into namespaces.

Fixes #431