### PR TITLE
Add attachment_url_to_postid() to the restricted functions for WordPress-VIP

### DIFF
--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -112,6 +112,14 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 				),
 			),
 
+			'attachment_url_to_postid' => array(
+				'type' => 'error',
+				'message' => '%s is prohibited, please use wpcom_vip_attachment_url_to_postid() instead.',
+				'functions' => array(
+					'attachment_url_to_postid',
+				),
+			),
+
 			'wp_remote_get' => array(
 				'type' => 'warning',
 				'message' => '%s is highly discouraged, please use vip_safe_wp_remote_get() instead.',

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -46,3 +46,6 @@ get_term_by( $field, $value, $taxonomy ); // bad
 get_category_by_slug( $slug ); // bad
 
 url_to_postid( $url ); // bad
+
+attachment_url_to_postid( $url ); // bad
+wpcom_vip_attachment_url_to_postid( $url ); // ok

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -36,6 +36,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
             44 => 1,
             46 => 1,
             48 => 1,
+            50 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Now included among the uncached functions: https://vip.wordpress.com/documentation/caching/uncached-functions/