### PR TITLE
Add wp_dropdown_pages() to printing functions list

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -334,6 +334,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'user_error' => true,
 		'vprintf' => true,
 		'wp_die' => true,
+		'wp_dropdown_pages' => true,
 	);
 
 	/**


### PR DESCRIPTION
It is possible to disable direct output from this function, however, it is enabled by default.

See #358