### PR TITLE
This adds support for standards installation through Composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
 	"name"       : "wp-coding-standards/wpcs",
 	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
 	"type"       : "phpcs-standard",
-	"version": "9.0",
 	"keywords"   : ["phpcs", "standards", "WordPress"],
 	"license"    : "MIT",
 	"authors"    : [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
 	},
 	"extra"      : {
-		"standards": {
+		"phpcs-standards": {
 			"WordPress"      : "WordPress",
 			"WordPress-Core" : "WordPress-Core",
 			"WordPress-Docs" : "WordPress-Docs",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
 	"name"       : "wp-coding-standards/wpcs",
 	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+	"type"       : "phpcs-standard",
+	"version": "9.0",
 	"keywords"   : ["phpcs", "standards", "WordPress"],
 	"license"    : "MIT",
 	"authors"    : [
@@ -20,5 +22,14 @@
 	"scripts"    : {
 		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..",
 		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+	},
+	"extra"      : {
+		"standards": {
+			"WordPress"      : "WordPress",
+			"WordPress-Core" : "WordPress-Core",
+			"WordPress-Docs" : "WordPress-Docs",
+			"WordPress-Extra": "WordPress-Extra",
+			"WordPress-VIP"  : "WordPress-VIP"
+		}
 	}
 }


### PR DESCRIPTION
This depends on the following pull request for the `squizlabs/php_codesniffer` package, and should only be merged once that pull request has been merged as well:
https://github.com/squizlabs/PHP_CodeSniffer/pull/936
