### PR TITLE
Remove `get_pages()` from uncached functions in …

### DIFF
--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -177,12 +177,11 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 				),
 			),
 
-			'get_pages' => array(
+			'get_children' => array(
 				'type' => 'error',
 				'message' => '%s is highly discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query.',
 				'functions' => array(
 					'get_children',
-					'get_pages',
 				),
 			),
 

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -174,13 +174,6 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 				'functions' => array(
 					'get_posts',
 					'wp_get_recent_posts',
-				),
-			),
-
-			'get_children' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query.',
-				'functions' => array(
 					'get_children',
 				),
 			),

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -58,7 +58,7 @@ attachment_url_to_postid(); // error
 get_posts(); // warning
 wp_get_recent_posts(); // warning
 
-get_children(); // error
+get_children(); // warning
 wp_get_post_terms(); // error
 wp_get_post_categories(); // error
 wp_get_post_tags(); // error

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -57,7 +57,7 @@ url_to_post_id(); // error
 attachment_url_to_postid(); // error
 get_posts(); // warning
 wp_get_recent_posts(); // warning
-get_pages(); // error
+
 get_children(); // error
 wp_get_post_terms(); // error
 wp_get_post_categories(); // error

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -43,7 +43,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
             55 => 1,
             56 => 1,
             57 => 1,
-            61 => 1,
             62 => 1,
             63 => 1,
             64 => 1,
@@ -79,6 +78,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
             19 => 1,
             58 => 1,
             59 => 1,
+            61 => 1,
             72 => 1,
             );
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -43,7 +43,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
             55 => 1,
             56 => 1,
             57 => 1,
-            60 => 1,
             61 => 1,
             62 => 1,
             63 => 1,


### PR DESCRIPTION
…WordPress.VIP.RestrictedFunctions

It is cached and is no longer on the VIP restricted list.

Fixes #569