### PR TITLE
Add sniff and tests for concatenation operator spacing

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -55,6 +55,12 @@
 
 	<!-- https://make.wordpress.org/core/handbook/coding-standards/php/#space-usage -->
 	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1"/>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
 
 	<!-- https://make.wordpress.org/core/handbook/coding-standards/php/#brace-style -->
 	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>


### PR DESCRIPTION
This change adds the ConcatenationSpacingSniff, which checks that the concatenation operator is correctly surrounded by spaces. Tests are also included.

The relevant WordPress coding standard [reads](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage): "Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators."

Both the sniff and test classes are simply extensions of the `Squiz.Strings.ConcatenationSpacing` code (which kindly already supported the functionality we require here).

Refs #535.