### PR TITLE
Run travis against PHP 7.0 as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
 
 env:
   - PHPCS_BRANCH=master


### PR DESCRIPTION
Considering PHP 7 has been out for 7 months... might it be time for this ?