### PR TITLE
Simplify and improve ternary handling in XSS sniff

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -172,16 +172,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 				$ternary = $phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );
 
 				// If there is a ternary skip over the part before the ?. However, if
-				// there is a closing parenthesis ending the statement, we only do
-				// this when the opening parenthesis comes after the ternary. If the
-				// ternary is within the parentheses, it will be handled in the loop.
-				if (
-					$ternary
-					&& (
-						T_CLOSE_PARENTHESIS !== $tokens[ $last_token ]['code']
-						|| $ternary < $tokens[ $last_token ]['parenthesis_opener']
-					)
-				) {
+				// the ternary is within parentheses, it will be handled in the loop.
+				if ( $ternary && empty( $tokens[ $ternary ]['nested_parenthesis'] ) ) {
 					$stackPtr = $ternary;
 				}
 			}

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -157,3 +157,10 @@ echo sprintf( 'Howdy, %s', esc_html( $name ? $name : __( 'Partner' ) ) ); // OK
 
 _e( 'Something' ); // Bad
 esc_html_e( 'Something' ); // OK
+
+echo $something // Bad
+     . esc_attr( 'baz-' // Rest is OK
+	         . $r
+	         . ( $r === $active_round ? ' foo' : '' )
+	         . ( $r < $active_round ? ' bar' : '' )
+	) . 'something';

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -75,6 +75,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			148 => 1,
 			151 => 2,
 			158 => 1,
+			161 => 1,
 		);
 
     }//end getErrorList()


### PR DESCRIPTION
Most ternary conditions handled by this sniff occur within a set of
parentheses, and these are handled when an open parenthesis is
encountered in the token loop. However, the echo “function” is often
used without parentheses. Because of this, special handling is required
for ternary conditions that are used in an echo statement without
parentheses.

Previously the code for detecting this scenario was unnecessarily
complex, and incorrectly identified some ternary conditions as not
occurring in parentheses when they actually did. The result of this was
twofold: first, it would sometimes flag an expression as needing to be
escaped when it did not; and second, it could also skip over an
expression that did need to be escaped without flagging it.

This is now fixed.

Fixes #421