### PR TITLE
XSS sniff: fix ternary detection bug

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -208,7 +208,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 					if ( $ternary ) {
 
-						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $i, $tokens[ $i ]['parenthesis_closer'] );
+						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $i + 1, $tokens[ $i ]['parenthesis_closer'] );
 
 						// We only do it if the ternary isn't within a subset of parentheses.
 						if ( ! $next_paren || $ternary > $tokens[ $next_paren ]['parenthesis_closer'] ) {

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -171,3 +171,8 @@ echo implode( '<br>', array_map( 'esc_html', $items ) ); // OK
 echo implode( '<br>', array_map( 'foo', $items ) ); // Bad
 echo join( '<br>', $items ); // Bad
 echo join( '<br>', array_map( 'esc_html', $items ) ); // OK
+
+echo '<option name="' . esc_attr( $name ) . '"' .
+     ( $name === $selected ? ' selected' : '' ) .
+     '>' . esc_html( $value )
+     . '</option>';


### PR DESCRIPTION
The logic was supposed to be looking for a second set of parentheses
within an outer set of parentheses. But because it passed `$i` to
`findNext()`, the current opening parenthesis was being found, since
`$i` points to the opening parenthesis at that point, and `findNext()`
starts with the _current_ token.

The solution is to start looking for the next opening parenthesis at
`$i + 1` instead.

Fixes #466