### PR TITLE
Add Squiz.PHP.CommentedOutCode to WordPress-VIP

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -11,4 +11,7 @@
 	<rule ref="WordPress.PHP.StrictComparisons" />
 	<rule ref="WordPress.WP.PreparedSQL" />
 
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
+	<rule ref="Squiz.PHP.CommentedOutCode" />
+
 </ruleset>


### PR DESCRIPTION
https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output

> ## Commented out code, Debug code or output
> […] The use of commented out code should be avoided. Having code that is not ready for production on production is bad practice and could easily lead to mistakes while reviewing (since the commented out code might not of been reviewed and the removing on a comment might slip in accidently).
