### PR TITLE
Fix for incorrect Yoda sniff message when comparing two variables.

### DIFF
--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -87,6 +87,10 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 )
 		$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true );
 
+		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$castTokens ) ) {
+			$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $next_non_empty + 1, null, true );
+		}
+
 		if ( in_array( $tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ) ) ) {
 			$next_non_empty = $phpcsFile->findNext(
 				array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -82,3 +82,5 @@ if ( $on !== self::$network_mode ) { // OK
 return 0 === strpos( $foo, 'a' ); // OK
 return 0 == $foo; // OK
 return $foo == 0; // Bad
+
+if ( (int) $a['interval'] === (int) $b['interval'] ) {} // OK


### PR DESCRIPTION
Type casts were not taken into account.