### PR TITLE
Add more i18n sniffs

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -194,6 +194,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$arg_name = $context['arg_name'];
 		$method = empty( $context['warning'] ) ? 'addError' : 'addWarning';
 		$content = $tokens[0]['content'];
+		$fixable_method = empty( $context['warning'] ) ? 'addFixableError' : 'addFixableWarning';
 
 		if ( 0 === count( $tokens ) ) {
 			$code = 'MissingArg' . ucfirst( $arg_name );
@@ -228,12 +229,20 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 					$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], ( $i + 1 ) . '$', 1, 0 );
 				}
 
-				$phpcs_file->$method(
+				$fix = $phpcs_file->$fixable_method(
 					'Multiple placeholders should be ordered. Expected \'%s\', but got %s.',
 					$stack_ptr,
 					'UnorderedPlaceholders',
 					array( join( ', ', $suggestions ), join( ',', $unordered_matches ) )
 				);
+
+				if ( true === $fix ) {
+					$fixed_str = str_replace( $unordered_matches, $suggestions, $content );
+
+					$phpcs_file->fixer->beginChangeset();
+					$phpcs_file->fixer->replaceToken( $stack_ptr, $fixed_str );
+					$phpcs_file->fixer->endChangeset();
+				}
 			}
 		}
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -48,6 +48,11 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		'_nx_noop'                       => 'noopnumber_context',
 	);
 
+	// These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
+    static $sprintf_placeholder_regex = '/(?:%%|(%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFos]))/';
+	// "Unordered" means there's no position specifier: '%s', not '%2$s'
+	static $unordered_sprintf_placeholder_regex = '/(?:%%|(?:%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX]))/';
+
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -222,11 +227,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		// Check for multiple unordered placeholders.
-		// Regex copied from http://php.net/manual/en/function.sprintf.php#93552
-		$unordered_sprintf_placeholder_regex = '/(?:%%|(?:%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX]))/';
 
 		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ) ) ) {
-			preg_match_all( $unordered_sprintf_placeholder_regex, $content, $unordered_matches );
+			preg_match_all( self::$unordered_sprintf_placeholder_regex, $content, $unordered_matches );
 			$unordered_matches = $unordered_matches[0];
 
 			if ( count( $unordered_matches ) >= 2 ) {
@@ -294,13 +297,10 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$single_content = $single_context['tokens'][0]['content'];
 		$plural_content = $plural_context['tokens'][0]['content'];
 
-		// Regex copied from http://php.net/manual/en/function.sprintf.php#93552
-		$sprintf_placeholder_regex = '/(?:%%|(%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFos]))/';
-
-		preg_match_all( $sprintf_placeholder_regex, $single_content, $single_placeholders );
+		preg_match_all( self::$sprintf_placeholder_regex, $single_content, $single_placeholders );
 		$single_placeholders = $single_placeholders[0];
 
-		preg_match_all( $sprintf_placeholder_regex, $plural_content, $plural_placeholders );
+		preg_match_all( self::$sprintf_placeholder_regex, $plural_content, $plural_placeholders );
 		$plural_placeholders = $plural_placeholders[0];
 
 		// English conflates "singular" with "only one", described in the codex:

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -193,6 +193,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$tokens = $context['tokens'];
 		$arg_name = $context['arg_name'];
 		$method = empty( $context['warning'] ) ? 'addError' : 'addWarning';
+		$content = $tokens[0]['content'];
 
 		if ( 0 === count( $tokens ) ) {
 			$code = 'MissingArg' . ucfirst( $arg_name );
@@ -216,7 +217,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$unordered_sprintf_placeholder_regex = '/(?:%%|(?:%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX]))/';
 
 		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ) ) ) {
-			preg_match_all( $unordered_sprintf_placeholder_regex, $tokens[0]['content'], $unordered_matches );
+			preg_match_all( $unordered_sprintf_placeholder_regex, $content, $unordered_matches );
 			$unordered_matches = $unordered_matches[0];
 
 			if ( count( $unordered_matches ) >= 2 ) {
@@ -237,14 +238,14 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $tokens[0]['content'], '\'""' ) !== $this->text_domain ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $tokens[0]['content'] ) );
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $content, '\'""' ) !== $this->text_domain ) {
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $content ) );
 				return false;
 			}
 			return true;
 		}
 		if ( T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] ) {
-			$interpolated_variables = $this->get_interpolated_variables( $tokens[0]['content'] );
+			$interpolated_variables = $this->get_interpolated_variables( $content );
 			foreach ( $interpolated_variables as $interpolated_variable ) {
 				$code = 'InterpolatedVariable' . ucfirst( $arg_name );
 				$phpcs_file->$method( 'The $%s arg must not contain interpolated variables. Found "$%s".', $stack_ptr, $code, array( $arg_name, $interpolated_variable ) );
@@ -252,15 +253,15 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			if ( ! empty( $interpolated_variables ) ) {
 				return false;
 			}
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $tokens[0]['content'], '\'""' ) !== $this->text_domain ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $tokens[0]['content'] ) );
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $content, '\'""' ) !== $this->text_domain ) {
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $content ) );
 				return false;
 			}
 			return true;
 		}
 
 		$code = 'NonSingularStringLiteral' . ucfirst( $arg_name );
-		$phpcs_file->$method( 'The $%s arg should be single a string literal, not "%s".', $stack_ptr, $code, array( $arg_name, $tokens[0]['content'] ) );
+		$phpcs_file->$method( 'The $%s arg should be single a string literal, not "%s".', $stack_ptr, $code, array( $arg_name, $content ) );
 		return false;
 	}
 }

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -334,5 +334,15 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				$phpcs_file->fixer->endChangeset();
 			}
 		}
+
+		// NoEmptyStrings
+
+		// Strip placeholders and surrounding quotes.
+		$non_placeholder_content = trim( $content, "'" );
+		$non_placeholder_content = preg_replace( self::$sprintf_placeholder_regex, '', $non_placeholder_content );
+
+		if ( empty( $non_placeholder_content ) ) {
+			$phpcs_file->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
+		}
 	}
 }

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -101,3 +101,8 @@ _n( 'I have a cat.', 'I have %d cats.', $number, 'my-slug' ); // Bad, singular s
 _n_noop( 'I have a cat.', 'I have %d cats.', 'my-slug' ); // Bad, singular should have placeholder.
 _nx( 'I have a cat.', 'I have %d cats.', $number, 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
 _nx_noop( 'I have a cat.', 'I have %d cats.', 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
+
+__( '%s', 'my-slug' ); // Bad, don't waste translator's time
+__( '%1$s%2$s', 'my-slug' ); // Bad, don't waste translator's time
+_n( 'I have %d cat.', '%d', $number, 'my-slug' ); // Bad, move the logic out of the translation
+__( '\'%s\'', 'my-slug' ); // OK (ish. this is a technical test, not a great string)

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -88,3 +88,9 @@ _n_noop('I have %d cat.', 'I have %d cats.', 'my-slug'); // OK.
 
 // Dollar sign in literal string is not interpolated, so OK.
 _n_noop( 'I have %d cat.', 'I have %d cats literal-string-so-$variable-not-interpolated.', 'my-slug' ); // OK.
+
+// Multiple placeholders should have orderable
+__( 'There are %d monkeys in the %s', 'my-slug' ); // Multiple arguments should be numbered
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK
+_n( 'There is %d monkey in the %s', 'There are %d monkeys in the %s', $number, 'my-slug' ); // Multiple arguments should be numbered
+_n( 'There is %1$d monkey in the %2$s', 'In the %2$s are There are %1$d monkeys', $number, 'my-slug' ); // OK

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -89,8 +89,15 @@ _n_noop('I have %d cat.', 'I have %d cats.', 'my-slug'); // OK.
 // Dollar sign in literal string is not interpolated, so OK.
 _n_noop( 'I have %d cat.', 'I have %d cats literal-string-so-$variable-not-interpolated.', 'my-slug' ); // OK.
 
-// Multiple placeholders should have orderable placeholders
-__( 'There are %d monkeys in the %s', 'my-slug' ); // Multiple arguments should be numbered
-__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK
-_n( 'There is %d monkey in the %s', 'There are %d monkeys in the %s', $number, 'my-slug' ); // Multiple arguments should be numbered
-_n( 'There is %1$d monkey in the %2$s', 'In the %2$s are There are %1$d monkeys', $number, 'my-slug' ); // OK
+// Multiple placeholders should have orderable placeholders.
+__( 'There are %d monkeys in the %s', 'my-slug' ); // Multiple arguments should be numbered.
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK.
+_n( 'There is %d monkey in the %s', 'There are %d monkeys in the %s', $number, 'my-slug' ); // Multiple arguments should be numbered.
+_n( 'There is %1$d monkey in the %2$s', 'In the %2$s there are %1$d monkeys', $number, 'my-slug' ); // OK.
+
+// The singular form should use placeholders if the plural does.
+// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals
+_n( 'I have a cat.', 'I have %d cats.', $number, 'my-slug' ); // Bad, singular should have placeholder.
+_n_noop( 'I have a cat.', 'I have %d cats.', 'my-slug' ); // Bad, singular should have placeholder.
+_nx( 'I have a cat.', 'I have %d cats.', $number, 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
+_nx_noop( 'I have a cat.', 'I have %d cats.', 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -101,3 +101,8 @@ _n( 'I have a cat.', 'I have %d cats.', $number, 'my-slug' ); // Bad, singular s
 _n_noop( 'I have a cat.', 'I have %d cats.', 'my-slug' ); // Bad, singular should have placeholder.
 _nx( 'I have a cat.', 'I have %d cats.', $number, 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
 _nx_noop( 'I have a cat.', 'I have %d cats.', 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
+
+__( '%s', 'my-slug' ); // Bad, don't waste translator's time
+__( '%1$s%2$s', 'my-slug' ); // Bad, don't waste translator's time
+_n( 'I have %d cat.', '%d', $number, 'my-slug' ); // Bad, move the logic out of the translation
+__( '\'%s\'', 'my-slug' ); // OK (ish. this is a technical test, not a great string)

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -90,7 +90,7 @@ _n_noop('I have %d cat.', 'I have %d cats.', 'my-slug'); // OK.
 _n_noop( 'I have %d cat.', 'I have %d cats literal-string-so-$variable-not-interpolated.', 'my-slug' ); // OK.
 
 // Multiple placeholders should have orderable placeholders
-__( 'There are %d monkeys in the %s', 'my-slug' ); // Multiple arguments should be numbered
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // Multiple arguments should be numbered
 __( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK
-_n( 'There is %d monkey in the %s', 'There are %d monkeys in the %s', $number, 'my-slug' ); // Multiple arguments should be numbered
+_n( 'There is %1$d monkey in the %2$s', 'There are %1$d monkeys in the %2$s', $number, 'my-slug' ); // Multiple arguments should be numbered
 _n( 'There is %1$d monkey in the %2$s', 'In the %2$s are There are %1$d monkeys', $number, 'my-slug' ); // OK

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -89,8 +89,15 @@ _n_noop('I have %d cat.', 'I have %d cats.', 'my-slug'); // OK.
 // Dollar sign in literal string is not interpolated, so OK.
 _n_noop( 'I have %d cat.', 'I have %d cats literal-string-so-$variable-not-interpolated.', 'my-slug' ); // OK.
 
-// Multiple placeholders should have orderable placeholders
-__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // Multiple arguments should be numbered
-__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK
-_n( 'There is %1$d monkey in the %2$s', 'There are %1$d monkeys in the %2$s', $number, 'my-slug' ); // Multiple arguments should be numbered
-_n( 'There is %1$d monkey in the %2$s', 'In the %2$s are There are %1$d monkeys', $number, 'my-slug' ); // OK
+// Multiple placeholders should have orderable placeholders.
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // Multiple arguments should be numbered.
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // OK.
+_n( 'There is %1$d monkey in the %2$s', 'There are %1$d monkeys in the %2$s', $number, 'my-slug' ); // Multiple arguments should be numbered.
+_n( 'There is %1$d monkey in the %2$s', 'In the %2$s there are %1$d monkeys', $number, 'my-slug' ); // OK.
+
+// The singular form should use placeholders if the plural does.
+// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals
+_n( 'I have a cat.', 'I have %d cats.', $number, 'my-slug' ); // Bad, singular should have placeholder.
+_n_noop( 'I have a cat.', 'I have %d cats.', 'my-slug' ); // Bad, singular should have placeholder.
+_nx( 'I have a cat.', 'I have %d cats.', $number, 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.
+_nx_noop( 'I have a cat.', 'I have %d cats.', 'Not really.', 'my-slug' ); // Bad, singular should have placeholder.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -72,6 +72,9 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			101 => 1,
 			102 => 1,
 			103 => 1,
+			105 => 1,
+			106 => 1,
+			107 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -68,6 +68,10 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			78 => 1,
 			93 => 1,
 			95 => 2,
+			100 => 1,
+			101 => 1,
+			102 => 1,
+			103 => 1,
 		);
 	}
 
@@ -83,6 +87,10 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 		return array(
 			69 => 1,
 			70 => 1,
+			100 => 1,
+			101 => 1,
+			102 => 1,
+			103 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -66,7 +66,8 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			76 => 1,
 			77 => 1,
 			78 => 1,
-
+			93 => 1,
+			95 => 2,
 		);
 	}
 


### PR DESCRIPTION
This PR is to add another test to the I18nSniff.php to ensure that multiple placeholders are orderable.

e.g. from the PHP: sprintf page:
`__( 'The %s contains %d monkeys' );` is a problem because the variables will need to be the other order in some languages, and the string should be:
 `__( 'The %1$s contains %2$d monkeys' );`

The PR includes tests and a fixer.

One thing worth discussing is that the fixer could potentially get it wrong if:
1. It's a pluralised string
2. The order of the placeholders is different between the two strings
3. The placeholders are unordered.

The test file gives an example of the sort of string I'm talking about:
`_n( 'There is %d monkey in the %s', 'In the %s there are %d monkeys', $number, 'my-slug' );`

My assessment here is that this is a bug in the code, and this sniff won't fix it, but it also won't make it any worse than it already was.  I was tempted to not apply the fix in plural cases, but think the good outweighs the bad, so for now the fix does run on plurals.