### PR TITLE
Allow 'posts_per_page' of up to 100 on VIP

### DIFF
--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -61,7 +61,7 @@ class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_Arr
 			in_array( $key, array( 'posts_per_page', 'numberposts' ) )
 			) {
 
-			if ( $val > 50 ) {
+			if ( $val > 100 ) {
 				return 'Detected high pagination limit, `%s` is set to `%s`';
 			}
 		}


### PR DESCRIPTION
The current VIP docs for "no-limit queries" suggest that 100 can be an acceptable value for `posts_per_page`: https://vip.wordpress.com/documentation/code-review-what-we-look-for/#no-limit-queries.