### PR TITLE
Introduce WordPress.NamingConventions.ValidVariableName

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -85,6 +85,7 @@
 	</rule>
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 	<rule ref="WordPress.Classes.ValidClassName"/>
+	<rule ref="WordPress.NamingConventions.ValidVariableName"/>
 	<rule ref="WordPress.Files.FileName"/>
 	<rule ref="WordPress.NamingConventions.ValidFunctionName"/>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * WordPress_Sniffs_NamingConventions_ValidVariableNameSniff.
+ *
+ * Based on Squiz_Sniffs_NamingConventions_ValidVariableNameSniff:
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/ed257ca0e56ad86cd2a4d6fa38ce0b95141c824f/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Weston Ruter
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if ( class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) === false ) {
+	throw new PHP_CodeSniffer_Exception( 'Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found' );
+}
+
+/**
+ * WordPress_Sniffs_NamingConventions_ValidVariableNameSniff.
+ *
+ * Checks the naming of variables and member variables.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Weston Ruter
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff {
+
+	/**
+	 * PHP Reserved Vars.
+	 *
+	 * @var array
+	 */
+	public $php_reserved_vars = array(
+		'_SERVER',
+		'_GET',
+		'_POST',
+		'_REQUEST',
+		'_SESSION',
+		'_ENV',
+		'_COOKIE',
+		'_FILES',
+		'GLOBALS',
+		'http_response_header',
+		'HTTP_RAW_POST_DATA',
+		'php_errormsg',
+	);
+
+	/**
+	 * List of member variables that can have mixed case.
+	 *
+	 * @var array
+	 */
+	public $whitelisted_mixed_case_member_var_names = array(
+		'ID',
+		'comment_ID',
+		'comment_post_ID',
+		'post_ID',
+		'comment_author_IP',
+	);
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 * @param int                  $stack_ptr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function processVariable( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+		$tokens  = $phpcs_file->getTokens();
+		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
+
+		// If it's a php reserved var, then its ok.
+		if ( in_array( $var_name, $this->php_reserved_vars ) === true ) {
+			return;
+		}
+
+		$obj_operator = $phpcs_file->findNext( array( T_WHITESPACE ), ( $stack_ptr + 1 ), null, true );
+		if ( T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+			// Check to see if we are using a variable from an object.
+			$var = $phpcs_file->findNext( array( T_WHITESPACE ), ($obj_operator + 1), null, true );
+			if ( T_STRING === $tokens[ $var ]['code'] ) {
+				$bracket = $phpcs_file->findNext( array( T_WHITESPACE ), ($var + 1), null, true );
+				if ( T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] ) {
+					$obj_var_name = $tokens[ $var ]['content'];
+
+					// There is no way for us to know if the var is public or
+					// private, so we have to ignore a leading underscore if there is
+					// one and just check the main part of the variable name.
+					$original_var_name = $obj_var_name;
+					if ( substr( $obj_var_name, 0, 1 ) === '_' ) {
+						$obj_var_name = substr( $obj_var_name, 1 );
+					}
+
+					if ( ! in_array( $obj_var_name, $this->whitelisted_mixed_case_member_var_names, true ) && static::isSnakeCase( $obj_var_name ) === false ) {
+						$error = 'Variable "%s" is not in valid camel caps format';
+						$data  = array( $original_var_name );
+						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
+					}
+				}//end if
+			}//end if
+		}//end if
+
+		// There is no way for us to know if the var is public or private,
+		// so we have to ignore a leading underscore if there is one and just
+		// check the main part of the variable name.
+		$original_var_name = $var_name;
+		if ( substr( $var_name, 0, 1 ) === '_' ) {
+			$obj_operator = $phpcs_file->findPrevious( array( T_WHITESPACE ), ( $stack_ptr - 1 ), null, true );
+			if ( T_DOUBLE_COLON === $tokens[ $obj_operator ]['code'] ) {
+				// The variable lives within a class, and is referenced like
+				// this: MyClass::$_variable, so we don't know its scope.
+				$in_class = true;
+			} else {
+				$in_class = $phpcs_file->hasCondition( $stack_ptr, array( T_CLASS, T_INTERFACE, T_TRAIT ) );
+			}
+
+			if ( true === $in_class ) {
+				$var_name = substr( $var_name, 1 );
+			}
+		}
+
+		if ( static::isSnakeCase( $var_name ) === false ) {
+			$error = 'Variable "%s" is not in valid snake_case format';
+			$data  = array( $original_var_name );
+			$phpcs_file->addError( $error, $stack_ptr, 'NotSnakeCase', $data );
+		}
+
+	}
+
+	/**
+	 * Processes class member variables.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 * @param int                  $stack_ptr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function processMemberVar( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+
+		$var_name     = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
+		$member_props = $phpcs_file->getMemberProperties( $stack_ptr );
+		if ( empty( $member_props ) === true ) {
+			// Couldn't get any info about this variable, which
+			// generally means it is invalid or possibly has a parse
+			// error. Any errors will be reported by the core, so
+			// we can ignore it.
+			return;
+		}
+
+		$public    = ( 'private' !== $member_props['scope'] );
+		$error_data = array( $var_name );
+
+		if ( $public ) {
+			if ( substr( $var_name, 0, 1 ) === '_' ) {
+				$error = '%s member variable "%s" must not contain a leading underscore';
+				$data  = array(
+					ucfirst( $member_props['scope'] ),
+					$error_data[0],
+				);
+				$phpcs_file->addError( $error, $stack_ptr, 'PublicHasUnderscore', $data );
+				return;
+			}
+		} else {
+			if ( substr( $var_name, 0, 1 ) !== '_' ) {
+				$error = 'Private member variable "%s" must contain a leading underscore';
+				$phpcs_file->addError( $error, $stack_ptr, 'PrivateNoUnderscore', $error_data );
+				return;
+			}
+		}
+
+		if ( ! in_array( $var_name, $this->whitelisted_mixed_case_member_var_names, true ) && static::isSnakeCase( $var_name ) === false ) {
+			$error = 'Member variable "%s" is not in valid snake_case format.';
+			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
+		}
+
+	}
+
+
+	/**
+	 * Processes the variable found within a double quoted string.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 * @param int                  $stack_ptr  The position of the double quoted
+	 *                                        string.
+	 *
+	 * @return void
+	 */
+	protected function processVariableInString( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+		$tokens = $phpcs_file->getTokens();
+
+		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) !== 0 ) {
+			foreach ( $matches[1] as $var_name ) {
+				// If it's a php reserved var, then its ok.
+				if ( in_array( $var_name, $this->php_reserved_vars ) === true ) {
+					continue;
+				}
+
+				if ( static::isSnakeCase( $var_name ) === false ) {
+					$error = 'Variable "%s" is not in snake_case format';
+					$data  = array( $var_name );
+					$phpcs_file->addError( $error, $stack_ptr, 'StringNotSnakeCase', $data );
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Return whether the variable is in snake_case.
+	 *
+	 * @param string $var_name
+	 * @return bool
+	 */
+	static function isSnakeCase( $var_name ) {
+		return (bool) preg_match( '/^[a-z0-9_]+$/', $var_name );
+	}
+}//end class

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -104,7 +104,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 						$obj_var_name = substr( $obj_var_name, 1 );
 					}
 
-					if ( ! in_array( $obj_var_name, $this->whitelisted_mixed_case_member_var_names, true ) && static::isSnakeCase( $obj_var_name ) === false ) {
+					if ( ! in_array( $obj_var_name, $this->whitelisted_mixed_case_member_var_names, true ) && self::isSnakeCase( $obj_var_name ) === false ) {
 						$error = 'Variable "%s" is not in valid camel caps format';
 						$data  = array( $original_var_name );
 						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
@@ -132,7 +132,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			}
 		}
 
-		if ( static::isSnakeCase( $var_name ) === false ) {
+		if ( self::isSnakeCase( $var_name ) === false ) {
 			$error = 'Variable "%s" is not in valid snake_case format';
 			$data  = array( $original_var_name );
 			$phpcs_file->addError( $error, $stack_ptr, 'NotSnakeCase', $data );
@@ -184,7 +184,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			}
 		}
 
-		if ( ! in_array( $var_name, $this->whitelisted_mixed_case_member_var_names, true ) && static::isSnakeCase( $var_name ) === false ) {
+		if ( ! in_array( $var_name, $this->whitelisted_mixed_case_member_var_names, true ) && self::isSnakeCase( $var_name ) === false ) {
 			$error = 'Member variable "%s" is not in valid snake_case format.';
 			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
 		}
@@ -211,7 +211,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 					continue;
 				}
 
-				if ( static::isSnakeCase( $var_name ) === false ) {
+				if ( self::isSnakeCase( $var_name ) === false ) {
 					$error = 'Variable "%s" is not in snake_case format';
 					$data  = array( $var_name );
 					$phpcs_file->addError( $error, $stack_ptr, 'StringNotSnakeCase', $data );

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -1,0 +1,91 @@
+<?php
+$varName  = 'hello';
+$var_name = 'hello';
+$varname  = 'hello';
+$_varName = 'hello';
+
+class MyClass {
+	$varName  = 'hello';
+	$var_name = 'hello';
+	$varname  = 'hello';
+	$_varName = 'hello';
+
+	public $varName  = 'hello';
+	public $var_name = 'hello';
+	public $varname  = 'hello';
+	public $_varName = 'hello';
+
+	protected $varName  = 'hello';
+	protected $var_name = 'hello';
+	protected $varname  = 'hello';
+	protected $_varName = 'hello';
+
+	private $_varName  = 'hello';
+	private $_var_name = 'hello';
+	private $_varname  = 'hello';
+	private $varName   = 'hello';
+}
+
+echo $varName;
+echo $var_name;
+echo $varname;
+echo $_varName;
+
+echo "Hello $varName";
+echo "Hello $var_name";
+echo "Hello ${var_name}";
+echo "Hello $varname";
+echo "Hello $_varName";
+
+echo 'Hello '.$varName;
+echo 'Hello '.$var_name;
+echo 'Hello '.$varname;
+echo 'Hello '.$_varName;
+
+echo $_SERVER['var_name'];
+echo $_REQUEST['var_name'];
+echo $_GET['var_name'];
+echo $_POST['var_name'];
+echo $GLOBALS['var_name'];
+
+echo MyClass::$varName;
+echo MyClass::$var_name;
+echo MyClass::$varname;
+echo MyClass::$_varName;
+
+echo $this->varName2;
+echo $this->var_name2;
+echo $this->varname2;
+echo $this->_varName2;
+echo $object->varName2;
+echo $object->var_name2;
+echo $object_name->varname2;
+echo $object_name->_varName2;
+
+echo $this->myFunction($one, $two);
+echo $object->myFunction($one_two);
+
+$error = "format is \$GLOBALS['$varName']";
+
+echo $_SESSION['var_name'];
+echo $_FILES['var_name'];
+echo $_ENV['var_name'];
+echo $_COOKIE['var_name'];
+
+$XML       = 'hello';
+$myXML     = 'hello';
+$XMLParser = 'hello';
+$xmlParser = 'hello';
+
+$ID = 1;
+$post = get_post( $x );
+echo $post->ID;
+
+echo $comment_ID;
+echo $comment_post_ID;
+echo $comment_author_IP;
+
+$comment = get_comment( 1 );
+echo $comment->comment_ID;
+echo $comment->comment_post_ID;
+echo $comment->comment_author_IP;

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -1,46 +1,46 @@
 <?php
 $varName  = 'hello';
-$var_name = 'hello';
+$var_name = 'hello'; // Bad
 $varname  = 'hello';
-$_varName = 'hello';
+$_varName = 'hello'; // Bad
 
 class MyClass {
-	$varName  = 'hello';
+	$varName  = 'hello'; // Bad
 	$var_name = 'hello';
 	$varname  = 'hello';
-	$_varName = 'hello';
+	$_varName = 'hello'; // Bad
 
-	public $varName  = 'hello';
+	public $varName  = 'hello'; // Bad
 	public $var_name = 'hello';
 	public $varname  = 'hello';
-	public $_varName = 'hello';
+	public $_varName = 'hello'; // Bad
 
-	protected $varName  = 'hello';
+	protected $varName  = 'hello'; // Bad
 	protected $var_name = 'hello';
 	protected $varname  = 'hello';
-	protected $_varName = 'hello';
+	protected $_varName = 'hello'; // Bad
 
-	private $_varName  = 'hello';
+	private $_varName  = 'hello'; // Bad
 	private $_var_name = 'hello';
 	private $_varname  = 'hello';
-	private $varName   = 'hello';
+	private $varName   = 'hello'; // Bad
 }
 
-echo $varName;
+echo $varName; // Bad
 echo $var_name;
 echo $varname;
-echo $_varName;
+echo $_varName; // Bad
 
-echo "Hello $varName";
+echo "Hello $varName"; // Bad
 echo "Hello $var_name";
 echo "Hello ${var_name}";
 echo "Hello $varname";
-echo "Hello $_varName";
+echo "Hello $_varName"; // Bad
 
-echo 'Hello '.$varName;
+echo 'Hello '.$varName; // Bad
 echo 'Hello '.$var_name;
 echo 'Hello '.$varname;
-echo 'Hello '.$_varName;
+echo 'Hello '.$_varName; // Bad
 
 echo $_SERVER['var_name'];
 echo $_REQUEST['var_name'];
@@ -48,42 +48,42 @@ echo $_GET['var_name'];
 echo $_POST['var_name'];
 echo $GLOBALS['var_name'];
 
-echo MyClass::$varName;
+echo MyClass::$varName; // Bad
 echo MyClass::$var_name;
 echo MyClass::$varname;
-echo MyClass::$_varName;
+echo MyClass::$_varName; // Bad
 
-echo $this->varName2;
+echo $this->varName2; // Bad
 echo $this->var_name2;
 echo $this->varname2;
-echo $this->_varName2;
-echo $object->varName2;
+echo $this->_varName2; // Bad
+echo $object->varName2; // Bad
 echo $object->var_name2;
 echo $object_name->varname2;
-echo $object_name->_varName2;
+echo $object_name->_varName2; // Bad
 
 echo $this->myFunction($one, $two);
 echo $object->myFunction($one_two);
 
-$error = "format is \$GLOBALS['$varName']";
+$error = "format is \$GLOBALS['$varName']"; // Bad
 
 echo $_SESSION['var_name'];
 echo $_FILES['var_name'];
 echo $_ENV['var_name'];
 echo $_COOKIE['var_name'];
 
-$XML       = 'hello';
-$myXML     = 'hello';
-$XMLParser = 'hello';
-$xmlParser = 'hello';
+$XML       = 'hello'; // Bad
+$myXML     = 'hello'; // Bad
+$XMLParser = 'hello'; // Bad
+$xmlParser = 'hello'; // Bad
 
-$ID = 1;
+$ID = 1; // Bad
 $post = get_post( $x );
 echo $post->ID;
 
-echo $comment_ID;
-echo $comment_post_ID;
-echo $comment_author_IP;
+echo $comment_ID; // Bad
+echo $comment_post_ID; // Bad
+echo $comment_author_IP; // Bad
 
 $comment = get_comment( 1 );
 echo $comment->comment_ID;

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Unit test class for WordPress_Sniffs_NamingConventions_ValidVariableNameSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Weston Ruter
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for WordPress_Sniffs_NamingConventions_ValidVariableNameSniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Weston Ruter
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList() {
+		$errors = array(
+			2   => 1,
+			5   => 1,
+			8   => 1,
+			11   => 1,
+			13   => 1,
+			16   => 1,
+			18   => 1,
+			21   => 1,
+			23   => 1,
+			26   => 1,
+			29   => 1,
+			32   => 1,
+			34   => 1,
+			38   => 1,
+			40   => 1,
+			43   => 1,
+			51   => 1,
+			54   => 1,
+			56   => 1,
+			59   => 1,
+			60   => 1,
+			63   => 1,
+			68   => 1,
+			75   => 1,
+			76   => 1,
+			77   => 1,
+			78   => 1,
+			80   => 1,
+			84   => 1,
+			85   => 1,
+			86   => 1,
+		);
+
+		return $errors;
+
+	}//end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}//end class


### PR DESCRIPTION
Forks `Squiz.NamingConventions.ValidVariableName` for WordPress conventions.

Fixes #489.