### PR TITLE
Update PHPCS version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "~2.2"
+		"squizlabs/php_codesniffer": "^2.6"
 	},
 	"minimum-stability" : "RC",
+	"prefer-stable": true,
 	"support"    : {
 		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues"
 	},


### PR DESCRIPTION
Should we require the latest minor release of PHPCS?