### PR TITLE
Add two sections to the VIP.RestrictedFunctions sniff.

### DIFF
--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -326,6 +326,33 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 				),
 			),
 
+			'runtime_configuration' => array(
+				'type' => 'error',
+				'message' => '%s is prohibited, changing configuration at runtime is not allowed on VIP Production.',
+				'functions' => array(
+					'dl',
+					'error_reporting',
+					'ini_alter',
+					'ini_restore',
+					'ini_set',
+					'magic_quotes_runtime',
+					'set_magic_quotes_runtime',
+					'apache_setenv',
+					'putenv',
+					'set_include_path',
+					'restore_include_path',
+				),
+			),
+
+			'prevent_path_disclosure' => array(
+				'type' => 'error',
+				'message' => '%s is prohibited as it can lead to full path disclosure.',
+				'functions' => array(
+					'error_reporting',
+					'phpinfo',
+				),
+			),
+
 		);
 	}
 }//end class

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -70,3 +70,16 @@ get_adjacent_post(); // error
 get_previous_post(); // error
 get_next_post(); // error
 parse_url( 'http://example.com/' ); // warning
+
+dl(); // error
+error_reporting(); // error
+ini_alter(); // error
+ini_restore(); // error
+ini_set(); // error
+magic_quotes_runtime(); // error
+set_magic_quotes_runtime(); // error
+apache_setenv(); // error
+putenv(); // error
+set_include_path(); // error
+restore_include_path(); // error
+phpinfo(); // error

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -55,6 +55,18 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
             69 => 1,
             70 => 1,
             71 => 1,
+            74 => 1,
+            75 => 2,
+            76 => 1,
+            77 => 1,
+            78 => 1,
+            79 => 1,
+            80 => 1,
+            81 => 1,
+            82 => 1,
+            83 => 1,
+            84 => 1,
+            85 => 1,
         );
 
     }//end getErrorList()


### PR DESCRIPTION
> Using ini_set() for alternating PHP settings, as well as other functions with ability to change configuration at runtime of your scripts, such as error_reporting(), is prohibited on the WordPress.com VIP platform. Allowed error reporting in production can lead to Full Path Disclosure.

See https://vip.wordpress.com/documentation/code-review-what-we-look-for/#settings-alteration

I've added the most obvious PHP functions which would relate to this. Careful review of the functions listed needed & appreciated.

Fixes #460