### PR TITLE
Fix false positives and false negatives in PreparedSQL sniff

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -308,6 +308,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $formattingFunctions = array(
+		'array_fill' => true,
 		'ent2ncr' => true,
 		'implode' => true,
 		'join' => true,
@@ -341,6 +342,31 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'vprintf' => true,
 		'wp_die' => true,
 		'wp_dropdown_pages' => true,
+	);
+
+	/**
+	 * Functions that escape values for use in SQL queries.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @var array
+	 */
+	public static $SQLEscapingFunctions = array(
+		'absint' => true,
+		'esc_sql' => true,
+		'intval' => true,
+		'like_escape' => true,
+	);
+
+	/**
+	 * Functions whose output is automatically escaped for use in SQL queries.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @var array
+	 */
+	public static $SQLAutoEscapedFunctions = array(
+		'count' => true,
 	);
 
 	/**

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -16,3 +16,6 @@ $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = 'Th
 $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = 'The $_GET[foo] var is evil.' AND ID = %s", array( 123 ) ) ); // Bad
 $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = 'The \\$_GET[foo]// var is evil again.' AND ID = %s", array( 123 ) ) ); // Bad
 $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = 'The \$_GET var can be evil, but $_GET[foo] var is evil.' AND ID = %s", array( 123 ) ) ); // Bad
+
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad
+$wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ) ); // Bad

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -21,3 +21,13 @@ $wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';
 $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ) ); // Bad
 
 $wpdb->query( "SELECT * FROM " . $wpdb->posts . " WHERE post_title LIKE 'foo';" ); // OK
+
+// All OK.
+$all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
+	'SELECT `post_id`, `meta_value` FROM `%s` WHERE `meta_key` = "sort_order" AND `post_id` IN (%s)',
+	$wpdb->postmeta,
+	implode( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+), $post_ids ) );
+
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . esc_sql( $foo ) . "';" ); // OK
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE ID = " . absint( $foo ) . ";" ); // OK

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -19,3 +19,5 @@ $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = 'Th
 
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad
 $wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ) ); // Bad
+
+$wpdb->query( "SELECT * FROM " . $wpdb->posts . " WHERE post_title LIKE 'foo';" ); // OK

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -26,6 +26,8 @@ class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			17 => 1,
 			18 => 1,
+			20 => 1,
+			21 => 1,
 		);
 	}
 


### PR DESCRIPTION
The prepared SQL sniff was incorrectly flagging code that was properly escaping SQL without using the `$wpdb->prepare()` function. I've updated it not to flag this code, but perhaps it should be possible to toggle this feature (in case we want to force `$wpdb->prepare()` to be used)?

The sniff was also incorrectly only looking for variables being incorporated into SQL queries, not constants, function calls, etc. This is now fixed, and anything being incorporated into an SQL query will be flagged.

Fixes #508