### PR TITLE
Add whitelisting comment for tax query

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -6,15 +6,15 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_CodeSniffer_Sniff
+class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_Sniff
 {
 
 	/**
 	 * Exclude groups
 	 *
 	 * Example: 'foo,bar'
-	 * 
-	 * @var string Comma-delimited group list 
+	 *
+	 * @var string Comma-delimited group list
 	 */
 	public $exclude = '';
 
@@ -22,7 +22,7 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_Co
 	 * Groups of variable data to check against.
 	 * Don't use this in extended classes, override getGroups() instead.
 	 * This is only used for Unit tests.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $groups = array();
@@ -132,7 +132,7 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_Co
 
 
 		foreach ( $groups as $groupName => $group ) {
-			
+
 			if ( in_array( $groupName, $exclude ) ) {
 				continue;
 			}
@@ -165,9 +165,9 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_Co
 
 					call_user_func(
 						$addWhat,
-						$message, 
-						$stackPtr, 
-						$groupName, 
+						$message,
+						$stackPtr,
+						$groupName,
 						array( $key, $val )
 						);
 				}
@@ -183,7 +183,7 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff implements PHP_Co
 	/**
 	 * Callback to process each confirmed key, to check value
 	 * This must be extended to add the logic to check assignment value
-	 * 
+	 *
 	 * @param  string   $key   Array index / key
 	 * @param  mixed    $val   Assigned value
 	 * @param  int      $line  Token line

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -39,4 +39,24 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_Arra
 				)
 			);
 	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		$this->init( $phpcsFile );
+
+		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
+			return;
+		}
+
+		parent::process( $phpcsFile, $stackPtr );
+	}
 }//end class

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
@@ -21,3 +21,20 @@ $query = 'foo=bar&meta_key=foo&meta_value=bar';
 if ( ! isset( $widget['params'][0] ) ) {
 	$widget['params'][0] = array();
 }
+
+
+// Testing whitelisting comments.
+$test = array(
+
+	// Single-line statements.
+	'tax_query' => array(), // Bad.
+	'tax_query' => array(), // WPCS: tax_query ok.
+
+	// Multi-line statement.
+	'tax_query' => array( // WPCS: tax_query ok.
+		array(
+			'taxonomy' => 'foo',
+			),
+		),
+	),
+);

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -42,6 +42,7 @@ class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest
             15 => 1,
             16 => 1,
             19 => 2,
+            30 => 1,
             );
 
     }//end getWarningList()


### PR DESCRIPTION
Fixes #479.

Also removes a bunch of extra whitespace that got stripped out by Atom when I saved the file.