### PR TITLE
Allow `translators:` comments.

### DIFF
--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -61,6 +61,8 @@
 
 		<!-- Exclude to allow duplicate hooks to be documented -->
 		<exclude name="Squiz.Commenting.InlineComment.DocBlock"/>
+		<!-- Excluded to allow /* translators: ... */ comments -->
+		<exclude name="Squiz.Commenting.InlineComment.NotCapital"/>
 
 		<!-- Not in Inline Docs standard, and a code smell -->
 		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>


### PR DESCRIPTION
A bugfix upstream now causes `Doc comment short description must start with a capital letter` errors for `/* translators: ... */` comments.

Excluding the offending rule to continue to allow these type of comments.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/855