### PR TITLE
XSS sniff: support implode() and array_map()

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -304,6 +304,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	public static $formattingFunctions = array(
 		'ent2ncr' => true,
+		'implode' => true,
 		'sprintf' => true,
 		'vsprintf' => true,
 		'wp_sprintf' => true,

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -305,6 +305,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	public static $formattingFunctions = array(
 		'ent2ncr' => true,
 		'implode' => true,
+		'join' => true,
 		'sprintf' => true,
 		'vsprintf' => true,
 		'wp_sprintf' => true,

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -274,6 +274,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			// Now check that next token is a function call.
 			if ( T_STRING === $this->tokens[ $i ]['code'] ) {
 
+				$ptr = $i;
+
 				$functionName = $this->tokens[ $i ]['content'];
 
 				$function_opener = $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS ), $i + 1, null, null, null, true );
@@ -295,6 +297,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 						// If we're able to resolve the function name, do so.
 						if ( $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
 							$functionName = trim( $this->tokens[ $mapped_function ]['content'], '\'' );
+							$ptr = $mapped_function;
 						}
 					}
 
@@ -317,13 +320,19 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 				) {
 					continue;
 				}
+
+				$content = $functionName;
+
+			} else {
+				$content = $this->tokens[ $i ]['content'];
+				$ptr = $i;
 			}
 
 			$this->phpcsFile->addError(
 				"Expected next thing to be an escaping function (see Codex for 'Data Validation'), not '%s'",
-				$i,
+				$ptr,
 				'OutputNotEscaped',
-				$this->tokens[ $i ]['content']
+				$content
 			);
 		}
 

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -288,10 +288,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 						// Get the first parameter (name of function being used on the array).
 						$mapped_function = $this->phpcsFile->findNext(
-							PHP_CodeSniffer_Tokens::$emptyTokens
-							, $function_opener + 1
-							, $tokens[ $function_opener ]['parenthesis_closer']
-							, true
+							PHP_CodeSniffer_Tokens::$emptyTokens,
+							$function_opener + 1,
+							$tokens[ $function_opener ]['parenthesis_closer'],
+							true
 						);
 
 						// If we're able to resolve the function name, do so.

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -164,3 +164,6 @@ echo $something // Bad
 	         . ( $r === $active_round ? ' foo' : '' )
 	         . ( $r < $active_round ? ' bar' : '' )
 	) . 'something';
+
+echo implode( '<br>', $items ); // Bad
+echo implode( '<br>', urlencode_deep( $items ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -167,3 +167,5 @@ echo $something // Bad
 
 echo implode( '<br>', $items ); // Bad
 echo implode( '<br>', urlencode_deep( $items ) ); // OK
+echo implode( '<br>', array_map( 'esc_html', $items ) ); // OK
+echo implode( '<br>', array_map( 'foo', $items ) ); // Bad

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -169,3 +169,5 @@ echo implode( '<br>', $items ); // Bad
 echo implode( '<br>', urlencode_deep( $items ) ); // OK
 echo implode( '<br>', array_map( 'esc_html', $items ) ); // OK
 echo implode( '<br>', array_map( 'foo', $items ) ); // Bad
+echo join( '<br>', $items ); // Bad
+echo join( '<br>', array_map( 'esc_html', $items ) ); // OK

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -78,6 +78,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			161 => 1,
 			168 => 1,
 			171 => 1,
+			172 => 1,
 		);
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -76,6 +76,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			151 => 2,
 			158 => 1,
 			161 => 1,
+			168 => 1,
 		);
 
     }//end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -77,6 +77,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			158 => 1,
 			161 => 1,
 			168 => 1,
+			171 => 1,
 		);
 
     }//end getErrorList()


### PR DESCRIPTION
Because `implode()` is mostly useless without `array_map()`.

Fixes #442 