### PR TITLE
Require yoda conditions for object properties

### DIFF
--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -75,7 +75,7 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $tokens[ $i ]['code'], array( T_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
 				return;
 			}
 		}

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -68,14 +68,14 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 				continue;
 			}
 
-			// If this is a variable, we've seen all we need to see.
-			if ( T_VARIABLE === $tokens[ $i ]['code'] ) {
+			// If this is a variable or array, we've seen all we need to see.
+			if ( T_VARIABLE === $tokens[ $i ]['code'] || T_CLOSE_SQUARE_BRACKET === $tokens[ $i ]['code'] ) {
 				$needs_yoda = true;
 				break;
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $tokens[ $i ]['code'], array( T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
 				return;
 			}
 		}

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -84,3 +84,7 @@ return 0 == $foo; // OK
 return $foo == 0; // Bad
 
 if ( (int) $a['interval'] === (int) $b['interval'] ) {} // OK
+
+if ( $GLOBALS['wpdb']->num_rows === 0 ) {} // Bad
+
+if ( $true == strtolower( $check ) ) {} // Bad

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -88,3 +88,5 @@ if ( (int) $a['interval'] === (int) $b['interval'] ) {} // OK
 if ( $GLOBALS['wpdb']->num_rows === 0 ) {} // Bad
 
 if ( $true == strtolower( $check ) ) {} // Bad
+
+$update = 'yes' === strtolower( $this->from_post( 'update' ) ); // OK

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -50,6 +50,8 @@ class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest
             62 => 1,
             68 => 1,
             84 => 1,
+            88 => 1,
+            90 => 1,
         );
 
     }//end getErrorList()


### PR DESCRIPTION
(I added the unrelated function assignment check because there wasn’t
one in the tests yet and I wanted to make sure that we didn’t change
behavior on that.)

Fixes #497