### PR TITLE
Validate $domain arg in WordPress.WP.I18n

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -101,5 +101,6 @@
 	<rule ref="WordPress.WhiteSpace.OperatorSpacing"/>
 	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
 	<rule ref="WordPress.PHP.YodaConditions"/>
+	<rule ref="WordPress.WP.I18n"/>
 
 </ruleset>

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -1,46 +1,46 @@
 <?php
 
-__( "hell$varo", 'domain' ); // Bad, shouldn't use a string with variables
+__( "hell$varo", 'my-slug' ); // Bad, shouldn't use a string with variables
 
-__( "hell\$varo", 'domain' ); // OK, Variable is not interpolated.
-__( "hell\\$varo", 'domain' ); // Bad, is interpolated.
-__( "hell\\\$varo", 'domain' ); // OK, variable is escaped.
+__( "hell\$varo", 'my-slug' ); // OK, Variable is not interpolated.
+__( "hell\\$varo", 'my-slug' ); // Bad, is interpolated.
+__( "hell\\\$varo", 'my-slug' ); // OK, variable is escaped.
 
-__( $var, 'domain' ); // Bad, shouldn't use variables
+__( $var, 'my-slug' ); // Bad, shouldn't use variables
 
 __( 'string', SOMETHING ); // Bad, shouldn't use CONSTANTS
 
-__( 'string' . $var, 'domain' ); // Bad, shouldn't use variable for string
+__( 'string' . $var, 'my-slug' ); // Bad, shouldn't use variable for string
 
-__( $var . 'string', 'domain' ); // Bad, shouldn't use variable for string
+__( $var . 'string', 'my-slug' ); // Bad, shouldn't use variable for string
 
-__( SOMETHING, 'domain' ); // Bad, shouldn't use constant for string
+__( SOMETHING, 'my-slug' ); // Bad, shouldn't use constant for string
 
-__( 'string' . SOMETHING, 'domain' ); // Bad, shouldn't use constant for string
+__( 'string' . SOMETHING, 'my-slug' ); // Bad, shouldn't use constant for string
 
-__( SOMETHING . 'string', 'domain' ); // Bad, shouldn't use variable for string
+__( SOMETHING . 'string', 'my-slug' ); // Bad, shouldn't use variable for string
 
 __( 'string', $domain ); // Bad, shouldn't use variable for domain
 
 __( 'string', 'my' . $domain ); // Bad, shouldn't use variable for domain
 
-__( 'string', $domain . 'domain' ); // Bad, shouldn't use variable for domain
+__( 'string', $domain . 'my-slug' ); // Bad, shouldn't use variable for domain
 
-__( 'string', 'domain' ); // Good
+__( 'string', 'my-slug' ); // Good
 
-_x( 'string', 'context', 'domain' ); // Good
+_x( 'string', 'context', 'my-slug' ); // Good
 
-_x( 'string', $var, 'domain' ); // Bad, shouldn't use variable for context
+_x( 'string', $var, 'my-slug' ); // Bad, shouldn't use variable for context
 
-_x( 'string', 'context' . $var, 'domain' ); // Bad, shouldn't use variable for context
+_x( 'string', 'context' . $var, 'my-slug' ); // Bad, shouldn't use variable for context
 
-_x( 'string', $var . 'context', 'domain' ); // Bad, shouldn't use variable for context
+_x( 'string', $var . 'context', 'my-slug' ); // Bad, shouldn't use variable for context
 
-_x( 'string', SOMETHING, 'domain' ); // Bad, shouldn't use constant for context
+_x( 'string', SOMETHING, 'my-slug' ); // Bad, shouldn't use constant for context
 
-_x( 'string', SOMETHING . 'context', 'domain' ); // Bad, shouldn't use constant for context
+_x( 'string', SOMETHING . 'context', 'my-slug' ); // Bad, shouldn't use constant for context
 
-_x( 'string', 'context' . SOMETHING, 'domain' ); // Bad, shouldn't use constant for context
+_x( 'string', 'context' . SOMETHING, 'my-slug' ); // Bad, shouldn't use constant for context
 
 _n( 'I have %d cat.', 'I have %d cats.', $number ); // Bad, no text domain.
 _n( 'I have %d cat.', 'I have %d cats.', $number, 'my-slug' ); // OK.
@@ -66,13 +66,13 @@ _nx_noop( 'I have %d cat.', 'I have %d cats.', $context, 'my-slug' ); // Bad.
 _nx_noop( 'I have %d cat.', 'I have %d cats.', 'Not really.', "illegal $string" ); // Bad.
 _nx_noop( 'I have %d cat.', 'I have %d cats.', 'Not really.', SOMETHING ); // Bad.
 
-translate( 'foo', 'bar' ); // Bad, low-level API function.
-translate_with_gettext_context( 'foo', 'bar', 'baz' ); // Bad, low-level API function.
+translate( 'foo', 'my-slug' ); // Bad, low-level API function.
+translate_with_gettext_context( 'foo', 'bar', 'my-slug' ); // Bad, low-level API function.
 
-_( 'foo', 'bar' ); // Bad.
+_( 'foo', 'my-slug' ); // Bad.
 
-__( 'foo', 'bar', 'too-many-args' ); // Bad.
-_x( 'string', 'context', 'domain', 'too-many-args' ); // Bad
+__( 'foo', 'my-slug', 'too-many-args' ); // Bad.
+_x( 'string', 'context', 'my-slug', 'too-many-args' ); // Bad
 _n( 'I have %d cat.', 'I have %d cats.', $number, 'my-slug', 'too-many-args' ); // Bad
 _n_noop( 'I have %d cat.', 'I have %d cats.', 'my-slug', 'too-many-args' ); // Bad.
 _nx_noop( 'I have %d cat.', 'I have %d cats.', 'Not really.', 'my-slug', 'too-many-args' ); // Bad.
@@ -81,11 +81,10 @@ _nx_noop( 'I have %d cat.', 'I have %d cats.', 'Not really.', 'my-slug', 'too-ma
 _nx( 'I have
 %d cat.', 'I have
 %d cats.', $number, 'Not
-really.', 'my-
-slug' ); // OK.
+really.', 'my-slug' ); // OK.
 
 // Ensure lack of spaces doesn't cause i18n error.
 _n_noop('I have %d cat.', 'I have %d cats.', 'my-slug'); // OK.
 
 // Dollar sign in literal string is not interpolated, so OK.
-_n_noop( 'I have %d cat.', 'I have %d cats.', 'literal-string-so-$variable-not-interpolated' ); // OK.
+_n_noop( 'I have %d cat.', 'I have %d cats literal-string-so-$variable-not-interpolated.', 'my-slug' ); // OK.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -10,6 +10,12 @@
  */
 class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 
+	protected function setUp() {
+		// @todo Should be possible via self::$phpcs->setSniffProperty( 'WordPress_Sniffs_WP_I18nSniff', 'text_domain', 'my-slug' );
+		WordPress_Sniffs_WP_I18nSniff::$text_domain_override = 'my-slug';
+		parent::setUp();
+	}
+
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -23,27 +29,44 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			3 => 1,
 			6 => 1,
 			9 => 1,
+			11 => 1,
 			13 => 1,
 			15 => 1,
 			17 => 1,
 			19 => 1,
 			21 => 1,
+			23 => 1,
+			25 => 1,
+			27 => 1,
 			33 => 1,
 			35 => 1,
 			37 => 1,
 			39 => 1,
 			41 => 1,
 			43 => 1,
-			56 => 1,
+			45 => 1,
+			47 => 1,
+			48 => 1,
+			50 => 1,
+			52 => 1,
+			53 => 1,
+			55 => 1,
+			56 => 2,
 			58 => 1,
-			63 => 1,
+			59 => 1,
+			60 => 1,
+			62 => 1,
+			63 => 2,
 			65 => 1,
+			66 => 1,
+			67 => 1,
 			72 => 1,
 			74 => 1,
 			75 => 1,
 			76 => 1,
 			77 => 1,
 			78 => 1,
+
 		);
 	}
 
@@ -57,24 +80,6 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			11 => 1,
-			23 => 1,
-			25 => 1,
-			27 => 1,
-			45 => 1,
-			47 => 1,
-			48 => 1,
-			50 => 1,
-			52 => 1,
-			53 => 1,
-			55 => 1,
-			56 => 1,
-			59 => 1,
-			60 => 1,
-			62 => 1,
-			63 => 1,
-			66 => 1,
-			67 => 1,
 			69 => 1,
 			70 => 1,
 		);


### PR DESCRIPTION
* Introduce `WordPress_Sniffs_WP_I18nSniff::$text_domain` property.
* Skip reporting issues for missing `$domain` if `WordPress_Sniffs_WP_I18nSniff::$text_domain` is not defined.
* Increase severity of domain issues from warning to error.
* Add `WordPress.WP.I18n` to WordPress-Core.

A project's ruleset can opt-in to doing `$domain` validation via adding this to there PHPCS `ruleset.xml`, here for the Customize Posts plugin:

```xml
...
	<rule ref="WordPress.WP.I18n">
		<properties>
			<property name="text_domain" value="customize-posts" />
		</properties>
	</rule>
...
```

See #50.