### PR TITLE
Fix codestyle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
 matrix:
   fast_finish: true
   include:
+    # Run PHPCS against WPCS. I just picked to run it against 5.5.
+    - php: 5.5
+      env: PHPCS_BRANCH=master SNIFF=1
     # Run against PHPCS 3.0. I just picked to run it against 5.6.
     - php: 5.6
       env: PHPCS_BRANCH=3.0
@@ -41,3 +44,13 @@ before_script:
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     - phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php
+    # WordPress Coding Standards.
+    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link http://pear.php.net/package/PHP_CodeSniffer/
+    # -p flag: Show progress of the run.
+    # -s flag: Show sniff codes in all reports.
+    # -v flag: Print verbose output.
+    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
+    # --standard: Use WordPress as the standard.
+    # --extensions: Only sniff PHP files.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./bin/phpcs.xml --extensions=php; fi

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1126,5 +1126,6 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 		}
 		return $variables;
-	}
+	} // end get_interpolated_variables()
+
 }

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
  *
@@ -29,9 +28,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $nonceVerificationFunctions = array(
-		'wp_verify_nonce' => true,
+		'wp_verify_nonce'     => true,
 		'check_admin_referer' => true,
-		'check_ajax_referer' => true,
+		'check_ajax_referer'  => true,
 	);
 
 	/**
@@ -42,37 +41,37 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $escapingFunctions = array(
-		'absint' => true,
-		'esc_attr__' => true,
-		'esc_attr_e' => true,
-		'esc_attr_x' => true,
-		'esc_attr' => true,
-		'esc_html__' => true,
-		'esc_html_e' => true,
-		'esc_html_x' => true,
-		'esc_html' => true,
-		'esc_js' => true,
-		'esc_sql' => true,
-		'esc_textarea' => true,
-		'esc_url_raw' => true,
-		'esc_url' => true,
-		'filter_input' => true,
-		'filter_var' => true,
-		'intval' => true,
-		'json_encode' => true,
-		'like_escape' => true,
-		'number_format' => true,
-		'rawurlencode' => true,
-		'sanitize_html_class' => true,
-		'sanitize_user_field' => true,
-		'tag_escape' => true,
-		'urlencode_deep' => true,
-		'urlencode' => true,
-		'wp_json_encode' => true,
+		'absint'               => true,
+		'esc_attr__'           => true,
+		'esc_attr_e'           => true,
+		'esc_attr_x'           => true,
+		'esc_attr'             => true,
+		'esc_html__'           => true,
+		'esc_html_e'           => true,
+		'esc_html_x'           => true,
+		'esc_html'             => true,
+		'esc_js'               => true,
+		'esc_sql'              => true,
+		'esc_textarea'         => true,
+		'esc_url_raw'          => true,
+		'esc_url'              => true,
+		'filter_input'         => true,
+		'filter_var'           => true,
+		'intval'               => true,
+		'json_encode'          => true,
+		'like_escape'          => true,
+		'number_format'        => true,
+		'rawurlencode'         => true,
+		'sanitize_html_class'  => true,
+		'sanitize_user_field'  => true,
+		'tag_escape'           => true,
+		'urlencode_deep'       => true,
+		'urlencode'            => true,
+		'wp_json_encode'       => true,
 		'wp_kses_allowed_html' => true,
-		'wp_kses_data' => true,
-		'wp_kses_post' => true,
-		'wp_kses' => true,
+		'wp_kses_data'         => true,
+		'wp_kses_post'         => true,
+		'wp_kses'              => true,
 	);
 
 	/**
@@ -83,150 +82,150 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $autoEscapedFunctions = array(
-		'allowed_tags' => true,
-		'bloginfo' => true,
-		'body_class' => true,
-		'calendar_week_mod' => true,
+		'allowed_tags'              => true,
+		'bloginfo'                  => true,
+		'body_class'                => true,
+		'calendar_week_mod'         => true,
 		'cancel_comment_reply_link' => true,
-		'category_description' => true,
-		'checked' => true,
+		'category_description'      => true,
+		'checked'                   => true,
 		'comment_author_email_link' => true,
-		'comment_author_email' => true,
-		'comment_author_IP' => true,
-		'comment_author_link' => true,
-		'comment_author_rss' => true,
-		'comment_author_url_link' => true,
-		'comment_author_url' => true,
-		'comment_author' => true,
-		'comment_class' => true,
-		'comment_date' => true,
-		'comment_excerpt' => true,
-		'comment_form_title' => true,
-		'comment_form' => true,
-		'comment_id_fields' => true,
-		'comment_ID' => true,
-		'comment_reply_link' => true,
-		'comment_text_rss' => true,
-		'comment_text' => true,
-		'comment_time' => true,
-		'comment_type' => true,
-		'comments_link' => true,
-		'comments_number' => true,
-		'comments_popup_link' => true,
-		'comments_popup_script' => true,
-		'comments_rss_link' => true,
-		'count' => true,
+		'comment_author_email'      => true,
+		'comment_author_IP'         => true,
+		'comment_author_link'       => true,
+		'comment_author_rss'        => true,
+		'comment_author_url_link'   => true,
+		'comment_author_url'        => true,
+		'comment_author'            => true,
+		'comment_class'             => true,
+		'comment_date'              => true,
+		'comment_excerpt'           => true,
+		'comment_form_title'        => true,
+		'comment_form'              => true,
+		'comment_id_fields'         => true,
+		'comment_ID'                => true,
+		'comment_reply_link'        => true,
+		'comment_text_rss'          => true,
+		'comment_text'              => true,
+		'comment_time'              => true,
+		'comment_type'              => true,
+		'comments_link'             => true,
+		'comments_number'           => true,
+		'comments_popup_link'       => true,
+		'comments_popup_script'     => true,
+		'comments_rss_link'         => true,
+		'count'                     => true,
 		'delete_get_calendar_cache' => true,
-		'disabled' => true,
-		'do_shortcode' => true,
-		'do_shortcode_tag' => true,
-		'edit_bookmark_link' => true,
-		'edit_comment_link' => true,
-		'edit_post_link' => true,
-		'edit_tag_link' => true,
-		'get_archives_link' => true,
-		'get_attachment_link' => true,
-		'get_avatar' => true,
-		'get_bookmark_field' => true,
-		'get_bookmark' => true,
-		'get_calendar' => true,
-		'get_comment_author_link' => true,
-		'get_comment_date' => true,
-		'get_comment_time' => true,
-		'get_current_blog_id' => true,
-		'get_delete_post_link' => true,
-		'get_footer' => true,
-		'get_header' => true,
-		'get_search_form' => true,
-		'get_search_query' => true,
-		'get_sidebar' => true,
-		'get_template_part' => true,
-		'get_the_author_link' => true,
-		'get_the_author' => true,
-		'get_the_date' => true,
-		'get_the_post_thumbnail' => true,
-		'get_the_term_list' => true,
-		'get_the_title' => true,
-		'has_post_thumbnail' => true,
-		'is_attachment' => true,
-		'next_comments_link' => true,
-		'next_image_link' => true,
-		'next_post_link' => true,
-		'next_posts_link' => true,
-		'paginate_comments_links' => true,
-		'permalink_anchor' => true,
-		'post_class' => true,
-		'post_password_required' => true,
-		'post_type_archive_title' => true,
-		'posts_nav_link' => true,
-		'previous_comments_link' => true,
-		'previous_image_link' => true,
-		'previous_post_link' => true,
-		'previous_posts_link' => true,
-		'selected' => true,
-		'single_cat_title' => true,
-		'single_month_title' => true,
-		'single_post_title' => true,
-		'single_tag_title' => true,
-		'single_term_title' => true,
-		'sticky_class' => true,
-		'tag_description' => true,
-		'term_description' => true,
-		'the_attachment_link' => true,
-		'the_author_link' => true,
-		'the_author_meta' => true,
-		'the_author_posts_link' => true,
-		'the_author_posts' => true,
-		'the_author' => true,
-		'the_category_rss' => true,
-		'the_category' => true,
-		'the_content_rss' => true,
-		'the_content' => true,
-		'the_date_xml' => true,
-		'the_date' => true,
-		'the_excerpt_rss' => true,
-		'the_excerpt' => true,
-		'the_feed_link' => true,
-		'the_ID' => true,
-		'the_meta' => true,
-		'the_modified_author' => true,
-		'the_modified_date' => true,
-		'the_modified_time' => true,
-		'the_permalink' => true,
-		'the_post_thumbnail' => true,
-		'the_search_query' => true,
-		'the_shortlink' => true,
-		'the_tags' => true,
-		'the_taxonomies' => true,
-		'the_terms' => true,
-		'the_time' => true,
-		'the_title_attribute' => true,
-		'the_title_rss' => true,
-		'the_title' => true,
-		'vip_powered_wpcom' => true,
-		'walk_nav_menu_tree' => true,
-		'wp_attachment_is_image' => true,
-		'wp_dropdown_categories' => true,
-		'wp_dropdown_users' => true,
-		'wp_enqueue_script' => true,
-		'wp_generate_tag_cloud' => true,
-		'wp_get_archives' => true,
-		'wp_get_attachment_image' => true,
-		'wp_get_attachment_link' => true,
-		'wp_link_pages' => true,
-		'wp_list_authors' => true,
-		'wp_list_bookmarks' => true,
-		'wp_list_categories' => true,
-		'wp_list_comments' => true,
-		'wp_login_form' => true,
-		'wp_loginout' => true,
-		'wp_meta' => true,
-		'wp_nav_menu' => true,
-		'wp_register' => true,
-		'wp_shortlink_header' => true,
-		'wp_shortlink_wp_head' => true,
-		'wp_tag_cloud' => true,
-		'wp_title' => true,
+		'disabled'                  => true,
+		'do_shortcode'              => true,
+		'do_shortcode_tag'          => true,
+		'edit_bookmark_link'        => true,
+		'edit_comment_link'         => true,
+		'edit_post_link'            => true,
+		'edit_tag_link'             => true,
+		'get_archives_link'         => true,
+		'get_attachment_link'       => true,
+		'get_avatar'                => true,
+		'get_bookmark_field'        => true,
+		'get_bookmark'              => true,
+		'get_calendar'              => true,
+		'get_comment_author_link'   => true,
+		'get_comment_date'          => true,
+		'get_comment_time'          => true,
+		'get_current_blog_id'       => true,
+		'get_delete_post_link'      => true,
+		'get_footer'                => true,
+		'get_header'                => true,
+		'get_search_form'           => true,
+		'get_search_query'          => true,
+		'get_sidebar'               => true,
+		'get_template_part'         => true,
+		'get_the_author_link'       => true,
+		'get_the_author'            => true,
+		'get_the_date'              => true,
+		'get_the_post_thumbnail'    => true,
+		'get_the_term_list'         => true,
+		'get_the_title'             => true,
+		'has_post_thumbnail'        => true,
+		'is_attachment'             => true,
+		'next_comments_link'        => true,
+		'next_image_link'           => true,
+		'next_post_link'            => true,
+		'next_posts_link'           => true,
+		'paginate_comments_links'   => true,
+		'permalink_anchor'          => true,
+		'post_class'                => true,
+		'post_password_required'    => true,
+		'post_type_archive_title'   => true,
+		'posts_nav_link'            => true,
+		'previous_comments_link'    => true,
+		'previous_image_link'       => true,
+		'previous_post_link'        => true,
+		'previous_posts_link'       => true,
+		'selected'                  => true,
+		'single_cat_title'          => true,
+		'single_month_title'        => true,
+		'single_post_title'         => true,
+		'single_tag_title'          => true,
+		'single_term_title'         => true,
+		'sticky_class'              => true,
+		'tag_description'           => true,
+		'term_description'          => true,
+		'the_attachment_link'       => true,
+		'the_author_link'           => true,
+		'the_author_meta'           => true,
+		'the_author_posts_link'     => true,
+		'the_author_posts'          => true,
+		'the_author'                => true,
+		'the_category_rss'          => true,
+		'the_category'              => true,
+		'the_content_rss'           => true,
+		'the_content'               => true,
+		'the_date_xml'              => true,
+		'the_date'                  => true,
+		'the_excerpt_rss'           => true,
+		'the_excerpt'               => true,
+		'the_feed_link'             => true,
+		'the_ID'                    => true,
+		'the_meta'                  => true,
+		'the_modified_author'       => true,
+		'the_modified_date'         => true,
+		'the_modified_time'         => true,
+		'the_permalink'             => true,
+		'the_post_thumbnail'        => true,
+		'the_search_query'          => true,
+		'the_shortlink'             => true,
+		'the_tags'                  => true,
+		'the_taxonomies'            => true,
+		'the_terms'                 => true,
+		'the_time'                  => true,
+		'the_title_attribute'       => true,
+		'the_title_rss'             => true,
+		'the_title'                 => true,
+		'vip_powered_wpcom'         => true,
+		'walk_nav_menu_tree'        => true,
+		'wp_attachment_is_image'    => true,
+		'wp_dropdown_categories'    => true,
+		'wp_dropdown_users'         => true,
+		'wp_enqueue_script'         => true,
+		'wp_generate_tag_cloud'     => true,
+		'wp_get_archives'           => true,
+		'wp_get_attachment_image'   => true,
+		'wp_get_attachment_link'    => true,
+		'wp_link_pages'             => true,
+		'wp_list_authors'           => true,
+		'wp_list_bookmarks'         => true,
+		'wp_list_categories'        => true,
+		'wp_list_comments'          => true,
+		'wp_login_form'             => true,
+		'wp_loginout'               => true,
+		'wp_meta'                   => true,
+		'wp_nav_menu'               => true,
+		'wp_register'               => true,
+		'wp_shortlink_header'       => true,
+		'wp_shortlink_wp_head'      => true,
+		'wp_tag_cloud'              => true,
+		'wp_title'                  => true,
 	);
 
 	/**
@@ -237,46 +236,46 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $sanitizingFunctions = array(
-		'_wp_handle_upload' => true,
-		'absint' => true,
-		'array_key_exists' => true,
-		'esc_url_raw' => true,
-		'filter_input' => true,
-		'filter_var' => true,
-		'hash_equals' => true,
-		'in_array' => true,
-		'intval' => true,
-		'is_array' => true,
-		'is_email' => true,
-		'number_format' => true,
-		'sanitize_bookmark_field' => true,
-		'sanitize_bookmark' => true,
-		'sanitize_email' => true,
-		'sanitize_file_name' => true,
-		'sanitize_html_class' => true,
-		'sanitize_key' => true,
-		'sanitize_meta' => true,
-		'sanitize_mime_type' => true,
-		'sanitize_option' => true,
-		'sanitize_sql_orderby' => true,
-		'sanitize_term_field' => true,
-		'sanitize_term' => true,
-		'sanitize_text_field' => true,
-		'sanitize_title_for_query' => true,
+		'_wp_handle_upload'          => true,
+		'absint'                     => true,
+		'array_key_exists'           => true,
+		'esc_url_raw'                => true,
+		'filter_input'               => true,
+		'filter_var'                 => true,
+		'hash_equals'                => true,
+		'in_array'                   => true,
+		'intval'                     => true,
+		'is_array'                   => true,
+		'is_email'                   => true,
+		'number_format'              => true,
+		'sanitize_bookmark_field'    => true,
+		'sanitize_bookmark'          => true,
+		'sanitize_email'             => true,
+		'sanitize_file_name'         => true,
+		'sanitize_html_class'        => true,
+		'sanitize_key'               => true,
+		'sanitize_meta'              => true,
+		'sanitize_mime_type'         => true,
+		'sanitize_option'            => true,
+		'sanitize_sql_orderby'       => true,
+		'sanitize_term_field'        => true,
+		'sanitize_term'              => true,
+		'sanitize_text_field'        => true,
+		'sanitize_title_for_query'   => true,
 		'sanitize_title_with_dashes' => true,
-		'sanitize_title' => true,
-		'sanitize_user_field' => true,
-		'sanitize_user' => true,
-		'validate_file' => true,
-		'wp_handle_sideload' => true,
-		'wp_handle_upload' => true,
-		'wp_kses_allowed_html' => true,
-		'wp_kses_data' => true,
-		'wp_kses_post' => true,
-		'wp_kses' => true,
-		'wp_parse_id_list' => true,
-		'wp_redirect' => true,
-		'wp_safe_redirect' => true,
+		'sanitize_title'             => true,
+		'sanitize_user_field'        => true,
+		'sanitize_user'              => true,
+		'validate_file'              => true,
+		'wp_handle_sideload'         => true,
+		'wp_handle_upload'           => true,
+		'wp_kses_allowed_html'       => true,
+		'wp_kses_data'               => true,
+		'wp_kses_post'               => true,
+		'wp_kses'                    => true,
+		'wp_parse_id_list'           => true,
+		'wp_redirect'                => true,
+		'wp_safe_redirect'           => true,
 	);
 
 	/**
@@ -287,10 +286,10 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $unslashingSanitizingFunctions = array(
-		'absint' => true,
-		'boolval' => true,
-		'intval' => true,
-		'is_array' => true,
+		'absint'       => true,
+		'boolval'      => true,
+		'intval'       => true,
+		'is_array'     => true,
 		'sanitize_key' => true,
 	);
 
@@ -309,12 +308,12 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	public static $formattingFunctions = array(
 		'array_fill' => true,
-		'ent2ncr' => true,
-		'implode' => true,
-		'join' => true,
-		'nl2br' => true,
-		'sprintf' => true,
-		'vsprintf' => true,
+		'ent2ncr'    => true,
+		'implode'    => true,
+		'join'       => true,
+		'nl2br'      => true,
+		'sprintf'    => true,
+		'vsprintf'   => true,
 		'wp_sprintf' => true,
 	);
 
@@ -327,21 +326,21 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	public static $printingFunctions = array(
 		'_deprecated_argument' => true,
-		'_deprecated_file' => true,
+		'_deprecated_file'     => true,
 		'_deprecated_function' => true,
-		'_doing_it_wrong' => true,
-		'_e' => true,
-		'_ex' => true,
-		'die' => true,
-		'echo' => true,
-		'exit' => true,
-		'print' => true,
-		'printf' => true,
-		'trigger_error' => true,
-		'user_error' => true,
-		'vprintf' => true,
-		'wp_die' => true,
-		'wp_dropdown_pages' => true,
+		'_doing_it_wrong'      => true,
+		'_e'                   => true,
+		'_ex'                  => true,
+		'die'                  => true,
+		'echo'                 => true,
+		'exit'                 => true,
+		'print'                => true,
+		'printf'               => true,
+		'trigger_error'        => true,
+		'user_error'           => true,
+		'vprintf'              => true,
+		'wp_die'               => true,
+		'wp_dropdown_pages'    => true,
 	);
 
 	/**
@@ -352,9 +351,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @var array
 	 */
 	public static $SQLEscapingFunctions = array(
-		'absint' => true,
-		'esc_sql' => true,
-		'intval' => true,
+		'absint'      => true,
+		'esc_sql'     => true,
+		'intval'      => true,
 		'like_escape' => true,
 	);
 
@@ -442,7 +441,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	protected function init( PHP_CodeSniffer_File $phpcsFile ) {
 		$this->phpcsFile = $phpcsFile;
-		$this->tokens = $phpcsFile->getTokens();
+		$this->tokens    = $phpcsFile->getTokens();
 	}
 
 	/**
@@ -457,9 +456,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	protected function get_last_ptr_on_line( $stackPtr ) {
 
-		$tokens = $this->tokens;
+		$tokens      = $this->tokens;
 		$currentLine = $tokens[ $stackPtr ]['line'];
-		$nextPtr = $stackPtr + 1;
+		$nextPtr     = ( $stackPtr + 1 );
 
 		while ( isset( $tokens[ $nextPtr ] ) && $tokens[ $nextPtr ]['line'] === $currentLine ) {
 			$nextPtr++;
@@ -468,7 +467,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		// We've made it to the next line, back up one to the last in the previous line.
 		// We do this for micro-optimization of the above loop.
-		$lastPtr = $nextPtr - 1;
+		$lastPtr = ( $nextPtr - 1 );
 
 		return $lastPtr;
 	}
@@ -501,10 +500,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		// There is a findEndOfStatement() method, but it considers more tokens than
 		// we need to here.
-		$end_of_statement = $this->phpcsFile->findNext(
-			array( T_CLOSE_TAG, T_SEMICOLON )
-			, $stackPtr
-		);
+		$end_of_statement = $this->phpcsFile->findNext( array( T_CLOSE_TAG, T_SEMICOLON ), $stackPtr );
 
 		// Check at the end of the statement if it comes before the end of the line.
 		if ( $end_of_statement < $end_of_line ) {
@@ -513,9 +509,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			// whitespace token. If the semicolon was left out and it was terminated
 			// by an ending tag, we need to look backwards.
 			if ( T_SEMICOLON === $this->tokens[ $end_of_statement ]['code'] ) {
-				$lastPtr = $this->phpcsFile->findNext( T_WHITESPACE, $end_of_statement + 1, null, true );
+				$lastPtr = $this->phpcsFile->findNext( T_WHITESPACE, ( $end_of_statement + 1 ), null, true );
 			} else {
-				$lastPtr = $this->phpcsFile->findPrevious( T_WHITESPACE, $end_of_statement - 1, null, true );
+				$lastPtr = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $end_of_statement - 1 ), null, true );
 			}
 		}
 
@@ -549,13 +545,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		$tokens = $this->phpcsFile->getTokens();
 
 		// Must be a variable or closing square bracket (see below).
-		if ( ! in_array( $tokens[ $stackPtr ]['code'], array( T_VARIABLE, T_CLOSE_SQUARE_BRACKET ) ) ) {
+		if ( ! in_array( $tokens[ $stackPtr ]['code'], array( T_VARIABLE, T_CLOSE_SQUARE_BRACKET ), true ) ) {
 			return false;
 		}
 
 		$next_non_empty = $this->phpcsFile->findNext(
 			PHP_CodeSniffer_Tokens::$emptyTokens
-			, $stackPtr + 1
+			, ( $stackPtr + 1 )
 			, null
 			, true
 			, null
@@ -568,7 +564,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// If the next token is an assignment, that's all we need to know.
-		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens ) ) {
+		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true ) ) {
 			return true;
 		}
 
@@ -605,7 +601,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		static $last;
 
 		$start = 0;
-		$end = $stackPtr;
+		$end   = $stackPtr;
 
 		$tokens = $this->phpcsFile->getTokens();
 
@@ -694,7 +690,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		$open_parenthesis = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
 		reset( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
 
-		return in_array( $this->tokens[ $open_parenthesis - 1 ]['code'], array( T_ISSET, T_EMPTY ) );
+		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( T_ISSET, T_EMPTY ), true );
 	}
 
 	/**
@@ -744,16 +740,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// Get the last non-empty token.
 		$prev = $this->phpcsFile->findPrevious(
 			PHP_CodeSniffer_Tokens::$emptyTokens
-			, $stackPtr - 1
+			, ( $stackPtr - 1 )
 			, null
 			, true
 		);
 
 		// Check if it is a safe cast.
-		return in_array(
-			$this->tokens[ $prev ]['code']
-			, array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST )
-		);
+		return in_array( $this->tokens[ $prev ]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ), true );
 	}
 
 	/**
@@ -785,7 +778,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// Get the function that it's in.
 		$function_closer = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
 		$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-		$function = $this->tokens[ $function_opener - 1 ];
+		$function        = $this->tokens[ ( $function_opener - 1 ) ];
 
 		// If it is just being unset, the value isn't used at all, so it's safe.
 		if ( T_UNSET === $function['code'] ) {
@@ -805,8 +798,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// Check if wp_unslash() is being used.
 		if ( 'wp_unslash' === $functionName ) {
 
-			$is_unslashed = true;
-
+			$is_unslashed    = true;
 			$function_closer = prev( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
 
 			// If there is no other function being used, this value is unsanitized.
@@ -815,7 +807,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 
 			$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-			$functionName = $this->tokens[ $function_opener - 1 ]['content'];
+			$functionName    = $this->tokens[ ( $function_opener - 1 ) ]['content'];
 
 		} else {
 
@@ -828,7 +820,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			// Get the first parameter (name of function being used on the array).
 			$mapped_function = $this->phpcsFile->findNext(
 				PHP_CodeSniffer_Tokens::$emptyTokens
-				, $function_opener + 1
+				, ( $function_opener + 1 )
 				, $function_closer
 				, true
 			);
@@ -881,7 +873,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// Find the next non-empty token.
 		$open_bracket = $this->phpcsFile->findNext(
 			PHP_CodeSniffer_Tokens::$emptyTokens,
-			$stackPtr + 1,
+			( $stackPtr + 1 ),
 			null,
 			true
 		);
@@ -892,8 +884,8 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		$key = $this->phpcsFile->getTokensAsString(
-			$open_bracket + 1
-			, $this->tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1
+			( $open_bracket + 1 )
+			, ( $this->tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
 		);
 
 		return trim( $key );
@@ -937,8 +929,10 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		if ( $in_condition_only ) {
 
-			// This is a stricter check, requiring the variable to be used only
-			// within the validation condition.
+			/*
+			   This is a stricter check, requiring the variable to be used only
+			   within the validation condition.
+			 */
 
 			// If there are no conditions, there's no validation.
 			if ( empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
@@ -946,9 +940,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 
 			$conditions = $this->tokens[ $stackPtr ]['conditions'];
-			end( $conditions ); // Get closest condition
+			end( $conditions ); // Get closest condition.
 			$conditionPtr = key( $conditions );
-			$condition = $this->tokens[ $conditionPtr ];
+			$condition    = $this->tokens[ $conditionPtr ];
 
 			if ( ! isset( $condition['parenthesis_opener'] ) ) {
 
@@ -966,8 +960,10 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		} else {
 
-			// We are are more loose, requiring only that the variable be validated
-			// in the same function/file scope as it is used.
+			/*
+			   We are are more loose, requiring only that the variable be validated
+			   in the same function/file scope as it is used.
+			 */
 
 			// Check if we are in a function.
 			$function = $this->phpcsFile->findPrevious( T_FUNCTION, $stackPtr );
@@ -982,9 +978,9 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			$scope_end = $stackPtr;
 		}
 
-		for ( $i = $scope_start + 1; $i < $scope_end; $i++ ) {
+		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
-			if ( ! in_array( $this->tokens[ $i ]['code'], array( T_ISSET, T_EMPTY, T_UNSET ) ) ) {
+			if ( ! in_array( $this->tokens[ $i ]['code'], array( T_ISSET, T_EMPTY, T_UNSET ), true ) ) {
 				continue;
 			}
 
@@ -992,7 +988,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			$issetCloser = $this->tokens[ $issetOpener ]['parenthesis_closer'];
 
 			// Look for this variable. We purposely stomp $i from the parent loop.
-			for ( $i = $issetOpener + 1; $i < $issetCloser; $i++ ) {
+			for ( $i = ( $issetOpener + 1 ); $i < $issetCloser; $i++ ) {
 
 				if ( T_VARIABLE !== $this->tokens[ $i ]['code'] ) {
 					continue;
@@ -1042,19 +1038,19 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// yoda conditions are usually expected.
 		$previous_token = $this->phpcsFile->findPrevious(
 			PHP_CodeSniffer_Tokens::$emptyTokens,
-			$stackPtr - 1,
+			( $stackPtr - 1 ),
 			null,
 			true
 		);
 
-		if ( in_array( $this->tokens[ $previous_token ]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens ) ) {
+		if ( in_array( $this->tokens[ $previous_token ]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens, true ) ) {
 			return true;
 		}
 
 		// Maybe the comparison operator is after this.
 		$next_token = $this->phpcsFile->findNext(
 			PHP_CodeSniffer_Tokens::$emptyTokens,
-			$stackPtr + 1,
+			( $stackPtr + 1 ),
 			null,
 			true
 		);
@@ -1064,13 +1060,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 			$next_token = $this->phpcsFile->findNext(
 				PHP_CodeSniffer_Tokens::$emptyTokens,
-				$this->tokens[ $next_token ]['bracket_closer'] + 1,
+				( $this->tokens[ $next_token ]['bracket_closer'] + 1 ),
 				null,
 				true
 			);
 		}
 
-		if ( in_array( $this->tokens[ $next_token ]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens ) ) {
+		if ( in_array( $this->tokens[ $next_token ]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens, true ) ) {
 			return true;
 		}
 
@@ -1096,7 +1092,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	protected function get_use_type( $stackPtr ) {
 
 		// USE keywords inside closures.
-		$next = $this->phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
+		$next = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 
 		if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
 			return 'closure';
@@ -1124,7 +1120,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		$variables = array();
 		if ( preg_match_all( '/(?P<backslashes>\\\\*)\$(?P<symbol>\w+)/', $string, $match_sets, PREG_SET_ORDER ) ) {
 			foreach ( $match_sets as $matches ) {
-				if ( strlen( $matches['backslashes'] ) % 2 === 0 ) {
+				if ( ( strlen( $matches['backslashes'] ) % 2 ) === 0 ) {
 					$variables[] = $matches['symbol'];
 				}
 			}
@@ -1132,5 +1128,3 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		return $variables;
 	}
 }
-
-// EOF

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2,8 +2,6 @@
 /**
  * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  */

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -26,7 +26,6 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 */
 	public static $groups = array();
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -41,7 +40,6 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 		);
 
 	} // end register()
-
 
 	/**
 	 * Groups of variables to restrict.
@@ -62,7 +60,6 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	public function getGroups() {
 		return self::$groups;
 	}
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -190,5 +187,6 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		return true;
-	}
+	} // end callback()
+
 } // end class

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Restricts array assignment of certain keys.
  *
  * @category PHP

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Restricts array assignment of certain keys
+ * Restricts array assignment of certain keys.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_Sniff
-{
+class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_Sniff {
 
 	/**
-	 * Exclude groups
+	 * Exclude groups.
 	 *
 	 * Example: 'foo,bar'
 	 *
-	 * @var string Comma-delimited group list
+	 * @var string Comma-delimited group list.
 	 */
 	public $exclude = '';
 
@@ -33,19 +32,19 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_DOUBLE_ARROW,
-				T_CLOSE_SQUARE_BRACKET,
-				T_CONSTANT_ENCAPSED_STRING,
-				T_DOUBLE_QUOTED_STRING,
-			   );
+			T_DOUBLE_ARROW,
+			T_CLOSE_SQUARE_BRACKET,
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+		);
 
-	}//end register()
+	} // end register()
+
 
 	/**
-	 * Groups of variables to restrict
+	 * Groups of variables to restrict.
 	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
@@ -74,8 +73,7 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 
 		$groups = $this->getGroups();
 
@@ -84,45 +82,47 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 			return;
 		}
 
-		$tokens = $phpcsFile->getTokens();
-		$token = $tokens[ $stackPtr ];
+		$tokens  = $phpcsFile->getTokens();
+		$token   = $tokens[ $stackPtr ];
 		$exclude = explode( ',', $this->exclude );
 
-		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ) ) ) {
-			$equal = $phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
-			if ( $tokens[$equal]['code'] !== T_EQUAL ) {
+		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ), true ) ) {
+			$equal = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( T_EQUAL !== $tokens[ $equal ]['code'] ) {
 				return; // This is not an assignment!
 			}
 		}
 
-		// Instances: Multi-dimensional array, keyed by line
+		// Instances: Multi-dimensional array, keyed by line.
 		$inst = array();
 
-		// $foo = array( 'bar' => 'taz' );
-		// $foo['bar'] = $taz;
-		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ) ) ) {
-			if ( $token['code'] == T_CLOSE_SQUARE_BRACKET ) {
-				$operator = $phpcsFile->findNext( array( T_EQUAL ), $stackPtr + 1 );
-			} elseif ( $token['code'] == T_DOUBLE_ARROW ) {
+		/*
+		   Covers:
+		   $foo = array( 'bar' => 'taz' );
+		   $foo['bar'] = $taz;
+		 */
+		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
+			if ( T_CLOSE_SQUARE_BRACKET === $token['code']  ) {
+				$operator = $phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
+			} elseif ( T_DOUBLE_ARROW === $token['code'] ) {
 				$operator = $stackPtr;
 			}
-			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), $operator - 1, null, true );
-			if ( ! is_numeric( $tokens[$keyIdx]['content'] ) ) {
-				$key = trim( $tokens[$keyIdx]['content'], '\'"' );
-				$valStart = $phpcsFile->findNext( array( T_WHITESPACE ), $operator + 1, null, true );
-				$valEnd = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), $valStart + 1, null, false, null, true );
-				$val = $phpcsFile->getTokensAsString( $valStart, $valEnd - $valStart );
-				$val = trim( $val, '\'"' );
+			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			if ( ! is_numeric( $tokens[ $keyIdx ]['content'] ) ) {
+				$key            = trim( $tokens[ $keyIdx ]['content'], '\'"' );
+				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
+				$val            = trim( $val, '\'"' );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
-		}
-		// $foo = 'bar=taz&other=thing';
-		elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ) ) ) {
+		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			// $foo = 'bar=taz&other=thing';
 			if ( preg_match_all( '#[\'"&]([a-z_]+)=([^\'"&]*)#i', $token['content'], $matches ) <= 0 ) {
-				return; // No assignments here, nothing to check
+				return; // No assignments here, nothing to check.
 			}
 			foreach ( $matches[1] as $i => $_k ) {
-				$inst[ $_k ][] = array( $matches[2][$i], $token['line'] );
+				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
 			}
 		}
 
@@ -130,10 +130,9 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 			return;
 		}
 
-
 		foreach ( $groups as $groupName => $group ) {
 
-			if ( in_array( $groupName, $exclude ) ) {
+			if ( in_array( $groupName, $exclude, true ) ) {
 				continue;
 			}
 
@@ -143,21 +142,21 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 				foreach ( $assignments as $occurance ) {
 					list( $val, $line ) = $occurance;
 
-					if ( ! in_array( $key, $group['keys'] ) ) {
+					if ( ! in_array( $key, $group['keys'], true ) ) {
 						continue;
 					}
 
 					$output = call_user_func( $callback, $key, $val, $line, $group );
 
-					if ( $output === false || $output === null ) {
+					if ( ! isset( $output ) || false === $output ) {
 						continue;
-					} elseif ( $output === true ) {
+					} elseif ( true === $output ) {
 						$message = $group['message'];
 					} else {
 						$message = $output;
 					}
 
-					if ( $group['type'] == 'warning' ) {
+					if ( 'warning' === $group['type'] ) {
 						$addWhat = array( $phpcsFile, 'addWarning' );
 					} else {
 						$addWhat = array( $phpcsFile, 'addError' );
@@ -169,30 +168,27 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 						$stackPtr,
 						$groupName,
 						array( $key, $val )
-						);
+					);
 				}
 			}
 
-
-			// return; // Show one error only
-
+			// return; // Show one error only.
 		}
 
-	}//end process()
+	} // end process()
 
 	/**
-	 * Callback to process each confirmed key, to check value
-	 * This must be extended to add the logic to check assignment value
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
 	 *
-	 * @param  string   $key   Array index / key
-	 * @param  mixed    $val   Assigned value
-	 * @param  int      $line  Token line
-	 * @param  array    $group Group definition
-	 * @return mixed           FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process()
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		return true;
 	}
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces WordPress array format, based upon Squiz code
+ * Enforces WordPress array format, based upon Squiz code.
  *
  * PHP version 5
  *
@@ -12,7 +12,7 @@
  */
 
 /**
- * Enforces WordPress array format
+ * Enforces WordPress array format.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -29,57 +29,55 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 		parent::processSingleLineArray( $phpcsFile, $stackPtr, $arrayStart, $arrayEnd );
 
-		// This array is empty, so the below checks aren't necesary.
-		if ( $arrayStart + 1 === $arrayEnd ) {
+		// This array is empty, so the below checks aren't necessary.
+		if ( ( $arrayStart + 1 ) === $arrayEnd ) {
 			return;
 		}
 
 		$tokens = $phpcsFile->getTokens();
 
 		// Check that there is a single space after the array opener.
-		if ( T_WHITESPACE !== $tokens[ $arrayStart + 1 ]['code'] ) {
+		if ( T_WHITESPACE !== $tokens[ ( $arrayStart + 1 ) ]['code'] ) {
 
 			$warning = 'Missing space after array opener.';
-			$fix = $phpcsFile->addFixableError( $warning, $arrayStart, 'NoSpaceAfterOpenParenthesis' );
+			$fix     = $phpcsFile->addFixableError( $warning, $arrayStart, 'NoSpaceAfterOpenParenthesis' );
 
-			if ( $fix ) {
+			if ( true === $fix ) {
 				$phpcsFile->fixer->addContent( $arrayStart, ' ' );
 			}
-
-		} elseif ( ' ' !== $tokens[ $arrayStart + 1 ]['content'] ) {
+		} elseif ( ' ' !== $tokens[ ( $arrayStart + 1 ) ]['content'] ) {
 
 			$fix = $phpcsFile->addFixableError(
 				'Expected 1 space after array opener, found %s.',
 				$arrayStart,
 				'SpaceAfterArrayOpener',
-				strlen( $tokens[ $arrayStart + 1 ]['content'] )
+				strlen( $tokens[ ( $arrayStart + 1 ) ]['content'] )
 			);
 
-			if ( $fix ) {
-				$phpcsFile->fixer->replaceToken( $arrayStart + 1, ' ' );
+			if ( true === $fix ) {
+				$phpcsFile->fixer->replaceToken( ( $arrayStart + 1 ), ' ' );
 			}
 		}
 
-		if ( T_WHITESPACE !== $tokens[ $arrayEnd - 1 ]['code'] ) {
+		if ( T_WHITESPACE !== $tokens[ ( $arrayEnd - 1 ) ]['code'] ) {
 
 			$warning = 'Missing space before array closer.';
-			$fix = $phpcsFile->addFixableError( $warning, $arrayEnd, 'NoSpaceAfterOpenParenthesis' );
+			$fix     = $phpcsFile->addFixableError( $warning, $arrayEnd, 'NoSpaceAfterOpenParenthesis' );
 
-			if ( $fix ) {
+			if ( true === $fix ) {
 				$phpcsFile->fixer->addContentBefore( $arrayEnd, ' ' );
 			}
-
-		} elseif ( ' ' !== $tokens[ $arrayEnd - 1 ]['content'] ) {
+		} elseif ( ' ' !== $tokens[ ( $arrayEnd - 1 ) ]['content'] ) {
 
 			$fix = $phpcsFile->addFixableError(
 				'Expected 1 space before array closer, found %s.',
 				$arrayEnd,
 				'SpaceAfterArrayCloser',
-				strlen( $tokens[ $arrayEnd - 1 ]['content'] )
+				strlen( $tokens[ ( $arrayEnd - 1 ) ]['content'] )
 			);
 
-			if ( $fix ) {
-				$phpcsFile->fixer->replaceToken( $arrayEnd - 1, ' ' );
+			if ( true === $fix ) {
+				$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), ' ' );
 			}
 		}
 	}
@@ -90,37 +88,37 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 	 */
 	public function processMultiLineArray( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd ) {
 		$tokens       = $phpcsFile->getTokens();
-		$keywordStart = $tokens[$stackPtr]['column'];
+		$keywordStart = $tokens[ $stackPtr ]['column'];
 
 		// Check the closing bracket is on a new line.
-		$lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($arrayEnd - 1), $arrayStart, true);
-		if ($tokens[$lastContent]['line'] === $tokens[$arrayEnd]['line']) {
+		$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $arrayEnd - 1 ), $arrayStart, true );
+		if ( $tokens[ $lastContent ]['line'] === $tokens[ $arrayEnd ]['line'] ) {
 			$error = 'Closing parenthesis of array declaration must be on a new line';
-			$fix   = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceNewLine');
-			if ($fix === true) {
-				$phpcsFile->fixer->addNewlineBefore($arrayEnd);
+			$fix   = $phpcsFile->addFixableError( $error, $arrayEnd, 'CloseBraceNewLine' );
+			if ( true === $fix ) {
+				$phpcsFile->fixer->addNewlineBefore( $arrayEnd );
 			}
 			/*
-		} else if ($tokens[$arrayEnd]['column'] !== $keywordStart) {
+		} elseif ( $tokens[ $arrayEnd ]['column'] !== $keywordStart ) {
 			// Check the closing bracket is lined up under the "a" in array.
-			$expected = ($keywordStart - 1);
-			$found    = ($tokens[$arrayEnd]['column'] - 1);
+			$expected = ( $keywordStart - 1 );
+			$found    = ( $tokens[ $arrayEnd ]['column'] - 1 );
 			$error    = 'Closing parenthesis not aligned correctly; expected %s space(s) but found %s';
 			$data     = array(
 				$expected,
 				$found,
 			);
 
-			$fix = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceNotAligned', $data);
-			if ($fix === true) {
-				if ($found === 0) {
-					$phpcsFile->fixer->addContent(($arrayEnd - 1), str_repeat(' ', $expected));
+			$fix = $phpcsFile->addFixableError( $error, $arrayEnd, 'CloseBraceNotAligned', $data );
+			if ( true === $fix ) {
+				if ( 0 === $found ) {
+					$phpcsFile->fixer->addContent( ( $arrayEnd - 1 ), str_repeat(' ', $expected ) );
 				} else {
-					$phpcsFile->fixer->replaceToken(($arrayEnd - 1), str_repeat(' ', $expected));
+					$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), str_repeat(' ', $expected ) );
 				}
 			}
 			*/
-		}//end if
+		} // end if
 
 		$nextToken  = $stackPtr;
 		$keyUsed    = false;
@@ -128,33 +126,33 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 		$indices    = array();
 		$maxLength  = 0;
 
-		if ($tokens[$stackPtr]['code'] === T_ARRAY) {
-			$lastToken = $tokens[$stackPtr]['parenthesis_opener'];
+		if ( T_ARRAY === $tokens[ $stackPtr ]['code'] ) {
+			$lastToken = $tokens[ $stackPtr ]['parenthesis_opener'];
 		} else {
 			$lastToken = $stackPtr;
 		}
 
 		// Find all the double arrows that reside in this scope.
-		for ($nextToken = ($stackPtr + 1); $nextToken < $arrayEnd; $nextToken++) {
+		for ( $nextToken = ( $stackPtr + 1 ); $nextToken < $arrayEnd; $nextToken++ ) {
 			// Skip bracketed statements, like function calls.
-			if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS
-			    && (isset($tokens[$nextToken]['parenthesis_owner']) === false
-			        || $tokens[$nextToken]['parenthesis_owner'] !== $stackPtr)
+			if ( T_OPEN_PARENTHESIS === $tokens[ $nextToken ]['code']
+			    && ( ! isset( $tokens[ $nextToken ]['parenthesis_owner'] )
+			        || $tokens[ $nextToken ]['parenthesis_owner'] !== $stackPtr )
 			) {
-				$nextToken = $tokens[$nextToken]['parenthesis_closer'];
+				$nextToken = $tokens[ $nextToken ]['parenthesis_closer'];
 				continue;
 			}
 
-			if ($tokens[$nextToken]['code'] === T_ARRAY) {
+			if ( T_ARRAY === $tokens[ $nextToken ]['code'] ) {
 				// Let subsequent calls of this test handle nested arrays.
-				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
-					$indices[] = array('value' => $nextToken);
+				if ( T_DOUBLE_ARROW !== $tokens[ $lastToken ]['code'] ) {
+					$indices[] = array( 'value' => $nextToken );
 					$lastToken = $nextToken;
 				}
 
-				$nextToken = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
-				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+				$nextToken = $tokens[ $tokens[ $nextToken ]['parenthesis_opener'] ]['parenthesis_closer'];
+				$nextToken = $phpcsFile->findNext( T_WHITESPACE, ( $nextToken + 1 ), null, true );
+				if ( T_COMMA !== $tokens[ $nextToken ]['code'] ) {
 					$nextToken--;
 				} else {
 					$lastToken = $nextToken;
@@ -163,16 +161,16 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				continue;
 			}
 
-			if ($tokens[$nextToken]['code'] === T_OPEN_SHORT_ARRAY) {
+			if ( T_OPEN_SHORT_ARRAY === $tokens[ $nextToken ]['code'] ) {
 				// Let subsequent calls of this test handle nested arrays.
-				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
-					$indices[] = array('value' => $nextToken);
+				if ( T_DOUBLE_ARROW !== $tokens[ $lastToken ]['code'] ) {
+					$indices[] = array( 'value' => $nextToken );
 					$lastToken = $nextToken;
 				}
 
-				$nextToken = $tokens[$nextToken]['bracket_closer'];
-				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+				$nextToken = $tokens[ $nextToken ]['bracket_closer'];
+				$nextToken = $phpcsFile->findNext( T_WHITESPACE, ( $nextToken + 1 ), null, true );
+				if ( T_COMMA !== $tokens[ $nextToken ]['code'] ) {
 					$nextToken--;
 				} else {
 					$lastToken = $nextToken;
@@ -181,15 +179,15 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				continue;
 			}
 
-			if ($tokens[$nextToken]['code'] === T_CLOSURE) {
-				if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
-					$indices[] = array('value' => $nextToken);
+			if ( T_CLOSURE === $tokens[ $nextToken ]['code'] ) {
+				if ( T_DOUBLE_ARROW !== $tokens[ $lastToken ]['code'] ) {
+					$indices[] = array( 'value' => $nextToken );
 					$lastToken = $nextToken;
 				}
 
-				$nextToken = $tokens[$nextToken]['scope_closer'];
-				$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-				if ($tokens[$nextToken]['code'] !== T_COMMA) {
+				$nextToken = $tokens[ $nextToken ]['scope_closer'];
+				$nextToken = $phpcsFile->findNext( T_WHITESPACE, ( $nextToken + 1 ), null, true );
+				if ( T_COMMA !== $tokens[ $nextToken ]['code'] ) {
 					$nextToken--;
 				} else {
 					$lastToken = $nextToken;
@@ -198,30 +196,28 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				continue;
 			}
 
-			if ($tokens[$nextToken]['code'] !== T_DOUBLE_ARROW
-			    && $tokens[$nextToken]['code'] !== T_COMMA
-			) {
+			if ( T_DOUBLE_ARROW !== $tokens[ $nextToken ]['code'] && T_COMMA !== $tokens[ $nextToken ]['code'] ) {
 				continue;
 			}
 
 			$currentEntry = array();
 
-			if ($tokens[$nextToken]['code'] === T_COMMA) {
+			if ( T_COMMA === $tokens[ $nextToken ]['code'] ) {
 				$stackPtrCount = 0;
-				if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-					$stackPtrCount = count($tokens[$stackPtr]['nested_parenthesis']);
+				if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+					$stackPtrCount = count( $tokens[ $stackPtr ]['nested_parenthesis'] );
 				}
 
 				$commaCount = 0;
-				if (isset($tokens[$nextToken]['nested_parenthesis']) === true) {
-					$commaCount = count($tokens[$nextToken]['nested_parenthesis']);
-					if ($tokens[$stackPtr]['code'] === T_ARRAY) {
+				if ( isset( $tokens[ $nextToken ]['nested_parenthesis'] ) ) {
+					$commaCount = count( $tokens[ $nextToken ]['nested_parenthesis'] );
+					if ( T_ARRAY === $tokens[ $stackPtr ]['code'] ) {
 						// Remove parenthesis that are used to define the array.
 						$commaCount--;
 					}
 				}
 
-				if ($commaCount > $stackPtrCount) {
+				if ( $commaCount > $stackPtrCount ) {
 					// This comma is inside more parenthesis than the ARRAY keyword,
 					// then there it is actually a comma used to separate arguments
 					// in a function call.
@@ -229,20 +225,20 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				}
 
 				/*
-				if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
+				if ( true === $keyUsed && T_COMMA === $tokens[ $lastToken ]['code'] ) {
 					$error = 'No key specified for array entry; first entry specifies key';
-					$phpcsFile->addError($error, $nextToken, 'NoKeySpecified');
+					$phpcsFile->addError( $error, $nextToken, 'NoKeySpecified' );
 					return;
 				}
 				*/
 
-				if ($keyUsed === false) {
-					if ($tokens[($nextToken - 1)]['code'] === T_WHITESPACE) {
-						$content = $tokens[($nextToken - 2)]['content'];
-						if ($tokens[($nextToken - 1)]['content'] === $phpcsFile->eolChar) {
+				if ( false === $keyUsed ) {
+					if ( T_WHITESPACE === $tokens[ ( $nextToken - 1 ) ]['code'] ) {
+						$content = $tokens[ ( $nextToken - 2 ) ]['content'];
+						if ( $tokens[ ( $nextToken - 1 ) ]['content'] === $phpcsFile->eolChar ) {
 							$spaceLength = 'newline';
 						} else {
-							$spaceLength = $tokens[($nextToken - 1)]['length'];
+							$spaceLength = $tokens[ ( $nextToken - 1 ) ]['length'];
 						}
 
 						$error = 'Expected 0 spaces between "%s" and comma; %s found';
@@ -251,116 +247,115 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 							$spaceLength,
 						);
 
-						$fix = $phpcsFile->addFixableError($error, $nextToken, 'SpaceBeforeComma', $data);
-						if ($fix === true) {
-							$phpcsFile->fixer->replaceToken(($nextToken - 1), '');
+						$fix = $phpcsFile->addFixableError( $error, $nextToken, 'SpaceBeforeComma', $data );
+						if ( true === $fix ) {
+							$phpcsFile->fixer->replaceToken( ( $nextToken - 1 ), '' );
 						}
 					}
 
 					$valueContent = $phpcsFile->findNext(
 						PHP_CodeSniffer_Tokens::$emptyTokens,
-						($lastToken + 1),
+						( $lastToken + 1 ),
 						$nextToken,
 						true
 					);
 
-					$indices[]  = array('value' => $valueContent);
+					$indices[]  = array( 'value' => $valueContent );
 					$singleUsed = true;
-				}//end if
+				} // end if
 
 				$lastToken = $nextToken;
 				continue;
-			}//end if
+			} // end if
 
-
-			if ($tokens[$nextToken]['code'] === T_DOUBLE_ARROW) {
+			if ( T_DOUBLE_ARROW === $tokens[ $nextToken ]['code'] ) {
 				/*
-				if ($singleUsed === true) {
+				if ( true === $singleUsed ) {
 					$error = 'Key specified for array entry; first entry has no key';
-					$phpcsFile->addError($error, $nextToken, 'KeySpecified');
+					$phpcsFile->addError( $error, $nextToken, 'KeySpecified' );
 					return;
 				}
 				*/
 
 				$currentEntry['arrow'] = $nextToken;
-				$keyUsed = true;
+				$keyUsed               = true;
 
 				// Find the start of index that uses this double arrow.
-				$indexEnd   = $phpcsFile->findPrevious(T_WHITESPACE, ($nextToken - 1), $arrayStart, true);
-				$indexStart = $phpcsFile->findStartOfStatement($indexEnd);
+				$indexEnd   = $phpcsFile->findPrevious( T_WHITESPACE, ( $nextToken - 1 ), $arrayStart, true );
+				$indexStart = $phpcsFile->findStartOfStatement( $indexEnd );
 
-				if ($indexStart === $indexEnd) {
+				if ( $indexStart === $indexEnd ) {
 					$currentEntry['index']         = $indexEnd;
-					$currentEntry['index_content'] = $tokens[$indexEnd]['content'];
+					$currentEntry['index_content'] = $tokens[ $indexEnd ]['content'];
 				} else {
 					$currentEntry['index']         = $indexStart;
-					$currentEntry['index_content'] = $phpcsFile->getTokensAsString($indexStart, ($indexEnd - $indexStart + 1));
+					$currentEntry['index_content'] = $phpcsFile->getTokensAsString( $indexStart, ( $indexEnd - $indexStart + 1 ) );
 				}
 
-				$indexLength = strlen($currentEntry['index_content']);
-				if ($maxLength < $indexLength) {
+				$indexLength = strlen( $currentEntry['index_content'] );
+				if ( $maxLength < $indexLength ) {
 					$maxLength = $indexLength;
 				}
 
 				// Find the value of this index.
 				$nextContent = $phpcsFile->findNext(
 					PHP_CodeSniffer_Tokens::$emptyTokens,
-					($nextToken + 1),
+					( $nextToken + 1 ),
 					$arrayEnd,
 					true
 				);
 
 				$currentEntry['value'] = $nextContent;
-				$indices[] = $currentEntry;
-				$lastToken = $nextToken;
-			}//end if
-		}//end for
+				$indices[]             = $currentEntry;
+				$lastToken             = $nextToken;
+			} // end if
+		} // end for
 
 		// Check for mutli-line arrays that should be single-line.
 		$singleValue = false;
 
-		if (empty($indices) === true) {
+		if ( empty( $indices ) ) {
 			$singleValue = true;
-		} else if (count($indices) === 1 && $tokens[$lastToken]['code'] === T_COMMA) {
+		} elseif ( 1 === count( $indices ) && T_COMMA === $tokens[ $lastToken ]['code'] ) {
 			// There may be another array value without a comma.
 			$exclude     = PHP_CodeSniffer_Tokens::$emptyTokens;
 			$exclude[]   = T_COMMA;
-			$nextContent = $phpcsFile->findNext($exclude, ($indices[0]['value'] + 1), $arrayEnd, true);
-			if ($nextContent === false) {
+			$nextContent = $phpcsFile->findNext( $exclude, ( $indices[0]['value'] + 1 ), $arrayEnd, true );
+			if ( false === $nextContent ) {
 				$singleValue = true;
 			}
 		}
 
 		/*
-		if ($singleValue === true) {
+		if ( true === $singleValue ) {
 			// Array cannot be empty, so this is a multi-line array with
 			// a single value. It should be defined on single line.
 			$error = 'Multi-line array contains a single value; use single-line array instead';
-			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MultiLineNotAllowed');
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'MultiLineNotAllowed' );
 
-			if ($fix === true) {
+			if ( true === $fix ) {
 				$phpcsFile->fixer->beginChangeset();
-				for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
-					if ($tokens[$i]['code'] !== T_WHITESPACE) {
+				for ( $i = ( $arrayStart + 1 ); $i < $arrayEnd; $i++ ) {
+					if ( T_WHITESPACE !== $tokens[ $i ]['code'] ) {
 						break;
 					}
 
-					$phpcsFile->fixer->replaceToken($i, '');
+					$phpcsFile->fixer->replaceToken( $i, '' );
 				}
 
-				for ($i = ($arrayEnd - 1); $i > $arrayStart; $i--) {
-					if ($tokens[$i]['code'] !== T_WHITESPACE) {
+				for ( $i = ( $arrayEnd - 1 ); $i > $arrayStart; $i-- ) {
+					if ( T_WHITESPACE !== $tokens[ $i ]['code'] ) {
 						break;
 					}
 
-					$phpcsFile->fixer->replaceToken($i, '');
+					$phpcsFile->fixer->replaceToken( $i, '' );
 				}
 
 				$phpcsFile->fixer->endChangeset();
 			}
 
 			return;
-		}//end if
+		} // end if
 		*/
 
 		/*
@@ -374,75 +369,75 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			   );
 		*/
 
-		if ($keyUsed === false && empty($indices) === false) {
-			$count     = count($indices);
-			$lastIndex = $indices[($count - 1)]['value'];
+		if ( false === $keyUsed && ! empty( $indices ) ) {
+			$count     = count( $indices );
+			$lastIndex = $indices[ ( $count - 1 ) ]['value'];
 
 			$trailingContent = $phpcsFile->findPrevious(
 				PHP_CodeSniffer_Tokens::$emptyTokens,
-				($arrayEnd - 1),
+				( $arrayEnd - 1 ),
 				$lastIndex,
 				true
 			);
 
-			if ($tokens[$trailingContent]['code'] !== T_COMMA) {
-				$phpcsFile->recordMetric($stackPtr, 'Array end comma', 'no');
+			if ( T_COMMA !== $tokens[ $trailingContent ]['code'] ) {
+				$phpcsFile->recordMetric( $stackPtr, 'Array end comma', 'no' );
 				$error = 'Comma required after last value in array declaration';
-				$fix   = $phpcsFile->addFixableError($error, $trailingContent, 'NoCommaAfterLast');
-				if ($fix === true) {
-					$phpcsFile->fixer->addContent($trailingContent, ',');
+				$fix   = $phpcsFile->addFixableError( $error, $trailingContent, 'NoCommaAfterLast' );
+				if ( true === $fix ) {
+					$phpcsFile->fixer->addContent( $trailingContent, ',' );
 				}
 			} else {
-				$phpcsFile->recordMetric($stackPtr, 'Array end comma', 'yes');
+				$phpcsFile->recordMetric( $stackPtr, 'Array end comma', 'yes' );
 			}
 
 			$lastValueLine = false;
-			foreach ($indices as $value) {
-				if (empty($value['value']) === true) {
+			foreach ( $indices as $value ) {
+				if ( empty( $value['value'] ) ) {
 					// Array was malformed and we couldn't figure out
 					// the array value correctly, so we have to ignore it.
 					// Other parts of this sniff will correct the error.
 					continue;
 				}
 
-				if ($lastValueLine !== false && $tokens[$value['value']]['line'] === $lastValueLine) {
+				if ( false !== $lastValueLine && $tokens[ $value['value'] ]['line'] === $lastValueLine ) {
 					$error = 'Each value in a multi-line array must be on a new line';
-					$fix   = $phpcsFile->addFixableError($error, $value['value'], 'ValueNoNewline');
-					if ($fix === true) {
-						if ($tokens[($value['value'] - 1)]['code'] === T_WHITESPACE) {
-							$phpcsFile->fixer->replaceToken(($value['value'] - 1), '');
+					$fix   = $phpcsFile->addFixableError( $error, $value['value'], 'ValueNoNewline' );
+					if ( true === $fix ) {
+						if ( T_WHITESPACE === $tokens[ ( $value['value'] - 1 ) ]['code'] ) {
+							$phpcsFile->fixer->replaceToken( ( $value['value'] - 1 ), '' );
 						}
 
-						$phpcsFile->fixer->addNewlineBefore($value['value']);
+						$phpcsFile->fixer->addNewlineBefore( $value['value'] );
 					}
 					/*
-				} else if ($tokens[($value['value'] - 1)]['code'] === T_WHITESPACE) {
+				} elseif ( T_WHITESPACE === $tokens[ ( $value['value'] - 1 ) ]['code'] ) {
 					$expected = $keywordStart;
 
-					$first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $value['value'], true);
-					$found = ($tokens[$first]['column'] - 1);
-					if ($found !== $expected) {
+					$first = $phpcsFile->findFirstOnLine( T_WHITESPACE, $value['value'], true );
+					$found = ($tokens[ $first ]['column'] - 1);
+					if ( $found !== $expected ) {
 						$error = 'Array value not aligned correctly; expected %s spaces but found %s';
 						$data  = array(
 							$expected,
 							$found,
 						);
 
-						$fix = $phpcsFile->addFixableError($error, $value['value'], 'ValueNotAligned', $data);
-						if ($fix === true) {
-							if ($found === 0) {
-								$phpcsFile->fixer->addContent(($value['value'] - 1), str_repeat(' ', $expected));
+						$fix = $phpcsFile->addFixableError( $error, $value['value'], 'ValueNotAligned', $data );
+						if ( true === $fix ) {
+							if ( 0 === $found ) {
+								$phpcsFile->fixer->addContent( ( $value['value'] - 1 ), str_repeat(' ', $expected ) );
 							} else {
-								$phpcsFile->fixer->replaceToken(($value['value'] - 1), str_repeat(' ', $expected));
+								$phpcsFile->fixer->replaceToken( ( $value['value'] - 1 ), str_repeat(' ', $expected ) );
 							}
 						}
 					}
 					*/
-				}//end if
+				} // end if
 
-				$lastValueLine = $tokens[$value['value']]['line'];
-			}//end foreach
-		}//end if
+				$lastValueLine = $tokens[ $value['value'] ]['line'];
+			} // end foreach
+		} // end if
 
 		/*
 			Below the actual indentation of the array is checked.
@@ -471,21 +466,21 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			to be moved back one space however, then both errors would be fixed.
 		*/
 
-		$numValues = count($indices);
+		$numValues = count( $indices );
 
-		$indicesStart  = ($keywordStart + 1);
-		$arrowStart    = ($indicesStart + $maxLength + 1);
-		$valueStart    = ($arrowStart + 3);
-		$indexLine     = $tokens[$stackPtr]['line'];
+		$indicesStart  = ( $keywordStart + 1 );
+		$arrowStart    = ( $indicesStart + $maxLength + 1 );
+		$valueStart    = ( $arrowStart + 3 );
+		$indexLine     = $tokens[ $stackPtr ]['line'];
 		$lastIndexLine = null;
-		foreach ($indices as $index) {
-			if (isset($index['index']) === false) {
+		foreach ( $indices as $index ) {
+			if ( ! isset( $index['index'] ) ) {
 				// Array value only.
-				if ($tokens[$index['value']]['line'] === $tokens[$stackPtr]['line'] && $numValues > 1) {
+				if ( $tokens[ $index['value'] ]['line'] === $tokens[ $stackPtr ]['line'] && $numValues > 1 ) {
 					$error = 'The first value in a multi-value array must be on a new line';
-					$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstValueNoNewline');
-					if ($fix === true) {
-						$phpcsFile->fixer->addNewlineBefore($index['value']);
+					$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'FirstValueNoNewline' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->addNewlineBefore( $index['value'] );
 					}
 				}
 
@@ -493,79 +488,79 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			}
 
 			$lastIndexLine = $indexLine;
-			$indexLine     = $tokens[$index['index']]['line'];
+			$indexLine     = $tokens[ $index['index'] ]['line'];
 
-			if ($indexLine === $tokens[$stackPtr]['line']) {
+			if ( $indexLine === $tokens[ $stackPtr ]['line'] ) {
 				$error = 'The first index in a multi-value array must be on a new line';
-				$fix   = $phpcsFile->addFixableError($error, $index['index'], 'FirstIndexNoNewline');
-				if ($fix === true) {
-					$phpcsFile->fixer->addNewlineBefore($index['index']);
+				$fix   = $phpcsFile->addFixableError( $error, $index['index'], 'FirstIndexNoNewline' );
+				if ( true === $fix ) {
+					$phpcsFile->fixer->addNewlineBefore( $index['index'] );
 				}
 
 				continue;
 			}
 
-			if ($indexLine === $lastIndexLine) {
+			if ( $indexLine === $lastIndexLine ) {
 				$error = 'Each index in a multi-line array must be on a new line';
-				$fix   = $phpcsFile->addFixableError($error, $index['index'], 'IndexNoNewline');
-				if ($fix === true) {
-					if ($tokens[($index['index'] - 1)]['code'] === T_WHITESPACE) {
-						$phpcsFile->fixer->replaceToken(($index['index'] - 1), '');
+				$fix   = $phpcsFile->addFixableError( $error, $index['index'], 'IndexNoNewline' );
+				if ( true === $fix ) {
+					if ( T_WHITESPACE === $tokens[ ( $index['index'] - 1 ) ]['code'] ) {
+						$phpcsFile->fixer->replaceToken( ( $index['index'] - 1 ), '' );
 					}
 
-					$phpcsFile->fixer->addNewlineBefore($index['index']);
+					$phpcsFile->fixer->addNewlineBefore( $index['index'] );
 				}
 
 				continue;
 			}
 
 			/*
-			if ($tokens[$index['index']]['column'] !== $indicesStart) {
-				$expected = ($indicesStart - 1);
-				$found    = ($tokens[$index['index']]['column'] - 1);
+			if ( $tokens[ $index['index'] ]['column'] !== $indicesStart ) {
+				$expected = ( $indicesStart - 1 );
+				$found    = ( $tokens[ $index['index'] ]['column'] - 1 );
 				$error    = 'Array key not aligned correctly; expected %s spaces but found %s';
 				$data     = array(
 					$expected,
 					$found,
 				);
 
-				$fix = $phpcsFile->addFixableError($error, $index['index'], 'KeyNotAligned', $data);
-				if ($fix === true) {
-					if ($found === 0) {
-						$phpcsFile->fixer->addContent(($index['index'] - 1), str_repeat(' ', $expected));
+				$fix = $phpcsFile->addFixableError( $error, $index['index'], 'KeyNotAligned', $data );
+				if ( true === $fix ) {
+					if ( 0 === $found ) {
+						$phpcsFile->fixer->addContent( ( $index['index'] - 1 ), str_repeat(' ', $expected ) );
 					} else {
-						$phpcsFile->fixer->replaceToken(($index['index'] - 1), str_repeat(' ', $expected));
+						$phpcsFile->fixer->replaceToken( ( $index['index'] - 1 ), str_repeat(' ', $expected ) );
 					}
 				}
 
 				continue;
 			}
 
-			if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
-				$expected = ($arrowStart - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
-				$found    = ($tokens[$index['arrow']]['column'] - (strlen($index['index_content']) + $tokens[$index['index']]['column']));
+			if ( $tokens[ $index['arrow'] ]['column'] !== $arrowStart ) {
+				$expected = ( $arrowStart - ( strlen( $index['index_content'] ) + $tokens[ $index['index'] ]['column'] ) );
+				$found    = ( $tokens[ $index['arrow'] ]['column'] - ( strlen( $index['index_content'] ) + $tokens[ $index['index'] ]['column'] ) );
 				$error    = 'Array double arrow not aligned correctly; expected %s space(s) but found %s';
 				$data     = array(
 					$expected,
 					$found,
 				);
 
-				$fix = $phpcsFile->addFixableError($error, $index['arrow'], 'DoubleArrowNotAligned', $data);
-				if ($fix === true) {
-					if ($found === 0) {
-						$phpcsFile->fixer->addContent(($index['arrow'] - 1), str_repeat(' ', $expected));
+				$fix = $phpcsFile->addFixableError( $error, $index['arrow'], 'DoubleArrowNotAligned', $data );
+				if ( true === $fix ) {
+					if ( 0 === $found ) {
+						$phpcsFile->fixer->addContent( ( $index['arrow'] - 1 ), str_repeat(' ', $expected ) );
 					} else {
-						$phpcsFile->fixer->replaceToken(($index['arrow'] - 1), str_repeat(' ', $expected));
+						$phpcsFile->fixer->replaceToken( ( $index['arrow'] - 1 ), str_repeat(' ', $expected ) );
 					}
 				}
 
 				continue;
 			}
 
-			if ($tokens[$index['value']]['column'] !== $valueStart) {
-				$expected = ($valueStart - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));
-				$found    = ($tokens[$index['value']]['column'] - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));
-				if ($found < 0) {
+			if ( $tokens[ $index['value'] ]['column'] !== $valueStart ) {
+				$expected = ( $valueStart - ( $tokens[ $index['arrow'] ]['length'] + $tokens[ $index['arrow'] ]['column'] ) );
+				$found    = ( $tokens[ $index['value'] ]['column'] - ( $tokens[ $index['arrow'] ]['length'] + $tokens[ $index['arrow'] ]['column'] ) );
+				if ( $found < 0 ) {
 					$found = 'newline';
 				}
 
@@ -575,95 +570,95 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					$found,
 				);
 
-				$fix = $phpcsFile->addFixableError($error, $index['arrow'], 'ValueNotAligned', $data);
-				if ($fix === true) {
-					if ($found === 'newline') {
-						$prev = $phpcsFile->findPrevious(T_WHITESPACE, ($index['value'] - 1), null, true);
+				$fix = $phpcsFile->addFixableError( $error, $index['arrow'], 'ValueNotAligned', $data );
+				if ( true === $fix ) {
+					if ( 'newline' === $found ) {
+						$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $index['value'] - 1 ), null, true );
 						$phpcsFile->fixer->beginChangeset();
-						for ($i = ($prev + 1); $i < $index['value']; $i++) {
-							$phpcsFile->fixer->replaceToken($i, '');
+						for ( $i = ( $prev + 1 ); $i < $index['value']; $i++ ) {
+							$phpcsFile->fixer->replaceToken( $i, '' );
 						}
 
-						$phpcsFile->fixer->replaceToken(($index['value'] - 1), str_repeat(' ', $expected));
+						$phpcsFile->fixer->replaceToken( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
 						$phpcsFile->fixer->endChangeset();
-					} else if ($found === 0) {
-						$phpcsFile->fixer->addContent(($index['value'] - 1), str_repeat(' ', $expected));
+					} elseif ( 0 === $found ) {
+						$phpcsFile->fixer->addContent( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
 					} else {
-						$phpcsFile->fixer->replaceToken(($index['value'] - 1), str_repeat(' ', $expected));
+						$phpcsFile->fixer->replaceToken( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
 					}
 				}
-			}//end if
+			} // end if
 			*/
 
 			// Check each line ends in a comma.
-			$valueLine = $tokens[$index['value']]['line'];
+			$valueLine = $tokens[ $index['value'] ]['line'];
 			$nextComma = false;
-			for ($i = $index['value']; $i < $arrayEnd; $i++) {
+			for ( $i = $index['value']; $i < $arrayEnd; $i++ ) {
 				// Skip bracketed statements, like function calls.
-				if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
-					$i         = $tokens[$i]['parenthesis_closer'];
-					$valueLine = $tokens[$i]['line'];
+				if ( T_OPEN_PARENTHESIS === $tokens[ $i ]['code'] ) {
+					$i         = $tokens[ $i ]['parenthesis_closer'];
+					$valueLine = $tokens[ $i ]['line'];
 					continue;
 				}
 
-				if ($tokens[$i]['code'] === T_ARRAY) {
-					$i         = $tokens[$tokens[$i]['parenthesis_opener']]['parenthesis_closer'];
-					$valueLine = $tokens[$i]['line'];
+				if ( T_ARRAY === $tokens[ $i ]['code'] ) {
+					$i         = $tokens[ $tokens[ $i ]['parenthesis_opener'] ]['parenthesis_closer'];
+					$valueLine = $tokens[ $i ]['line'];
 					continue;
 				}
 
-				if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
-					$i         = $tokens[$i]['bracket_closer'];
-					$valueLine = $tokens[$i]['line'];
+				if ( T_OPEN_SHORT_ARRAY === $tokens[ $i ]['code'] ) {
+					$i         = $tokens[ $i ]['bracket_closer'];
+					$valueLine = $tokens[ $i ]['line'];
 					continue;
 				}
 
-				if ($tokens[$i]['code'] === T_CLOSURE) {
-					$i         = $tokens[$i]['scope_closer'];
-					$valueLine = $tokens[$i]['line'];
+				if ( T_CLOSURE === $tokens[ $i ]['code'] ) {
+					$i         = $tokens[ $i ]['scope_closer'];
+					$valueLine = $tokens[ $i ]['line'];
 					continue;
 				}
 
-				if ($tokens[$i]['code'] === T_COMMA) {
+				if ( T_COMMA === $tokens[ $i ]['code'] ) {
 					$nextComma = $i;
 					break;
 				}
-			}//end for
+			} // end for
 
-			//if ($nextComma === false || ($tokens[$nextComma]['line'] !== $valueLine)) {
-			if ( $nextComma === false ) {
+			//if ( $nextComma === false || ( $tokens[ $nextComma ]['line'] !== $valueLine ) ) {
+			if ( false === $nextComma ) {
 				$error = 'Each line in an array declaration must end in a comma';
-				$fix   = $phpcsFile->addFixableError($error, $index['value'], 'NoComma');
+				$fix   = $phpcsFile->addFixableError( $error, $index['value'], 'NoComma' );
 
-				if ($fix === true) {
+				if ( true === $fix ) {
 					// Find the end of the line and put a comma there.
-					for ($i = ($index['value'] + 1); $i < $phpcsFile->numTokens; $i++) {
-						if ($tokens[$i]['line'] > $valueLine) {
+					for ( $i = ( $index['value'] + 1 ); $i < $phpcsFile->numTokens; $i++ ) {
+						if ( $tokens[ $i ]['line'] > $valueLine ) {
 							break;
 						}
 					}
 
-					$phpcsFile->fixer->addContentBefore(($i - 1), ',');
+					$phpcsFile->fixer->addContentBefore( ( $i - 1 ), ',' );
 				}
 			}
 
 			// Check that there is no space before the comma.
-			if ($nextComma !== false && $tokens[($nextComma - 1)]['code'] === T_WHITESPACE) {
-				$content     = $tokens[($nextComma - 2)]['content'];
-				$spaceLength = $tokens[($nextComma - 1)]['length'];
+			if ( false !== $nextComma && T_WHITESPACE === $tokens[ ( $nextComma - 1 ) ]['code'] ) {
+				$content     = $tokens[ ( $nextComma - 2 ) ]['content'];
+				$spaceLength = $tokens[ ( $nextComma - 1 ) ]['length'];
 				$error       = 'Expected 0 spaces between "%s" and comma; %s found';
 				$data        = array(
 					$content,
 					$spaceLength,
 				);
 
-				$fix = $phpcsFile->addFixableError($error, $nextComma, 'SpaceBeforeComma', $data);
-				if ($fix === true) {
-					$phpcsFile->fixer->replaceToken(($nextComma - 1), '');
+				$fix = $phpcsFile->addFixableError( $error, $nextComma, 'SpaceBeforeComma', $data );
+				if ( true === $fix ) {
+					$phpcsFile->fixer->replaceToken( ( $nextComma - 1 ), '' );
 				}
 			}
-		}//end foreach
+		} // end foreach
 
-	}//end processMultiLineArray()
+	} // end processMultiLineArray()
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -2,8 +2,6 @@
 /**
  * Enforces WordPress array format, based upon Squiz code.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley <john@urbangiraffe.com>

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -98,26 +98,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			if ( true === $fix ) {
 				$phpcsFile->fixer->addNewlineBefore( $arrayEnd );
 			}
-			/*
-		} elseif ( $tokens[ $arrayEnd ]['column'] !== $keywordStart ) {
-			// Check the closing bracket is lined up under the "a" in array.
-			$expected = ( $keywordStart - 1 );
-			$found    = ( $tokens[ $arrayEnd ]['column'] - 1 );
-			$error    = 'Closing parenthesis not aligned correctly; expected %s space(s) but found %s';
-			$data     = array(
-				$expected,
-				$found,
-			);
-
-			$fix = $phpcsFile->addFixableError( $error, $arrayEnd, 'CloseBraceNotAligned', $data );
-			if ( true === $fix ) {
-				if ( 0 === $found ) {
-					$phpcsFile->fixer->addContent( ( $arrayEnd - 1 ), str_repeat(' ', $expected ) );
-				} else {
-					$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), str_repeat(' ', $expected ) );
-				}
-			}
-			*/
 		} // end if
 
 		$nextToken  = $stackPtr;
@@ -224,14 +204,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					continue;
 				}
 
-				/*
-				if ( true === $keyUsed && T_COMMA === $tokens[ $lastToken ]['code'] ) {
-					$error = 'No key specified for array entry; first entry specifies key';
-					$phpcsFile->addError( $error, $nextToken, 'NoKeySpecified' );
-					return;
-				}
-				*/
-
 				if ( false === $keyUsed ) {
 					if ( T_WHITESPACE === $tokens[ ( $nextToken - 1 ) ]['code'] ) {
 						$content = $tokens[ ( $nextToken - 2 ) ]['content'];
@@ -269,13 +241,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			} // end if
 
 			if ( T_DOUBLE_ARROW === $tokens[ $nextToken ]['code'] ) {
-				/*
-				if ( true === $singleUsed ) {
-					$error = 'Key specified for array entry; first entry has no key';
-					$phpcsFile->addError( $error, $nextToken, 'KeySpecified' );
-					return;
-				}
-				*/
 
 				$currentEntry['arrow'] = $nextToken;
 				$keyUsed               = true;
@@ -325,38 +290,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				$singleValue = true;
 			}
 		}
-
-		/*
-		if ( true === $singleValue ) {
-			// Array cannot be empty, so this is a multi-line array with
-			// a single value. It should be defined on single line.
-			$error = 'Multi-line array contains a single value; use single-line array instead';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'MultiLineNotAllowed' );
-
-			if ( true === $fix ) {
-				$phpcsFile->fixer->beginChangeset();
-				for ( $i = ( $arrayStart + 1 ); $i < $arrayEnd; $i++ ) {
-					if ( T_WHITESPACE !== $tokens[ $i ]['code'] ) {
-						break;
-					}
-
-					$phpcsFile->fixer->replaceToken( $i, '' );
-				}
-
-				for ( $i = ( $arrayEnd - 1 ); $i > $arrayStart; $i-- ) {
-					if ( T_WHITESPACE !== $tokens[ $i ]['code'] ) {
-						break;
-					}
-
-					$phpcsFile->fixer->replaceToken( $i, '' );
-				}
-
-				$phpcsFile->fixer->endChangeset();
-			}
-
-			return;
-		} // end if
-		*/
 
 		/*
 			This section checks for arrays that don't specify keys.
@@ -410,29 +343,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 						$phpcsFile->fixer->addNewlineBefore( $value['value'] );
 					}
-					/*
-				} elseif ( T_WHITESPACE === $tokens[ ( $value['value'] - 1 ) ]['code'] ) {
-					$expected = $keywordStart;
-
-					$first = $phpcsFile->findFirstOnLine( T_WHITESPACE, $value['value'], true );
-					$found = ($tokens[ $first ]['column'] - 1);
-					if ( $found !== $expected ) {
-						$error = 'Array value not aligned correctly; expected %s spaces but found %s';
-						$data  = array(
-							$expected,
-							$found,
-						);
-
-						$fix = $phpcsFile->addFixableError( $error, $value['value'], 'ValueNotAligned', $data );
-						if ( true === $fix ) {
-							if ( 0 === $found ) {
-								$phpcsFile->fixer->addContent( ( $value['value'] - 1 ), str_repeat(' ', $expected ) );
-							} else {
-								$phpcsFile->fixer->replaceToken( ( $value['value'] - 1 ), str_repeat(' ', $expected ) );
-							}
-						}
-					}
-					*/
 				} // end if
 
 				$lastValueLine = $tokens[ $value['value'] ]['line'];
@@ -464,7 +374,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			In this array, the double arrow is indented too far, but this
 			will also cause an error in the value's alignment. If the arrow were
 			to be moved back one space however, then both errors would be fixed.
-		*/
+		 */
 
 		$numValues = count( $indices );
 
@@ -513,82 +423,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 				continue;
 			}
-
-			/*
-			if ( $tokens[ $index['index'] ]['column'] !== $indicesStart ) {
-				$expected = ( $indicesStart - 1 );
-				$found    = ( $tokens[ $index['index'] ]['column'] - 1 );
-				$error    = 'Array key not aligned correctly; expected %s spaces but found %s';
-				$data     = array(
-					$expected,
-					$found,
-				);
-
-				$fix = $phpcsFile->addFixableError( $error, $index['index'], 'KeyNotAligned', $data );
-				if ( true === $fix ) {
-					if ( 0 === $found ) {
-						$phpcsFile->fixer->addContent( ( $index['index'] - 1 ), str_repeat(' ', $expected ) );
-					} else {
-						$phpcsFile->fixer->replaceToken( ( $index['index'] - 1 ), str_repeat(' ', $expected ) );
-					}
-				}
-
-				continue;
-			}
-
-			if ( $tokens[ $index['arrow'] ]['column'] !== $arrowStart ) {
-				$expected = ( $arrowStart - ( strlen( $index['index_content'] ) + $tokens[ $index['index'] ]['column'] ) );
-				$found    = ( $tokens[ $index['arrow'] ]['column'] - ( strlen( $index['index_content'] ) + $tokens[ $index['index'] ]['column'] ) );
-				$error    = 'Array double arrow not aligned correctly; expected %s space(s) but found %s';
-				$data     = array(
-					$expected,
-					$found,
-				);
-
-				$fix = $phpcsFile->addFixableError( $error, $index['arrow'], 'DoubleArrowNotAligned', $data );
-				if ( true === $fix ) {
-					if ( 0 === $found ) {
-						$phpcsFile->fixer->addContent( ( $index['arrow'] - 1 ), str_repeat(' ', $expected ) );
-					} else {
-						$phpcsFile->fixer->replaceToken( ( $index['arrow'] - 1 ), str_repeat(' ', $expected ) );
-					}
-				}
-
-				continue;
-			}
-
-			if ( $tokens[ $index['value'] ]['column'] !== $valueStart ) {
-				$expected = ( $valueStart - ( $tokens[ $index['arrow'] ]['length'] + $tokens[ $index['arrow'] ]['column'] ) );
-				$found    = ( $tokens[ $index['value'] ]['column'] - ( $tokens[ $index['arrow'] ]['length'] + $tokens[ $index['arrow'] ]['column'] ) );
-				if ( $found < 0 ) {
-					$found = 'newline';
-				}
-
-				$error = 'Array value not aligned correctly; expected %s space(s) but found %s';
-				$data  = array(
-					$expected,
-					$found,
-				);
-
-				$fix = $phpcsFile->addFixableError( $error, $index['arrow'], 'ValueNotAligned', $data );
-				if ( true === $fix ) {
-					if ( 'newline' === $found ) {
-						$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $index['value'] - 1 ), null, true );
-						$phpcsFile->fixer->beginChangeset();
-						for ( $i = ( $prev + 1 ); $i < $index['value']; $i++ ) {
-							$phpcsFile->fixer->replaceToken( $i, '' );
-						}
-
-						$phpcsFile->fixer->replaceToken( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
-						$phpcsFile->fixer->endChangeset();
-					} elseif ( 0 === $found ) {
-						$phpcsFile->fixer->addContent( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
-					} else {
-						$phpcsFile->fixer->replaceToken( ( $index['value'] - 1 ), str_repeat(' ', $expected ) );
-					}
-				}
-			} // end if
-			*/
 
 			// Check each line ends in a comma.
 			$valueLine = $tokens[ $index['value'] ]['line'];

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -82,7 +82,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 		}
 	}
 
-
 	/**
 	 * @since 0.5.0
 	 */

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -1,8 +1,16 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Check for proper spacing in array key references.
  *
- * @see http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ * @link     http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -1,27 +1,26 @@
 <?php
 /**
- * Check for proper spacing in array key references
+ * Check for proper spacing in array key references.
  *
- * @see  http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ * @see http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_OPEN_SQUARE_BRACKET,
-			   );
+			T_OPEN_SQUARE_BRACKET,
+		);
 
-	}//end register()
+	} // end register()
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -32,8 +31,7 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		$token = $tokens[ $stackPtr ];
@@ -44,40 +42,39 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 
 		$need_spaces = $phpcsFile->findNext(
 			array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_WHITESPACE, T_MINUS ),
-			$stackPtr + 1,
+			( $stackPtr + 1 ),
 			$token['bracket_closer'],
 			true
 		);
 
-		$spaced1 = ( T_WHITESPACE === $tokens[ $stackPtr + 1 ]['code'] );
-		$spaced2 = ( T_WHITESPACE === $tokens[ $token['bracket_closer'] - 1 ]['code'] );
+		$spaced1 = ( T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code'] );
+		$spaced2 = ( T_WHITESPACE === $tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
 
-		// It should have spaces only if it only has strings or numbers as the key
+		// It should have spaces only if it only has strings or numbers as the key.
 		if ( $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
 			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
-			$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
-			if ( $fix ) {
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
+			if ( true === $fix ) {
 				if ( ! $spaced1 ) {
-					$phpcsFile->fixer->addContentBefore( $stackPtr + 1, ' ' );
+					$phpcsFile->fixer->addContentBefore( ( $stackPtr + 1 ), ' ' );
 				}
 				if ( ! $spaced2 ) {
 					$phpcsFile->fixer->addContentBefore( $token['bracket_closer'], ' ' );
 				}
 			}
-		}
-		elseif( ! $need_spaces && ( $spaced1 || $spaced2 ) ) {
+		} elseif ( ! $need_spaces && ( $spaced1 || $spaced2 ) ) {
 			$error = 'Array keys must NOT be surrounded by spaces if they only contain a string or an integer.';
-			$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
-			if ( $fix ) {
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
+			if ( true === $fix ) {
 				if ( $spaced1 ) {
-					$phpcsFile->fixer->replaceToken( $stackPtr + 1, '' );
+					$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
 				}
 				if ( $spaced2 ) {
-					$phpcsFile->fixer->replaceToken( $token['bracket_closer'] - 1, '' );
+					$phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
 				}
 			}
 		}
 
-	}//end process()
+	} // end process()
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -2,8 +2,6 @@
 /**
  * WordPress_Sniffs_CSRF_NonceVerificationSniff.
  *
- * PHP version 5
- *
  * @since 0.5.0
  *
  * @category PHP
@@ -13,12 +11,13 @@
 /**
  * Checks that nonce verification accompanies form processing.
  *
- * @since 0.5.0
+ * @link     https://developer.wordpress.org/plugins/security/nonces/ Nonces on Plugin Developer Handbook
+ *
+ * @since    0.5.0
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   J.D. Grimes <jdg@codesymphony.co>
- * @link     https://developer.wordpress.org/plugins/security/nonces/ Nonces on Plugin Developer Handbook
  */
 class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * WordPress_Sniffs_CSRF_NonceVerificationSniff.
  *
@@ -96,7 +95,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
 		$this->init( $phpcsFile );
 
-		$tokens = $phpcsFile->getTokens();
+		$tokens   = $phpcsFile->getTokens();
 		$instance = $tokens[ $stackPtr ];
 
 		$superglobals = array_merge(
@@ -104,7 +103,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 			, $this->warnForSuperGlobals
 		);
 
-		if ( ! in_array( $instance['content'], $superglobals ) ) {
+		if ( ! in_array( $instance['content'], $superglobals, true ) ) {
 			return;
 		}
 
@@ -125,7 +124,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 		}
 
 		// If we're still here, no nonce-verification function was found.
-		$severity = ( in_array( $instance['content'], $this->errorForSuperGlobals ) ) ? 0 : 'warning';
+		$severity = ( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ) ? 0 : 'warning';
 
 		$phpcsFile->addError(
 			'Processing form data without nonce verification.'

--- a/WordPress/Sniffs/Classes/ValidClassNameSniff.php
+++ b/WordPress/Sniffs/Classes/ValidClassNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Modified Squiz_Sniffs_Classes_ValidClassNameSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/WordPress/Sniffs/Classes/ValidClassNameSniff.php
+++ b/WordPress/Sniffs/Classes/ValidClassNameSniff.php
@@ -28,65 +28,57 @@
  * @version   Release: 1.2.0RC1
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sniff {
 
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_CLASS,
+			T_INTERFACE,
+		);
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                T_CLASS,
-                T_INTERFACE,
-               );
+	} // end register()
 
-    }//end register()
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The current file being processed.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
 
+		if ( ! isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
+			$error	= 'Possible parse error: ';
+			$error .= $tokens[ $stackPtr ]['content'];
+			$error .= ' missing opening or closing brace';
+			$phpcsFile->addWarning( $error, $stackPtr, 'MissingBrace' );
+			return;
+		}
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being processed.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+		// Determine the name of the class or interface. Note that we cannot
+		// simply look for the first T_STRING because a class name
+		// starting with the number will be multiple tokens.
+		$opener    = $tokens[ $stackPtr ]['scope_opener'];
+		$nameStart = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), $opener, true );
+		$nameEnd   = $phpcsFile->findNext( T_WHITESPACE, $nameStart, $opener );
+		$name	   = trim( $phpcsFile->getTokensAsString( $nameStart, ( $nameEnd - $nameStart ) ) );
 
-        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
-            $error  = 'Possible parse error: ';
-            $error .= $tokens[$stackPtr]['content'];
-            $error .= ' missing opening or closing brace';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace');
-            return;
-        }
+		// Check for camel caps format.
+		$valid = PHP_CodeSniffer::isCamelCaps( str_replace( '_', '', $name ), true, true, false );
+		if ( false === $valid ) {
+			$type  = ucfirst( $tokens[ $stackPtr ]['content'] );
+			$error = "$type name \"$name\" is not in camel caps format";
+			$phpcsFile->addError( $error, $stackPtr, 'NotCamelCaps' );
+		}
 
-        // Determine the name of the class or interface. Note that we cannot
-        // simply look for the first T_STRING because a class name
-        // starting with the number will be multiple tokens.
-        $opener    = $tokens[$stackPtr]['scope_opener'];
-        $nameStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $opener, true);
-        $nameEnd   = $phpcsFile->findNext(T_WHITESPACE, $nameStart, $opener);
-        $name      = trim($phpcsFile->getTokensAsString($nameStart, ($nameEnd - $nameStart)));
+	} // end process()
 
-        // Check for camel caps format.
-        $valid = PHP_CodeSniffer::isCamelCaps(str_replace('_', '', $name), true, true, false);
-        if ($valid === false) {
-            $type  = ucfirst($tokens[$stackPtr]['content']);
-            $error = "$type name \"$name\" is not in camel caps format";
-            $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps');
-        }
-
-    }//end process()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * WordPress Coding Standard
+ * WordPress Coding Standard.
  *
  * PHP version 5
  *
@@ -14,52 +13,44 @@
 /**
  * WordPress_Sniffs_Files_FileNameSniff.
  *
- * Ensures filenames do not contain underscores
+ * Ensures filenames do not contain underscores.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley
  */
-class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff {
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array( T_OPEN_TAG );
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( T_OPEN_TAG );
 
-    }//end register()
+	} // end register()
 
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return int
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return int
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
+		$fileName = basename( $phpcsFile->getFileName() );
 
-        $fileName = basename($phpcsFile->getFileName());
+		if ( false !== strpos( $fileName, '_' ) ) {
+			$expected = str_replace( '_', '-', $fileName );
+			$error    = 'Filename "' . $fileName . '" with underscores found; use ' . $expected . ' instead';
+			$phpcsFile->addError( $error, $stackPtr, 'UnderscoresNotAllowed' );
+		}
 
-        if (strpos($fileName, '_') !== false) {
-                $expected = str_replace('_', '-', $fileName);
-                $error    = 'Filename "'.$fileName.'" with underscores found; use '.$expected.' instead';
-                $phpcsFile->addError($error, $stackPtr, 'UnderscoresNotAllowed');
-        }
+		return ( $phpcsFile->numTokens + 1 );
 
-        return $phpcsFile->numTokens + 1;
-
-    }//end process()
-
-
-}//end class
-
-?>
+	} // end process()
+} // end class

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -53,4 +53,5 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff {
 		return ( $phpcsFile->numTokens + 1 );
 
 	} // end process()
+
 } // end class

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -2,12 +2,9 @@
 /**
  * WordPress Coding Standard.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
- * @author   John Godley
- * @link     http://codex.wordpress.org/WordPress_Coding_Standards
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Restricts usage of some functions
+ * Restricts usage of some functions.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
-	 * Exclude groups
+	 * Exclude groups.
 	 *
 	 * Example: 'switch_to_blog,user_meta'
-	 * 
-	 * @var string Comma-delimited group list 
+	 *
+	 * @var string Comma-delimited group list.
 	 */
 	public $exclude = '';
 
@@ -23,26 +22,25 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_STRING,
-				T_EVAL,
-			   );
+			T_STRING,
+			T_EVAL,
+		);
 
-	}//end register()
+	} // end register()
 
 	/**
-	 * Groups of functions to restrict
+	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
 	 * 	'lambda' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Use anonymous functions instead please!',
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
 	 * 		'functions' => array( 'eval', 'create_function' ),
 	 * 	)
 	 * )
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getGroups() {
@@ -59,29 +57,27 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
 
-		$token = $tokens[$stackPtr];
-
-		// exclude function definitions, class methods, and namespaced calls
+		// Exclude function definitions, class methods, and namespaced calls.
 		if (
-			$token['code'] == T_STRING
+			T_STRING === $token['code']
 			&&
-			( $prev = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true ) )
+			( $prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true ) )
 			&&
 			(
-				// Skip sniffing if calling a method, or on function definitions
-				in_array( $tokens[$prev]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ) )
+				// Skip sniffing if calling a method, or on function definitions.
+				in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true )
 				||
 				(
-					// Skip namespaced functions, ie: \foo\bar() not \bar()
-					$tokens[$prev]['code'] == T_NS_SEPARATOR
+					// Skip namespaced functions, ie: \foo\bar() not \bar().
+					T_NS_SEPARATOR === $tokens[ $prev ]['code']
 					&&
-					( $pprev = $phpcsFile->findPrevious( T_WHITESPACE, $prev - 1, null, true ) )
+					( $pprev = $phpcsFile->findPrevious( T_WHITESPACE, ( $prev - 1 ), null, true ) )
 					&&
-					$tokens[$pprev]['code'] == T_STRING
+					T_STRING === $tokens[ $pprev ]['code']
 				)
 			)
 			) {
@@ -93,12 +89,12 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			return count( $tokens ) + 1;
+			return ( count( $tokens ) + 1 );
 		}
 
 		foreach ( $groups as $groupName => $group ) {
-			
-			if ( in_array( $groupName, $exclude ) ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
 				continue;
 			}
 
@@ -109,7 +105,7 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 				continue;
 			}
 
-			if ( $group['type'] == 'warning' ) {
+			if ( 'warning' === $group['type'] ) {
 				$addWhat = array( $phpcsFile, 'addWarning' );
 			} else {
 				$addWhat = array( $phpcsFile, 'addError' );
@@ -117,15 +113,13 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 
 			call_user_func(
 				$addWhat,
-				$group['message'], 
-				$stackPtr, 
-				$groupName, 
+				$group['message'],
+				$stackPtr,
+				$groupName,
 				array( $token['content'] )
-				);
+			);
 
 		}
 
-	}//end process()
-
-
-}//end class
+	} // end process()
+} // end class

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Restricts usage of some functions.
  *
  * @category PHP

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -47,7 +47,6 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 		return array();
 	}
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
@@ -122,4 +121,5 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 		}
 
 	} // end process()
+
 } // end class

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -36,7 +36,6 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 		'debugInfo',
 	);
 
-
 	/**
 	 * Processes the tokens outside the scope.
 	 *
@@ -59,7 +58,6 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 		}
 
 	} // end processTokenOutsideScope()
-
 
 	/**
 	 * Processes the tokens within the scope.

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -2,15 +2,13 @@
 /**
  * Enforces WordPress function name format, based upon Squiz code.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley <john@urbangiraffe.com>
  */
 
 /**
- * Enforces WordPress array format.
+ * Enforces WordPress function name format.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces WordPress function name format, based upon Squiz code
+ * Enforces WordPress function name format, based upon Squiz code.
  *
  * PHP version 5
  *
@@ -10,136 +10,134 @@
  */
 
 /**
- * Enforces WordPress array format
+ * Enforces WordPress array format.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley <john@urbangiraffe.com>
  */
-class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff
-{
+class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff {
 
-    private $_magicMethods = array(
-                              'construct',
-                              'destruct',
-                              'call',
-                              'callStatic',
-                              'get',
-                              'set',
-                              'isset',
-                              'unset',
-                              'sleep',
-                              'wakeup',
-                              'toString',
-                              'set_state',
-                              'clone',
-                              'invoke',
-                              'debugInfo'
-                             );
-
-
-    /**
-     * Processes the tokens outside the scope.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
-     *
-     * @return void
-     */
-    protected function processTokenOutsideScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $functionName = $phpcsFile->getDeclarationName($stackPtr);
-
-        if (strtolower($functionName) !== $functionName) {
-            $suggested = preg_replace('/([A-Z])/', '_$1', $functionName);
-            $suggested = strtolower($suggested);
-            $suggested = str_replace('__', '_', $suggested);
-
-            $error = "Function name \"$functionName\" is in camel caps format, try '".$suggested."'";
-            $phpcsFile->addError($error, $stackPtr, 'FunctionNameInvalid');
-        }
-
-    }//end processTokenOutsideScope()
+	private $_magicMethods = array(
+		'construct',
+		'destruct',
+		'call',
+		'callStatic',
+		'get',
+		'set',
+		'isset',
+		'unset',
+		'sleep',
+		'wakeup',
+		'toString',
+		'set_state',
+		'clone',
+		'invoke',
+		'debugInfo',
+	);
 
 
-    /**
-     * Processes the tokens within the scope.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
-     * @param int                  $currScope The position of the current scope.
-     *
-     * @return void
-     */
-    protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
-    {
-        $className  = $phpcsFile->getDeclarationName($currScope);
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+	/**
+	 * Processes the tokens outside the scope.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
+	 * @param int                  $stackPtr  The position where this token was
+	 *                                        found.
+	 *
+	 * @return void
+	 */
+	protected function processTokenOutsideScope( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$functionName = $phpcsFile->getDeclarationName( $stackPtr );
 
-        // Is this a magic method. IE. is prefixed with "__".
-        if (preg_match('|^__|', $methodName) !== 0) {
-            $magicPart = substr($methodName, 2);
-            if (in_array($magicPart, $this->_magicMethods) === false) {
-                 $error = "Method name \"$className::$methodName\" is invalid; only PHP magic methods should be prefixed with a double underscore";
-                 $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore');
-            }
+		if ( strtolower( $functionName ) !== $functionName ) {
+			$suggested = preg_replace( '/([A-Z])/', '_$1', $functionName );
+			$suggested = strtolower( $suggested );
+			$suggested = str_replace( '__', '_', $suggested );
 
-            return;
-        }
+			$error = "Function name \"$functionName\" is in camel caps format, try '{$suggested}'";
+			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid' );
+		}
 
-        // PHP4 constructors are allowed to break our rules.
-        if ($methodName === $className) {
-            return;
-        }
+	} // end processTokenOutsideScope()
 
-        // PHP4 destructors are allowed to break our rules.
-        if ($methodName === '_'.$className) {
-            return;
-        }
 
-        // If this is a child class, it may have to use camelCase.
-        if ( $phpcsFile->findExtendedClassName( $currScope ) || $this->findImplementedInterfaceName( $currScope, $phpcsFile ) ) {
-            return;
-        }
+	/**
+	 * Processes the tokens within the scope.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
+	 * @param int                  $stackPtr  The position where this token was
+	 *                                        found.
+	 * @param int                  $currScope The position of the current scope.
+	 *
+	 * @return void
+	 */
+	protected function processTokenWithinScope( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope ) {
+		$className	= $phpcsFile->getDeclarationName( $currScope );
+		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
 
-        $methodProps    = $phpcsFile->getMethodProperties($stackPtr);
-        $scope          = $methodProps['scope'];
-        $scopeSpecified = $methodProps['scope_specified'];
+		// Is this a magic method. IE. is prefixed with "__".
+		if ( 0 === strpos( $methodName, '__' ) ) {
+			$magicPart = substr( $methodName, 2 );
+			if ( false === in_array( $magicPart, $this->_magicMethods, true ) ) {
+				 $error = "Method name \"$className::$methodName\" is invalid; only PHP magic methods should be prefixed with a double underscore";
+				 $phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore' );
+			}
 
-        if ($methodProps['scope'] === 'private')
-            $isPublic = false;
-        else
-            $isPublic = true;
+			return;
+		}
 
-        // If the scope was specified on the method, then the method must be
-        // camel caps and an underscore should be checked for. If it wasn't
-        // specified, treat it like a public method and remove the underscore
-        // prefix if there is one because we can't determine if it is private or
-        // public.
-        $testMethodName = $methodName;
-        if ($scopeSpecified === false && $methodName{0} === '_') {
-            $testMethodName = substr($methodName, 1);
-        }
+		// PHP4 constructors are allowed to break our rules.
+		if ( $methodName === $className ) {
+			return;
+		}
 
-        if (strtolower($testMethodName) !== $testMethodName) {
-            $suggested = preg_replace('/([A-Z])/', '_$1', $methodName);
-            $suggested = strtolower($suggested);
-            $suggested = str_replace('__', '_', $suggested);
+		// PHP4 destructors are allowed to break our rules.
+		if ( '_' . $className === $methodName ) {
+			return;
+		}
 
-            $error = "Function name \"$methodName\" is in camel caps format, try '".$suggested."'";
-            $phpcsFile->addError($error, $stackPtr, 'FunctionNameInvalid');
-        }
+		// If this is a child class, it may have to use camelCase.
+		if ( $phpcsFile->findExtendedClassName( $currScope ) || $this->findImplementedInterfaceName( $currScope, $phpcsFile ) ) {
+			return;
+		}
 
-    }//end processTokenWithinScope()
+		$methodProps	= $phpcsFile->getMethodProperties( $stackPtr );
+		$scope			= $methodProps['scope'];
+		$scopeSpecified = $methodProps['scope_specified'];
+
+		if ( 'private' === $methodProps['scope'] ) {
+			$isPublic = false;
+		} else {
+			$isPublic = true;
+		}
+
+		// If the scope was specified on the method, then the method must be
+		// camel caps and an underscore should be checked for. If it wasn't
+		// specified, treat it like a public method and remove the underscore
+		// prefix if there is one because we can't determine if it is private or
+		// public.
+		$testMethodName = $methodName;
+		if ( false === $scopeSpecified && '_' === $methodName{0} ) {
+			$testMethodName = substr( $methodName, 1 );
+		}
+
+		if ( strtolower( $testMethodName ) !== $testMethodName ) {
+			$suggested = preg_replace( '/([A-Z])/', '_$1', $methodName );
+			$suggested = strtolower( $suggested );
+			$suggested = str_replace( '__', '_', $suggested );
+
+			$error = "Function name \"$methodName\" is in camel caps format, try '{$suggested}'";
+			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid' );
+		}
+
+	} // end processTokenWithinScope()
 
 	/**
 	 * Returns the name of the class that the specified class implements.
 	 *
 	 * Returns FALSE on error or if there is no implemented class name.
 	 *
-	 * @param int $stackPtr The stack position of the class.
+	 * @param int                  $stackPtr  The stack position of the class.
 	 * @param PHP_CodeSniffer_File $phpcsFile The stack position of the class.
 	 *
 	 * @see PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff::findExtendedClassName()
@@ -152,17 +150,17 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 		$tokens = $phpcsFile->getTokens();
 
 		// Check for the existence of the token.
-		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+		if ( ! isset( $tokens[ $stackPtr ] ) ) {
 			return false;
 		}
-		if ( $tokens[ $stackPtr ]['code'] !== T_CLASS ) {
+		if ( T_CLASS !== $tokens[ $stackPtr ]['code'] ) {
 			return false;
 		}
-		if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) === false ) {
+		if ( ! isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
 			return false;
 		}
 		$classOpenerIndex = $tokens[ $stackPtr ]['scope_opener'];
-		$extendsIndex = $phpcsFile->findNext( T_IMPLEMENTS, $stackPtr, $classOpenerIndex );
+		$extendsIndex     = $phpcsFile->findNext( T_IMPLEMENTS, $stackPtr, $classOpenerIndex );
 		if ( false === $extendsIndex ) {
 			return false;
 		}
@@ -171,13 +169,13 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			T_STRING,
 			T_WHITESPACE,
 		);
-		$end  = $phpcsFile->findNext( $find, ( $extendsIndex + 1 ), $classOpenerIndex + 1, true );
+		$end  = $phpcsFile->findNext( $find, ( $extendsIndex + 1 ), ( $classOpenerIndex + 1 ), true );
 		$name = $phpcsFile->getTokensAsString( ( $extendsIndex + 1 ), ( $end - $extendsIndex - 1 ) );
 		$name = trim( $name );
-		if ( $name === '' ) {
+		if ( '' === $name ) {
 			return false;
 		}
 		return $name;
-	}//end findExtendedClassName()
+	} // end findExtendedClassName()
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -204,7 +204,6 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 
 	}
 
-
 	/**
 	 * Processes the variable found within a double quoted string.
 	 *
@@ -242,5 +241,6 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 */
 	static function isSnakeCase( $var_name ) {
 		return (bool) preg_match( '/^[a-z0-9_]+$/', $var_name );
-	}
+	} // end isSnakeCase()
+
 } // end class

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -106,20 +106,20 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			self::$addedCustomVariables = true;
 		}
 
-		$tokens  = $phpcs_file->getTokens();
+		$tokens   = $phpcs_file->getTokens();
 		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
 
 		// If it's a php reserved var, then its ok.
-		if ( in_array( $var_name, $this->php_reserved_vars ) === true ) {
+		if ( in_array( $var_name, $this->php_reserved_vars, true ) ) {
 			return;
 		}
 
 		$obj_operator = $phpcs_file->findNext( array( T_WHITESPACE ), ( $stack_ptr + 1 ), null, true );
 		if ( T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
 			// Check to see if we are using a variable from an object.
-			$var = $phpcs_file->findNext( array( T_WHITESPACE ), ($obj_operator + 1), null, true );
+			$var = $phpcs_file->findNext( array( T_WHITESPACE ), ( $obj_operator + 1 ), null, true );
 			if ( T_STRING === $tokens[ $var ]['code'] ) {
-				$bracket = $phpcs_file->findNext( array( T_WHITESPACE ), ($var + 1), null, true );
+				$bracket = $phpcs_file->findNext( array( T_WHITESPACE ), ( $var + 1 ), null, true );
 				if ( T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] ) {
 					$obj_var_name = $tokens[ $var ]['content'];
 
@@ -127,7 +127,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 					// private, so we have to ignore a leading underscore if there is
 					// one and just check the main part of the variable name.
 					$original_var_name = $obj_var_name;
-					if ( substr( $obj_var_name, 0, 1 ) === '_' ) {
+					if ( '_' === substr( $obj_var_name, 0, 1 ) ) {
 						$obj_var_name = substr( $obj_var_name, 1 );
 					}
 
@@ -136,9 +136,9 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 						$data  = array( $original_var_name );
 						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
 					}
-				}//end if
-			}//end if
-		}//end if
+				} // end if
+			} // end if
+		} // end if
 
 		$in_class     = false;
 		$obj_operator = $phpcs_file->findPrevious( array( T_WHITESPACE ), ( $stack_ptr - 1 ), null, true );
@@ -152,7 +152,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 		// so we have to ignore a leading underscore if there is one and just
 		// check the main part of the variable name.
 		$original_var_name = $var_name;
-		if ( substr( $var_name, 0, 1 ) === '_' && true === $in_class ) {
+		if ( '_' === substr( $var_name, 0, 1 ) && true === $in_class ) {
 			$var_name = substr( $var_name, 1 );
 		}
 
@@ -188,7 +188,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 
 		$var_name     = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
 		$member_props = $phpcs_file->getMemberProperties( $stack_ptr );
-		if ( empty( $member_props ) === true ) {
+		if ( empty( $member_props ) ) {
 			// Couldn't get any info about this variable, which
 			// generally means it is invalid or possibly has a parse
 			// error. Any errors will be reported by the core, so
@@ -197,7 +197,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 		}
 
 		$error_data = array( $var_name );
-		if ( ! in_array( $var_name, $this->whitelisted_mixed_case_member_var_names, true ) && self::isSnakeCase( $var_name ) === false ) {
+		if ( ! in_array( $var_name, $this->whitelisted_mixed_case_member_var_names, true ) && false === self::isSnakeCase( $var_name ) ) {
 			$error = 'Member variable "%s" is not in valid snake_case format.';
 			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
 		}
@@ -210,21 +210,21 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 *
 	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
 	 * @param int                  $stack_ptr  The position of the double quoted
-	 *                                        string.
+	 *                                         string.
 	 *
 	 * @return void
 	 */
 	protected function processVariableInString( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
 		$tokens = $phpcs_file->getTokens();
 
-		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) !== 0 ) {
+		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) > 0 ) {
 			foreach ( $matches[1] as $var_name ) {
 				// If it's a php reserved var, then its ok.
-				if ( in_array( $var_name, $this->php_reserved_vars ) === true ) {
+				if ( in_array( $var_name, $this->php_reserved_vars, true ) ) {
 					continue;
 				}
 
-				if ( self::isSnakeCase( $var_name ) === false ) {
+				if ( false === self::isSnakeCase( $var_name ) ) {
 					$error = 'Variable "%s" is not in valid snake_case format';
 					$data  = array( $var_name );
 					$phpcs_file->addError( $error, $stack_ptr, 'StringNotSnakeCase', $data );
@@ -237,10 +237,10 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	/**
 	 * Return whether the variable is in snake_case.
 	 *
-	 * @param string $var_name
+	 * @param string $var_name Variable name.
 	 * @return bool
 	 */
 	static function isSnakeCase( $var_name ) {
 		return (bool) preg_match( '/^[a-z0-9_]+$/', $var_name );
 	}
-}//end class
+} // end class

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -9,8 +9,8 @@
  * @author   John Godley <john@urbangiraffe.com>
  */
 
-if (class_exists('Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found');
+if ( false === class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
 }
 
 /**
@@ -24,29 +24,32 @@ if (class_exists('Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true) === false) 
  */
 class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 
-    /**
-     * A list of forbidden functions with their alternatives.
-     *
-     * The value is NULL if no alternative exists. IE, the
-     * function should just not be used.
-     *
-     * @var array(string => string|null)
-     */
-    public $forbiddenFunctions = array(
-    		// Deprecated
+	/**
+	 * A list of forbidden functions with their alternatives.
+	 *
+	 * The value is NULL if no alternative exists. I.e. the
+	 * function should just not be used.
+	 *
+	 * @var array(string => string|null)
+	 */
+	public $forbiddenFunctions = array(
+		// Deprecated.
 		'ereg_replace'             => 'preg_replace',
 		'ereg'                     => null,
 		'eregi_replace'            => 'preg_replace',
 		'split'                    => null,
 		'spliti'                   => null,
-    		// Development
+
+		// Development.
 		'print_r'                  => null,
 		'debug_print_backtrace'    => null,
 		'var_dump'                 => null,
 		'var_export'               => null,
-		// Discouraged
+
+		// Discouraged.
 		'json_encode'              => 'wp_json_encode',
-		// WordPress deprecated
+
+		// WordPress deprecated.
 		'find_base_dir'            => 'WP_Filesystem::abspath',
 		'get_base_dir'             => 'WP_Filesystem::abspath',
 		'dropdown_categories'      => 'wp_link_category_checklist',
@@ -61,16 +64,17 @@ class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_
 		'get_attachment_icon_src'  => 'wp_get_attachment_image_src',
 		'get_attachment_icon'      => 'wp_get_attachment_image',
 		'get_attachment_innerHTML' => 'wp_get_attachment_image',
-		// WordPress discouraged
+
+		// WordPress discouraged.
 		'query_posts'              => 'WP_Query',
 		'wp_reset_query'           => 'wp_reset_postdata',
 	);
 
-    /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
+	/**
+	 * If true, an error will be thrown; otherwise a warning.
+	 *
+	 * @var bool
+	 */
+	public $error = false;
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -2,8 +2,6 @@
 /**
  * WordPress_Sniffs_PHP_DiscouragedFunctionsSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley <john@urbangiraffe.com>

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -1,8 +1,14 @@
 <?php
 /**
- * Enforces Strict Comparison checks, based upon Squiz code.
+ * WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Enforces Strict Comparison checks, based upon Squiz code.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -23,7 +23,6 @@ class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff {
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces Strict Comparison checks, based upon Squiz code
+ * Enforces Strict Comparison checks, based upon Squiz code.
  *
  * PHP version 5
  *
@@ -8,44 +8,40 @@
  * @package  PHP_CodeSniffer
  * @author   Matt Robinson
  */
-
-class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff
-{
+class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
 			T_IS_EQUAL,
 			T_IS_NOT_EQUAL,
 		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File	$phpcsFile The file being scanned.
-	 * @param int			$stackPtr  The position of the current token in the
-	 *						stack passed in $tokens.
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
 	 *
 	 * @return void
 	 */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
 
 		if ( ! $this->has_whitelist_comment( 'loose comparison', $stackPtr ) ) {
 			$tokens = $phpcsFile->getTokens();
-			$error = 'Found: ' . $tokens[$stackPtr]['content'] . '. Use strict comparisons (=== or !==).';
+			$error  = 'Found: ' . $tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
 			$phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
 		}
 
-	}//end process()
+	} // end process()
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -71,5 +71,6 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_Ar
 			$phpcsFile->addWarning( 'Not using strict comparison for in_array(); supply true for third argument.', $lastToken, 'MissingTrueStrict' );
 			return;
 		}
-	}
-}
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -6,7 +6,7 @@
  * @category PHP
  * @package  PHP_CodeSniffer
  */
-class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
+class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -6,7 +6,6 @@
  * @category PHP
  * @package  PHP_CodeSniffer
  */
-
 class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
 
 	/**
@@ -23,8 +22,9 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_Ar
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File  $phpcsFile The file being scanned.
-	 * @param int                   $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
 	 *
 	 * @return void
 	 */
@@ -36,7 +36,7 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_Ar
 			return;
 		}
 
-		if ( ! isset( $tokens[ $stackPtr - 1 ] ) ) {
+		if ( ! isset( $tokens[ ( $stackPtr - 1 ) ] ) ) {
 			return;
 		}
 
@@ -48,7 +48,7 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_Ar
 		}
 
 		// Get the closing parenthesis.
-		$openParenthesis = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $stackPtr + 1 );
+		$openParenthesis = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $stackPtr + 1 ) );
 		if ( false === $openParenthesis ) {
 			return;
 		}
@@ -61,7 +61,7 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniffs_Arrays_Ar
 
 		// Get last token in the function call.
 		$closeParenthesis = $tokens[ $openParenthesis ]['parenthesis_closer'];
-		$lastToken = $phpcsFile->findPrevious( array( T_WHITESPACE, T_COMMENT ), $closeParenthesis - 1, $openParenthesis + 1, true );
+		$lastToken        = $phpcsFile->findPrevious( array( T_WHITESPACE, T_COMMENT ), ( $closeParenthesis - 1 ), ( $openParenthesis + 1 ), true );
 		if ( false === $lastToken ) {
 			$phpcsFile->addError( 'Missing arguments to in_array().', $openParenthesis, 'MissingArguments' );
 			return;

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -1,8 +1,17 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag calling in_array() without true as the third parameter.
  *
- * @link https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter
+ * @link     https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  */

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -2,15 +2,13 @@
 /**
  * Enforces Yoda conditional statements , based upon Squiz code.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Matt Robinson
  */
 
 /**
- * Squiz_Sniffs.
+ * Enforces Yoda conditional statements.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -35,7 +35,6 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces Yoda conditional statements , based upon Squiz code
+ * Enforces Yoda conditional statements , based upon Squiz code.
  *
  * PHP version 5
  *
@@ -18,16 +18,14 @@
  * @author   Greg Sherwood <gsherwood@squiz.net>
  * @author   Marc McIntyre <mmcintyre@squiz.net>
  */
-class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
 			T_IS_EQUAL,
 			T_IS_NOT_EQUAL,
@@ -35,20 +33,19 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			T_IS_NOT_IDENTICAL,
 		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File	$phpcsFile The file being scanned.
-	 * @param int					$stackPtr  The position of the current token in the
-	 *											stack passed in $tokens.
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
 	 *
 	 * @return void
 	 */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		$beginners = array_merge(
@@ -64,7 +61,7 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 		for ( $i = $stackPtr; $i > $beginning; $i-- ) {
 
 			// Ignore whitespace.
-			if ( in_array( $tokens[ $i ]['code'], PHP_CodeSniffer_Tokens::$emptyTokens ) ) {
+			if ( in_array( $tokens[ $i ]['code'], PHP_CodeSniffer_Tokens::$emptyTokens, true ) ) {
 				continue;
 			}
 
@@ -75,7 +72,7 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ), true ) ) {
 				return;
 			}
 		}
@@ -84,17 +81,17 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 			return;
 		}
 
-		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 )
-		$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true );
+		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 ).
+		$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$castTokens ) ) {
-			$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $next_non_empty + 1, null, true );
+		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$castTokens, true ) ) {
+			$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
 		}
 
-		if ( in_array( $tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ) ) ) {
+		if ( in_array( $tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
 			$next_non_empty = $phpcsFile->findNext(
 				array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )
-				, $next_non_empty + 1
+				, ( $next_non_empty + 1 )
 				, null
 				, true
 			);
@@ -106,9 +103,6 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff
 
 		$phpcsFile->addError( 'Use Yoda Condition checks, you must', $stackPtr, 'NotYoda' );
 
-	}//end process()
+	} // end process()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Discourages removal of the admin bar.
  *
@@ -7,23 +6,21 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_STRING,
-				T_CONSTANT_ENCAPSED_STRING,
-				T_DOUBLE_QUOTED_STRING,
-			   );
+			T_STRING,
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -35,16 +32,12 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		if ( in_array( trim( $tokens[$stackPtr]['content'], '"\'' ), array( 'show_admin_bar' ) ) ) {
-			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected');
+		if ( in_array( trim( $tokens[ $stackPtr ]['content'], '"\'' ), array( 'show_admin_bar' ), true ) ) {
+			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
 		}
-	}//end process()
+	} // end process()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Discourages removal of the admin bar.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -22,7 +22,6 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -22,7 +22,6 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
@@ -123,8 +122,8 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 
 	} // end process()
 
-
 	public function confused( $phpcsFile, $stackPtr ) {
 		$phpcsFile->addWarning( 'Detected changing of cron_schedules, but could not detect the interval value.', $stackPtr, 'ChangeDetected' );
-	}
+	} // end confused()
+
 } // end class

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag cron schedules less than 15 minutes.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -6,8 +6,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Flag cron schedules less than 15 minutes
+ * Flag cron schedules less than 15 minutes.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -14,14 +14,13 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
 			T_CONSTANT_ENCAPSED_STRING,
 			T_DOUBLE_QUOTED_STRING,
 		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -33,33 +32,32 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[$stackPtr];
+		$token  = $tokens[ $stackPtr ];
 
-		if ( 'cron_schedules' != trim( $token['content'], '"\'' ) ) {
+		if ( 'cron_schedules' !== trim( $token['content'], '"\'' ) ) {
 			return;
 		}
 
-		// If within add_filter
+		// If within add_filter.
 		$functionPtr = $phpcsFile->findPrevious( T_STRING, key( $token['nested_parenthesis'] ) );
-		if ( $tokens[$functionPtr]['content'] != 'add_filter' ) {
+		if ( 'add_filter' !== $tokens[ $functionPtr ]['content'] ) {
 			return;
 		}
 
-		// Detect callback function name
-		$callbackPtr = $phpcsFile->findNext( array( T_COMMA, T_WHITESPACE ), $stackPtr + 1, null, true, null, true );
+		// Detect callback function name.
+		$callbackPtr = $phpcsFile->findNext( array( T_COMMA, T_WHITESPACE ), ( $stackPtr + 1 ), null, true, null, true );
 
-		// If callback is array, get second element
-		if ( T_ARRAY === $tokens[$callbackPtr]['code'] ) {
-			$comma = $phpcsFile->findNext( T_COMMA, $callbackPtr + 1 );
+		// If callback is array, get second element.
+		if ( T_ARRAY === $tokens[ $callbackPtr ]['code'] ) {
+			$comma = $phpcsFile->findNext( T_COMMA, ( $callbackPtr + 1 ) );
 			if ( false === $comma ) {
 				$this->confused( $phpcsFile, $stackPtr );
 				return;
 			}
 
-			$callbackPtr = $phpcsFile->findNext( array( T_WHITESPACE ), $comma + 1, null, true, null, true );
+			$callbackPtr = $phpcsFile->findNext( array( T_WHITESPACE ), ( $comma + 1 ), null, true, null, true );
 			if ( false === $callbackPtr ) {
 				$this->confused( $phpcsFile, $stackPtr );
 				return;
@@ -68,18 +66,16 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 
 		$functionPtr = null;
 
-		// Search for the function in tokens
-		if ( in_array( $tokens[$callbackPtr]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ) ) ) {
-			$functionName = trim( $tokens[$callbackPtr]['content'], '"\'' );
+		// Search for the function in tokens.
+		if ( in_array( $tokens[ $callbackPtr ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			$functionName = trim( $tokens[ $callbackPtr ]['content'], '"\'' );
 
 			foreach ( $tokens as $ptr => $_token ) {
-				if ( $_token['code'] == T_STRING && $_token['content'] == $functionName ) {
+				if ( T_STRING === $_token['code'] && $_token['content'] === $functionName ) {
 					$functionPtr = $ptr;
 				}
 			}
-		}
-		// Closure
-		else if ( $tokens[$callbackPtr]['code'] === T_CLOSURE ) {
+		} elseif ( T_CLOSURE === $tokens[ $callbackPtr ]['code'] ) { // Closure.
 			$functionPtr = $callbackPtr;
 		}
 
@@ -92,16 +88,16 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 		$closing = $tokens[ $opening ]['bracket_closer'];
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
-			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ) ) ) {
-				if ( trim( $tokens[$i]['content'], '\'"' ) == 'interval' ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				if ( 'interval' === trim( $tokens[ $i ]['content'], '\'"' ) ) {
 					$operator = $phpcsFile->findNext( T_DOUBLE_ARROW, $i, null, null, null, true );
 					if ( empty( $operator ) ) {
 						$this->confused( $phpcsFile, $stackPtr );
 					}
 
-					$valueStart = $phpcsFile->findNext( T_WHITESPACE, $operator + 1, null, true, null, true );
-					$valueEnd   = $phpcsFile->findNext( array( T_COMMA, T_CLOSE_PARENTHESIS ), $valueStart + 1 );
-					$value = $phpcsFile->getTokensAsString( $valueStart, $valueEnd - $valueStart );
+					$valueStart = $phpcsFile->findNext( T_WHITESPACE, ( $operator + 1 ), null, true, null, true );
+					$valueEnd   = $phpcsFile->findNext( array( T_COMMA, T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
+					$value      = $phpcsFile->getTokensAsString( $valueStart, ( $valueEnd - $valueStart ) );
 
 					if ( is_numeric( $value ) ) {
 						$interval = $value;
@@ -110,7 +106,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 
 					// If all digits and operators, eval!
 					if ( preg_match( '#^[\s\d\+\*\-\/]+$#', $value ) > 0 ) {
-						$interval = eval( "return ( $value );" ); // No harm here
+						$interval = eval( "return ( $value );" ); // No harm here.
 						break;
 					}
 
@@ -125,13 +121,10 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff
 			return;
 		}
 
-
-	}//end process()
+	} // end process()
 
 
 	public function confused( $phpcsFile, $stackPtr ) {
 		$phpcsFile->addWarning( 'Detected changing of cron_schedules, but could not detect the interval value.', $stackPtr, 'ChangeDetected' );
 	}
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -73,7 +73,6 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -1,13 +1,20 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag Database direct queries.
  *
- * PHP version 5
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  */
 class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_Sniff {
 

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Flag Database direct queries
+ * Flag Database direct queries.
  *
  * PHP version 5
  *
@@ -9,8 +9,7 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  */
-class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * List of custom cache get functions.
@@ -67,13 +66,12 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_VARIABLE,
-			   );
+			T_VARIABLE,
+		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -85,8 +83,7 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 	 *
 	 * @return int|void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		if ( ! isset( self::$methods['all'] ) ) {
 			self::$methods['all'] = array_merge( self::$methods['cachable'], self::$methods['noncachable'] );
 
@@ -108,49 +105,51 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 
 		$tokens = $phpcsFile->getTokens();
 
-		// Check for $wpdb variable
-		if ( $tokens[$stackPtr]['content'] != '$wpdb' )
+		// Check for $wpdb variable.
+		if ( '$wpdb' !== $tokens[ $stackPtr ]['content'] ) {
 			return;
+		}
 
-		$is_object_call = $phpcsFile->findNext( array( T_OBJECT_OPERATOR ), $stackPtr + 1, null, null, null, true );
-		if ( false == $is_object_call )
-			return; // This is not a call to the wpdb object
+		$is_object_call = $phpcsFile->findNext( array( T_OBJECT_OPERATOR ), ( $stackPtr + 1 ), null, null, null, true );
+		if ( false === $is_object_call ) {
+			return; // This is not a call to the wpdb object.
+		}
 
-		$methodPtr = $phpcsFile->findNext( array( T_WHITESPACE ), $is_object_call + 1, null, true, null, true );
-		$method = $tokens[ $methodPtr ]['content'];
+		$methodPtr = $phpcsFile->findNext( array( T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
+		$method    = $tokens[ $methodPtr ]['content'];
 
 		if ( ! isset( self::$methods['all'][ $method ] ) ) {
 			return;
 		}
 
-		$endOfStatement = $phpcsFile->findNext( array( T_SEMICOLON ), $stackPtr + 1, null, null, null, true );
+		$endOfStatement   = $phpcsFile->findNext( array( T_SEMICOLON ), ( $stackPtr + 1 ), null, null, null, true );
 		$endOfLineComment = '';
-		for ( $i = $endOfStatement + 1; $i < count( $tokens ); $i++ ) {
+		$tokenCount       = count( $tokens );
+		for ( $i = ( $endOfStatement + 1 ); $i < $tokenCount; $i++ ) {
 
-			if ( $tokens[$i]['line'] !== $tokens[$endOfStatement]['line'] ) {
+			if ( $tokens[ $i ]['line'] !== $tokens[ $endOfStatement ]['line'] ) {
 				break;
 			}
 
-			if ( $tokens[$i]['code'] === T_COMMENT ) {
-				$endOfLineComment .= $tokens[$i]['content'];
+			if ( T_COMMENT === $tokens[ $i ]['code'] ) {
+				$endOfLineComment .= $tokens[ $i ]['content'];
 			}
-
 		}
 
 		$whitelisted_db_call = false;
-		if ( preg_match( '/db call\W*(ok|pass|clear|whitelist)/i', $endOfLineComment, $matches ) ) {
+		if ( preg_match( '/db call\W*(?:ok|pass|clear|whitelist)/i', $endOfLineComment ) ) {
 			$whitelisted_db_call = true;
 		}
 
-		// Check for Database Schema Changes
+		// Check for Database Schema Changes.
 		$_pos = $stackPtr;
-		while ( $_pos = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), $_pos + 1, $endOfStatement, null, null, true ) ) {
-			if ( preg_match( '#\b(ALTER|CREATE|DROP)\b#i', $tokens[$_pos]['content'], $matches ) > 0 ) {
+		while ( $_pos = $phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), ( $_pos + 1 ), $endOfStatement, null, null, true ) ) {
+			if ( preg_match( '#\b(?:ALTER|CREATE|DROP)\b#i', $tokens[ $_pos ]['content'] ) > 0 ) {
 				$phpcsFile->addError( 'Attempting a database schema change is highly discouraged.', $_pos, 'SchemaChange' );
 			}
 		}
 
-		// Flag instance if not whitelisted
+		// Flag instance if not whitelisted.
 		if ( ! $whitelisted_db_call ) {
 			$phpcsFile->addWarning( 'Usage of a direct database call is discouraged.', $stackPtr, 'DirectQuery' );
 		}
@@ -160,27 +159,26 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 		}
 
 		$whitelisted_cache = false;
-		$cached = $wp_cache_get = false;
-		if ( preg_match( '/cache\s+(ok|pass|clear|whitelist)/i', $endOfLineComment, $matches ) ) {
+		$cached            = $wp_cache_get = false;
+		if ( preg_match( '/cache\s+(?:ok|pass|clear|whitelist)/i', $endOfLineComment ) ) {
 			$whitelisted_cache = true;
 		}
-		if ( ! $whitelisted_cache && ! empty( $tokens[$stackPtr]['conditions'] ) ) {
+		if ( ! $whitelisted_cache && ! empty( $tokens[ $stackPtr ]['conditions'] ) ) {
 			$scope_function = $phpcsFile->getCondition( $stackPtr, T_FUNCTION );
 
 			if ( $scope_function ) {
-				$scopeStart = $tokens[$scope_function]['scope_opener'];
-				$scopeEnd = $tokens[$scope_function]['scope_closer'];
+				$scopeStart = $tokens[ $scope_function ]['scope_opener'];
+				$scopeEnd   = $tokens[ $scope_function ]['scope_closer'];
 
-				for ( $i = $scopeStart + 1; $i < $scopeEnd; $i++ ) {
+				for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
 					if ( T_STRING === $tokens[ $i ]['code'] ) {
 
 						if ( isset( WordPress_Sniff::$cacheDeleteFunctions[ $tokens[ $i ]['content'] ] ) ) {
 
-							if ( in_array( $method, array( 'query', 'update', 'replace', 'delete' ) ) ) {
+							if ( in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
 								$cached = true;
 								break;
 							}
-
 						} elseif ( isset( WordPress_Sniff::$cacheGetFunctions[ $tokens[ $i ]['content'] ] ) ) {
 
 							$wp_cache_get = true;
@@ -204,6 +202,6 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 
 		return $endOfStatement;
 
-	}//end process()
+	} // end process()
 
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -9,8 +9,7 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  */
-class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
-{
+class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 
 	/**
 	 * A list of forbidden functions with their alternatives.
@@ -21,32 +20,32 @@ class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_
 	 * @var array(string => string|null)
 	 */
 	public $forbiddenFunctions = array(
-										'file_put_contents' => null,
-										'fwrite'            => null,
-										'fputcsv'           => null,
-										'fputs'             => null,
-										'ftruncate'         => null,
-										'link'              => null,
-										'symlink'           => null,
-										'mkdir'             => null,
-										'rename'            => null,
-										'rmdir'             => null,
-										'tempnam'           => null,
-										'touch'             => null,
-										'unlink'            => null,
-										'is_writable'       => null,
-										'is_writeable'      => null,
-										'lchgrp'            => null,
-										'lchown'            => null,
-										'fputcsv'           => null,
-										'delete'            => null,
-										'chmod'             => null,
-										'chown'             => null,
-										'chgrp'             => null,
-										'chmod'             => null,
-										'chmod'             => null,
-										'flock'             => null,
-									);
+		'file_put_contents' => null,
+		'fwrite'            => null,
+		'fputcsv'           => null,
+		'fputs'             => null,
+		'ftruncate'         => null,
+		'link'              => null,
+		'symlink'           => null,
+		'mkdir'             => null,
+		'rename'            => null,
+		'rmdir'             => null,
+		'tempnam'           => null,
+		'touch'             => null,
+		'unlink'            => null,
+		'is_writable'       => null,
+		'is_writeable'      => null,
+		'lchgrp'            => null,
+		'lchown'            => null,
+		'fputcsv'           => null,
+		'delete'            => null,
+		'chmod'             => null,
+		'chown'             => null,
+		'chgrp'             => null,
+		'chmod'             => null,
+		'chmod'             => null,
+		'flock'             => null,
+	);
 
 	/**
 	 * If true, an error will be thrown; otherwise a warning.
@@ -66,18 +65,16 @@ class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_
 	 *
 	 * @return void
 	 */
-	protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null )
-	{
-		$data  = array($function);
+	protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null ) {
+		$data  = array( $function );
 		$error = 'Filesystem writes are forbidden, you should not be using %s()';
 
-		if ( $this->error === true ) {
+		if ( true === $this->error ) {
 			$phpcsFile->addError( $error, $stackPtr, 'FileWriteDetected', $data );
 		} else {
 			$phpcsFile->addWarning( $error, $stackPtr, 'FileWriteDetected', $data );
 		}
 
-	}//end addError()
+	} // end addError()
 
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -1,13 +1,20 @@
 <?php
 /**
- * Disallow Filesystem writes
+ * WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Disallow Filesystem writes.
+ *
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  */
 class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -20,7 +20,7 @@ class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_Sniffs_Arrays_Arra
 				'keys' => array(
 					'orderby',
 				),
-			)
+			),
 		);
 	}
 
@@ -28,11 +28,11 @@ class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_Sniffs_Arrays_Arra
 	 * Callback to process each confirmed key, to check value
 	 * This must be extended to add the logic to check assignment value
 	 *
-	 * @param  string   $key   Array index / key
-	 * @param  mixed    $val   Assigned value
-	 * @param  int      $line  Token line
-	 * @param  array    $group Group definition
-	 * @return mixed           FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process()
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		if ( 'rand' === strtolower( $val ) ) {
@@ -41,5 +41,4 @@ class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_Sniffs_Arrays_Arra
 			return false;
 		}
 	}
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -40,5 +40,6 @@ class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_Sniffs_Arrays_Arra
 		} else {
 			return false;
 		}
-	}
+	} // end callback()
+
 } // end class

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -1,8 +1,17 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag using orderby => rand.
  *
- * @link https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+ * @link     https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  */

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -1,6 +1,14 @@
 <?php
 /**
- * Warn about __FILE__ for page registration
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Warn about __FILE__ for page registration.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -38,7 +38,6 @@ class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff 
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -6,8 +6,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff {
 
 	public $add_menu_functions = array(
 		'add_menu_page',
@@ -25,20 +24,19 @@ class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff
 		'add_users_page',
 		'add_management_page',
 		'add_options_page',
-		);
+	);
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_STRING,
-			   );
+			T_STRING,
+		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -50,24 +48,23 @@ class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[$stackPtr];
+		$token  = $tokens[ $stackPtr ];
 
-		if ( ! in_array( $token['content'], $this->add_menu_functions ) ) {
+		if ( ! in_array( $token['content'], $this->add_menu_functions, true ) ) {
 			return;
 		}
 
 		$opening = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $stackPtr );
-		$closing = $tokens[$opening]['parenthesis_closer'];
+		$closing = $tokens[ $opening ]['parenthesis_closer'];
 
 		$string = $phpcsFile->findNext( T_FILE, $opening, $closing, null, '__FILE__', true );
 
 		if ( $string ) {
 			$phpcsFile->addError( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
 		}
-		
-	}//end process()
 
-}//end class
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -6,8 +6,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
-{
+class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -65,5 +65,6 @@ class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_Arr
 				return 'Detected high pagination limit, `%s` is set to `%s`';
 			}
 		}
-	}
+	} // end callback()
+
 } // end class

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Flag returning high or infinite posts_per_page
+ * Flag returning high or infinite posts_per_page.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -10,15 +10,15 @@ class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_Arr
 {
 
 	/**
-	 * Groups of variables to restrict
+	 * Groups of variables to restrict.
 	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
 	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
+	 * 		'type'          => 'error' | 'warning',
+	 * 		'message'       => 'Dont use this one please!',
+	 * 		'variables'     => array( '$val', '$var' ),
+	 * 		'object_vars'   => array( '$foo->bar', .. ),
 	 * 		'array_members' => array( '$foo['bar']', .. ),
 	 * 	)
 	 * )
@@ -33,39 +33,37 @@ class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_Arr
 					'posts_per_page',
 					'nopaging',
 					'numberposts',
-					),
-				)
-			);
+				),
+			),
+		);
 	}
 
 	/**
-	 * Callback to process each confirmed key, to check value
-	 * This must be extended to add the logic to check assignment value
-	 * 
-	 * @param  string   $key   Array index / key
-	 * @param  mixed    $val   Assigned value
-	 * @param  int      $line  Token line
-	 * @param  array    $group Group definition
-	 * @return mixed           FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process()
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		$key = strtolower( $key );
 		if (
-			( $key == 'nopaging' && ( $val == 'true' || $val == 1 ) )
+			( 'nopaging' === $key && ( 'true' === $val || 1 === $val ) )
 			||
-			( in_array( $key, array( 'numberposts', 'posts_per_page' ) ) && $val == '-1' )
+			( in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' == $val )
 			) {
+
 			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
-		}
-		elseif (
-			in_array( $key, array( 'posts_per_page', 'numberposts' ) )
-			) {
+
+		} elseif ( in_array( $key, array( 'posts_per_page', 'numberposts' ), true ) ) {
 
 			if ( $val > 100 ) {
 				return 'Detected high pagination limit, `%s` is set to `%s`';
 			}
 		}
 	}
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag returning high or infinite posts_per_page.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -346,5 +346,6 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 		);
-	}
+	} // end getGroups()
+
 } // end class

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -6,8 +6,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Functions_FunctionRestrictionsSniff
-{
+class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Functions_FunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Restricts usage of some functions in VIP context.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Restricts usage of some functions in VIP context
+ * Restricts usage of some functions in VIP context.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -10,12 +10,12 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 {
 
 	/**
-	 * Groups of functions to restrict
+	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
 	 * 	'lambda' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Use anonymous functions instead please!',
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
 	 * 		'functions' => array( 'eval', 'create_function' ),
 	 * 	)
 	 * )
@@ -29,27 +29,27 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 				'type'      => 'error',
 				'message'   => '%s is not something you should ever need to do in a VIP theme context. Instead use an API (XML-RPC, REST) to interact with other sites if needed.',
 				'functions' => array( 'switch_to_blog' ),
-				),
+			),
 
 			'create_function' => array(
-				'type' => 'warning',
-				'message' => '%s is discouraged, please use Anonymous functions instead.',
+				'type'      => 'warning',
+				'message'   => '%s is discouraged, please use Anonymous functions instead.',
 				'functions' => array(
 					'create_function',
 				),
 			),
 
 			'eval' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use Anonymous functions instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use Anonymous functions instead.',
 				'functions' => array(
 					'eval',
 				),
 			),
 
 			'file_get_contents' => array(
-				'type' => 'warning',
-				'message' => '%s is highly discouraged, please use wpcom_vip_file_get_contents() instead.',
+				'type'      => 'warning',
+				'message'   => '%s is highly discouraged, please use wpcom_vip_file_get_contents() instead.',
 				'functions' => array(
 					'file_get_contents',
 					'vip_wp_file_get_contents',
@@ -57,8 +57,8 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'get_term_link' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_get_term_link() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_get_term_link() instead.',
 				'functions' => array(
 					'get_term_link',
 					'get_tag_link',
@@ -67,24 +67,24 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'get_page_by_path' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_get_page_by_path() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_get_page_by_path() instead.',
 				'functions' => array(
 					'get_page_by_path',
 				),
 			),
 
 			'get_page_by_title' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_get_page_by_title() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_get_page_by_title() instead.',
 				'functions' => array(
 					'get_page_by_title',
 				),
 			),
 
 			'get_term_by' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_get_term_by() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_get_term_by() instead.',
 				'functions' => array(
 					'get_term_by',
 					'get_cat_ID',
@@ -92,16 +92,16 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'get_category_by_slug' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_get_category_by_slug() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_get_category_by_slug() instead.',
 				'functions' => array(
 					'get_category_by_slug',
 				),
 			),
 
 			'url_to_postid' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_url_to_postid() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_url_to_postid() instead.',
 				'functions' => array(
 					'url_to_postid',
 					'url_to_post_id',
@@ -109,68 +109,68 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'attachment_url_to_postid' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use wpcom_vip_attachment_url_to_postid() instead.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use wpcom_vip_attachment_url_to_postid() instead.',
 				'functions' => array(
 					'attachment_url_to_postid',
 				),
 			),
 
 			'wp_remote_get' => array(
-				'type' => 'warning',
-				'message' => '%s is highly discouraged, please use vip_safe_wp_remote_get() instead.',
+				'type'      => 'warning',
+				'message'   => '%s is highly discouraged, please use vip_safe_wp_remote_get() instead.',
 				'functions' => array(
 					'wp_remote_get',
-					),
 				),
+			),
 
 			'curl' => array(
-				'type' => 'warning',
-				'message' => 'Using cURL functions is highly discouraged within VIP context. Check (Fetching Remote Data) on VIP Documentation.',
+				'type'      => 'warning',
+				'message'   => 'Using cURL functions is highly discouraged within VIP context. Check (Fetching Remote Data) on VIP Documentation.',
 				'functions' => array(
 					'curl_*',
-					),
 				),
+			),
 
 			'extract' => array(
-				'type' => 'warning',
-				'message' => '%s() usage is highly discouraged, due to the complexity and unintended issues it might cause.',
+				'type'      => 'warning',
+				'message'   => '%s() usage is highly discouraged, due to the complexity and unintended issues it might cause.',
 				'functions' => array(
 					'extract',
-					),
 				),
+			),
 
 			'custom_role' => array(
-				'type' => 'error',
-				'message' => 'Use wpcom_vip_add_role() instead of add_role()',
+				'type'      => 'error',
+				'message'   => 'Use wpcom_vip_add_role() instead of add_role()',
 				'functions' => array(
 					'add_role',
-					),
 				),
+			),
 
 			'cookies' => array(
-				'type' => 'warning',
-				'message' => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
+				'type'      => 'warning',
+				'message'   => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
 				'functions' => array(
 					'setcookie',
-					),
 				),
+			),
 
 			'user_meta' => array(
-				'type' => 'error',
-				'message' => '%s() usage is highly discouraged, check VIP documentation on "Working with wp_users"',
+				'type'      => 'error',
+				'message'   => '%s() usage is highly discouraged, check VIP documentation on "Working with wp_users"',
 				'functions' => array(
 					'get_user_meta',
 					'update_user_meta',
 					'delete_user_meta',
 					'add_user_meta',
-					),
 				),
+			),
 
 			// @todo Introduce a sniff specific to get_posts() that checks for suppress_filters=>false being supplied.
 			'get_posts' => array(
-				'type' => 'warning',
-				'message' => '%s is discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query, unless you explicitly supply suppress_filters => false.',
+				'type'      => 'warning',
+				'message'   => '%s is discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query, unless you explicitly supply suppress_filters => false.',
 				'functions' => array(
 					'get_posts',
 					'wp_get_recent_posts',
@@ -179,8 +179,8 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'wp_get_post_terms' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged due to not being cached; please use get_the_terms() along with wp_list_pluck() to extract the IDs.',
+				'type'      => 'error',
+				'message'   => '%s is highly discouraged due to not being cached; please use get_the_terms() along with wp_list_pluck() to extract the IDs.',
 				'functions' => array(
 					'wp_get_post_terms',
 					'wp_get_post_categories',
@@ -190,32 +190,32 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'term_exists' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged due to not being cached; please use wpcom_vip_term_exists() instead.',
+				'type'      => 'error',
+				'message'   => '%s is highly discouraged due to not being cached; please use wpcom_vip_term_exists() instead.',
 				'functions' => array(
 					'term_exists',
 				),
 			),
 
 			'count_user_posts' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged due to not being cached; please use wpcom_vip_count_user_posts() instead.',
+				'type'      => 'error',
+				'message'   => '%s is highly discouraged due to not being cached; please use wpcom_vip_count_user_posts() instead.',
 				'functions' => array(
 					'count_user_posts',
 				),
 			),
 
 			'wp_old_slug_redirect' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged due to not being cached; please use wpcom_vip_old_slug_redirect() instead.',
+				'type'      => 'error',
+				'message'   => '%s is highly discouraged due to not being cached; please use wpcom_vip_old_slug_redirect() instead.',
 				'functions' => array(
 					'wp_old_slug_redirect',
 				),
 			),
 
 			'get_adjacent_post' => array(
-				'type' => 'error',
-				'message' => '%s is highly discouraged due to not being cached; please use wpcom_vip_get_adjacent_post() instead.',
+				'type'      => 'error',
+				'message'   => '%s is highly discouraged due to not being cached; please use wpcom_vip_get_adjacent_post() instead.',
 				'functions' => array(
 					'get_adjacent_post',
 					'get_previous_post',
@@ -226,24 +226,24 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'parse_url' => array(
-				'type' => 'warning',
-				'message' => '%s is discouraged due to a lack for backwards-compatibility in PHP versions; please use wp_parse_url() instead.',
+				'type'      => 'warning',
+				'message'   => '%s is discouraged due to a lack for backwards-compatibility in PHP versions; please use wp_parse_url() instead.',
 				'functions' => array(
 					'parse_url',
 				),
 			),
 
 			'get_intermediate_image_sizes' => array(
-				'type' => 'error',
-				'message' => 'Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.',
+				'type'      => 'error',
+				'message'   => 'Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.',
 				'functions' => array(
 					'get_intermediate_image_sizes',
 				),
 			),
 
 			'serialize' => array(
-				'type' => 'warning',
-				'message' => '%s Serialized data has <a href=\'https://www.owasp.org/index.php/PHP_Object_Injection\'>known vulnerability problems</a> with Object Injection. JSON is generally a better approach for serializing data.',
+				'type'      => 'warning',
+				'message'   => '%s Serialized data has <a href=\'https://www.owasp.org/index.php/PHP_Object_Injection\'>known vulnerability problems</a> with Object Injection. JSON is generally a better approach for serializing data.',
 				'functions' => array(
 					'serialize',
 					'unserialize',
@@ -251,8 +251,8 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'error_log' => array(
-				'type' => 'error',
-				'message' => '%s Debug code is not allowed on VIP Production',
+				'type'      => 'error',
+				'message'   => '%s Debug code is not allowed on VIP Production',
 				'functions' => array(
 					'error_log',
 					'var_dump',
@@ -263,64 +263,64 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'wp_redirect' => array(
-				'type' => 'warning',
-				'message' => '%s Using wp_safe_redirect(), along with the allowed_redirect_hosts filter, can help avoid any chances of malicious redirects within code. It’s also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
+				'type'     => 'warning',
+				'message'   => '%s Using wp_safe_redirect(), along with the allowed_redirect_hosts filter, can help avoid any chances of malicious redirects within code. It’s also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
 				'functions' => array(
 					'wp_redirect',
 				),
 			),
 
 			'wp_is_mobile' => array(
-				'type' => 'error',
-				'message' => '%s When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',
+				'type'      => 'error',
+				'message'   => '%s When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',
 				'functions' => array(
 					'wp_is_mobile',
 				),
 			),
 
 			'urlencode' => array(
-				'type' => 'warning',
-				'message' => '%s urlencode should only be used when dealing with legacy applications rawurlencode should now de used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html',
+				'type'      => 'warning',
+				'message'   => '%s urlencode should only be used when dealing with legacy applications rawurlencode should now de used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html',
 				'functions' => array(
 					'rawurlencode',
 				),
 			),
 
 			'ereg' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use preg_match() instead. See http://php.net/manual/en/function.ereg.php',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use preg_match() instead. See http://php.net/manual/en/function.ereg.php',
 				'functions' => array(
 					'ereg',
 				),
 			),
 
 			'eregi' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use preg_match() with i modifier instead. See http://php.net/manual/en/function.eregi.php',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use preg_match() with i modifier instead. See http://php.net/manual/en/function.eregi.php',
 				'functions' => array(
 					'eregi',
 				),
 			),
 
 			'ereg_replace' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use preg_replace() instead. See http://php.net/manual/en/function.ereg-replace.php',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use preg_replace() instead. See http://php.net/manual/en/function.ereg-replace.php',
 				'functions' => array(
 					'ereg_replace',
 				),
 			),
 
 			'split' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, please use explode() or preg_split() instead. See http://php.net/manual/en/function.split.php',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, please use explode() or preg_split() instead. See http://php.net/manual/en/function.split.php',
 				'functions' => array(
 					'split',
 				),
 			),
 
 			'runtime_configuration' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited, changing configuration at runtime is not allowed on VIP Production.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited, changing configuration at runtime is not allowed on VIP Production.',
 				'functions' => array(
 					'dl',
 					'error_reporting',
@@ -337,8 +337,8 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 			),
 
 			'prevent_path_disclosure' => array(
-				'type' => 'error',
-				'message' => '%s is prohibited as it can lead to full path disclosure.',
+				'type'      => 'error',
+				'message'   => '%s is prohibited as it can lead to full path disclosure.',
 				'functions' => array(
 					'error_reporting',
 					'phpinfo',
@@ -347,4 +347,4 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Fun
 
 		);
 	}
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Restricts usage of some variables in VIP context.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Restricts usage of some variables in VIP context
+ * Restricts usage of some variables in VIP context.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_Sniffs_Variables_VariableRestrictionsSniff
-{
+class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_Sniffs_Variables_VariableRestrictionsSniff {
 
 	/**
-	 * Groups of variables to restrict
+	 * Groups of variables to restrict.
 	 *
 	 * Example: groups => array(
 	 * 	'wpdb' => array(
@@ -27,26 +26,24 @@ class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_Sniffs_Var
 	public function getGroups() {
 		return array(
 			'user_meta' => array(
-				'type' => 'error',
-				'message' => 'Usage of users/usermeta tables is highly discouraged in VIP context, For storing user additional user metadata, you should look at User Attributes.',
+				'type'        => 'error',
+				'message'     => 'Usage of users/usermeta tables is highly discouraged in VIP context, For storing user additional user metadata, you should look at User Attributes.',
 				'object_vars' => array(
 					'$wpdb->users',
 					'$wpdb->usermeta',
-					),
 				),
+			),
 			'cache_constraints' => array(
-				'type' => 'warning',
-				'message' => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
-				'variables' => array(
+				'type'          => 'warning',
+				'message'       => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
+				'variables'     => array(
 					'$_COOKIE',
 					),
 				'array_members' => array(
 					'$_SERVER[\'HTTP_USER_AGENT\']',
 					'$_SERVER[\'REMOTE_ADDR\']',
-					),
 				),
-			);
+			),
+		);
 	}
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -45,5 +45,6 @@ class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_Sniffs_Var
 				),
 			),
 		);
-	}
+	} // end getGroups()
+
 } // end class

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -1,13 +1,22 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_VIP_SessionFunctionsUsageSniff.
  *
  * Discourages the use of session functions.
  *
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @see  https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
  */
 class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -2,57 +2,54 @@
 /**
  * WordPress_Sniffs_VIP_SessionFunctionsUsageSniff.
  *
- * Discourages the use of session functions
+ * Discourages the use of session functions.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  * @see  https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
  */
-class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
-{
+class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 
-    /**
-     * A list of forbidden functions with their alternatives.
-     *
-     * The value is NULL if no alternative exists. IE, the
-     * function should just not be used.
-     *
-     * @var array(string => string|null)
-     */
-    public $forbiddenFunctions = array(
-                                    'session_cache_expire'      => null,
-                                    'session_cache_limiter'     => null,
-                                    'session_commit'            => null,
-                                    'session_decode'            => null,
-                                    'session_destroy'           => null,
-                                    'session_encode'            => null,
-                                    'session_get_cookie_params' => null,
-                                    'session_id'                => null,
-                                    'session_is_registered'     => null,
-                                    'session_module_name'       => null,
-                                    'session_name'              => null,
-                                    'session_regenerate_id'     => null,
-                                    'session_register_shutdown' => null,
-                                    'session_register'          => null,
-                                    'session_save_path'         => null,
-                                    'session_set_cookie_params' => null,
-                                    'session_set_save_handler'  => null,
-                                    'session_start'             => null,
-                                    'session_status'            => null,
-                                    'session_unregister'        => null,
-                                    'session_unset'             => null,
-                                    'session_write_close'       => null,
-                                    );
+	/**
+	 * A list of forbidden functions with their alternatives.
+	 *
+	 * The value is NULL if no alternative exists. I.e. the
+	 * function should just not be used.
+	 *
+	 * @var array(string => string|null)
+	 */
+	public $forbiddenFunctions = array(
+		'session_cache_expire'      => null,
+		'session_cache_limiter'     => null,
+		'session_commit'            => null,
+		'session_decode'            => null,
+		'session_destroy'           => null,
+		'session_encode'            => null,
+		'session_get_cookie_params' => null,
+		'session_id'                => null,
+		'session_is_registered'     => null,
+		'session_module_name'       => null,
+		'session_name'              => null,
+		'session_regenerate_id'     => null,
+		'session_register_shutdown' => null,
+		'session_register'          => null,
+		'session_save_path'         => null,
+		'session_set_cookie_params' => null,
+		'session_set_save_handler'  => null,
+		'session_start'             => null,
+		'session_status'            => null,
+		'session_unregister'        => null,
+		'session_unset'             => null,
+		'session_write_close'       => null,
+	);
 
-    protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null )
-    {
-        $data  = array($function);
-        $error = 'The use of PHP session function %s() is prohibited.';
+	protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null ) {
+		$data  = array( $function );
+		$error = 'The use of PHP session function %s() is prohibited.';
 
-        $phpcsFile->addError( $error, $stackPtr, $function, $data );
+		$phpcsFile->addError( $error, $stackPtr, $function, $data );
 
-    }//end addError()
+	} // end addError()
 
-}//end class
-
+} // end class

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -10,45 +10,38 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
  */
-class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
-{
+class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 
 	/**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-               	T_VARIABLE,
-               );
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+		);
 
-    }//end register()
+	} // end register()
 
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @todo Allow T_CONSTANT_ENCAPSED_STRING?
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     *
-     * @todo Allow T_CONSTANT_ENCAPSED_STRING?
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+		if ( '$_SESSION' === $tokens[ $stackPtr ]['content'] ) {
+			$phpcsFile->addError( 'Usage of $_SESSION variable is prohibited.', $stackPtr, 'SessionVarsProhibited' );
+		}
 
-        if ( $tokens[$stackPtr]['content'] == '$_SESSION' ) {
-        	$phpcsFile->addError( 'Usage of $_SESSION variable is prohibited.', $stackPtr, 'SessionVarsProhibited' );
-        }
+	} // end process()
 
-
-    }//end process()
-
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -1,14 +1,23 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_VIP_SessionVariableUsageSniff
  *
  * Discourages the use of the session variable.
  * Creating a session writes a file to the server and is unreliable in a multi-server environment.
  *
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/75
  */
 class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -57,5 +57,6 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_Arra
 		}
 
 		parent::process( $phpcsFile, $stackPtr );
-	}
+	} // end process()
+
 } // end class

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -1,24 +1,23 @@
 <?php
 /**
- * Flag slow queries
+ * Flag slow queries.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
-{
+class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
 
 	/**
-	 * Groups of variables to restrict
+	 * Groups of variables to restrict.
 	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
 	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
+	 * 		'type'          => 'error' | 'warning',
+	 * 		'message'       => 'Dont use this one please!',
+	 * 		'variables'     => array( '$val', '$var' ),
+	 * 		'object_vars'   => array( '$foo->bar', .. ),
 	 * 		'array_members' => array( '$foo['bar']', .. ),
 	 * 	)
 	 * )
@@ -28,16 +27,16 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_Arra
 	public function getGroups() {
 		return array(
 			'slow_db_query' => array(
-				'type' => 'warning',
+				'type'    => 'warning',
 				'message' => 'Detected usage of %s, possible slow query.',
-				'keys' => array(
+				'keys'    => array(
 					'tax_query',
 					'meta_query',
 					'meta_key',
 					'meta_value',
-					),
-				)
-			);
+				),
+			),
+		);
 	}
 
 	/**
@@ -59,4 +58,4 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_Arra
 
 		parent::process( $phpcsFile, $stackPtr );
 	}
-}//end class
+} // end class

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag slow queries.
  *
  * @category PHP

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -1,11 +1,20 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Flag any usage of super global input var ( _GET / _POST / etc. )
+ *
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/79
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/79
  */
 class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -21,7 +21,6 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -7,21 +7,19 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/79
  */
-class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
-{
+class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_VARIABLE,
-			   );
+			T_VARIABLE,
+		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -33,27 +31,27 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
 		$tokens = $phpcsFile->getTokens();
 
-		// Check for global input variable
-		if ( ! in_array( $tokens[ $stackPtr ]['content'], WordPress_Sniff::$input_superglobals ) ) {
+		// Check for global input variable.
+		if ( ! in_array( $tokens[ $stackPtr ]['content'], WordPress_Sniff::$input_superglobals, true ) ) {
 			return;
 		}
 
-		$varName = $tokens[$stackPtr]['content'];
+		$varName = $tokens[ $stackPtr ]['content'];
 
-		// If we're overriding a superglobal with an assignment, no need to test
+		// If we're overriding a superglobal with an assignment, no need to test.
 		if ( $this->is_assignment( $stackPtr ) ) {
 			return;
 		}
 
-		// Check for whitelisting comment
+		// Check for whitelisting comment.
 		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
 			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
-	}//end process()
 
-}//end class
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -9,27 +9,24 @@
  * @author   Shady Sharaf <shady@x-team.com>
  * @see  http://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
  */
-class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
-{
+class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 
-    /**
-     * A list of forbidden functions with their alternatives.
-     *
-     * The value is NULL if no alternative exists. IE, the
-     * function should just not be used.
-     *
-     * @var array(string => string|null)
-     */
-    public $forbiddenFunctions = array(
-                                    'date_default_timezone_set'      => null,
-                                    );
+	/**
+	 * A list of forbidden functions with their alternatives.
+	 *
+	 * The value is NULL if no alternative exists. IE, the
+	 * function should just not be used.
+	 *
+	 * @var array(string => string|null)
+	 */
+	public $forbiddenFunctions = array(
+		'date_default_timezone_set' => null,
+	);
 
-    protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null )
-    {
-        $error = 'Using date_default_timezone_set() and similar isn’t allowed, instead use WP internal timezone support.';
-        $phpcsFile->addError( $error, $stackPtr, $function );
+	protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null ) {
+		$error = 'Using date_default_timezone_set() and similar isn’t allowed, instead use WP internal timezone support.';
+		$phpcsFile->addError( $error, $stackPtr, $function );
 
-    }//end addError()
+	} // end addError()
 
-}//end class
-
+} // end class

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -1,13 +1,22 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_VIP_TimezoneChangeSniff.
  *
  * Disallow the changing of timezone
  *
+ * @link     http://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @see  http://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
  */
 class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
 

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -1,14 +1,20 @@
 <?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
 
 /**
  * Flag any non-validated/sanitized input ( _GET / _POST / etc. )
  *
- * PHP version 5
+ * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
- * @link     https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
  */
 class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff {
 

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -13,7 +13,8 @@
 class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff {
 
 	/**
-	 * Check for validation functions for a variable within its own parenthesis only
+	 * Check for validation functions for a variable within its own parenthesis only.
+	 *
 	 * @var boolean
 	 */
 	public $check_validation_in_scope_only = false;
@@ -88,7 +89,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 		$tokens = $phpcsFile->getTokens();
 		$superglobals = WordPress_Sniff::$input_superglobals;
 
-		// Handling string interpolation
+		// Handling string interpolation.
 		if ( T_DOUBLE_QUOTED_STRING === $tokens[ $stackPtr ]['code'] ) {
 			$interpolated_variables = array_map(
 				create_function( '$symbol', 'return "$" . $symbol;' ), // Replace with closure when 5.3 is minimum requirement for PHPCS.
@@ -102,11 +103,11 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 		}
 
 		// Check if this is a superglobal.
-		if ( ! in_array( $tokens[ $stackPtr ]['content'], $superglobals ) ) {
+		if ( ! in_array( $tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
 			return;
 		}
 
-		// If we're overriding a superglobal with an assignment, no need to test
+		// If we're overriding a superglobal with an assignment, no need to test.
 		if ( $this->is_assignment( $stackPtr ) ) {
 			return;
 		}
@@ -137,7 +138,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			return;
 		}
 
-		// Now look for sanitizing functions
+		// Now look for sanitizing functions.
 		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
 			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', array( $tokens[ $stackPtr ]['content'] ) );
 		}

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_Variables_GlobalVariablesSniff.
  *
  * Warns about usage of global variables used by WordPress

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -8,8 +8,7 @@
  * @package  WordPress_Coding_Standards
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff
-{
+class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 
 	public $globals = array(
 		'comment',
@@ -278,23 +277,23 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
-		$search = array(); // Array of globals to watch for
+		$search = array(); // Array of globals to watch for.
 
 		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
-			$bracketPtr = $phpcsFile->findNext( array( T_WHITESPACE ), $stackPtr + 1, null, true );
+			$bracketPtr = $phpcsFile->findNext( array( T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
 
 			if ( T_OPEN_SQUARE_BRACKET !== $tokens[ $bracketPtr ]['code'] ) {
 				return;
 			}
 
-			$varPtr = $phpcsFile->findNext( T_WHITESPACE, $bracketPtr + 1, $tokens[ $bracketPtr ]['bracket_closer'], true );
+			$varPtr   = $phpcsFile->findNext( T_WHITESPACE, ( $bracketPtr + 1 ), $tokens[ $bracketPtr ]['bracket_closer'], true );
 			$varToken = $tokens[ $varPtr ];
 
-			if ( ! in_array( trim( $varToken['content'], '\'"' ), $this->globals ) ) {
+			if ( ! in_array( trim( $varToken['content'], '\'"' ), $this->globals, true ) ) {
 				return;
 			}
 
-			$assignment = $phpcsFile->findNext( T_WHITESPACE, $tokens[ $bracketPtr ]['bracket_closer'] + 1, null, true );
+			$assignment = $phpcsFile->findNext( T_WHITESPACE, ( $tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
 
 			if ( $assignment && T_EQUAL === $tokens[ $assignment ]['code'] ) {
 				if ( ! $this->has_whitelist_comment( 'override', $assignment ) ) {
@@ -304,19 +303,19 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff
 			}
 
 			return;
-		}
-		elseif ( T_GLOBAL === $token['code'] ) {
-			$ptr = $stackPtr + 1;
+
+		} elseif ( T_GLOBAL === $token['code'] ) {
+			$ptr = ( $stackPtr + 1 );
 			while ( $ptr ) {
 				$ptr++;
 				$var = $tokens[ $ptr ];
 				if ( T_VARIABLE === $var['code'] ) {
 					$varname = substr( $var['content'], 1 );
-					if ( in_array( $varname, $this->globals ) ) {
+					if ( in_array( $varname, $this->globals, true ) ) {
 						$search[] = $varname;
 					}
 				}
-				// Halt the loop
+				// Halt the loop.
 				if ( T_SEMICOLON === $var['code'] ) {
 					$ptr = false;
 				}
@@ -325,10 +324,10 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff
 				return;
 			}
 
-			// Check for assignments to collected global vars
+			// Check for assignments to collected global vars.
 			foreach ( $tokens as $ptr => $token ) {
-				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search ) ) {
-					$next = $phpcsFile->findNext( array( T_WHITESPACE, T_COMMENT ), $ptr + 1, null, true, null, true );
+				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
+					$next = $phpcsFile->findNext( array( T_WHITESPACE, T_COMMENT ), ( $ptr + 1 ), null, true, null, true );
 					if ( T_EQUAL === $tokens[ $next ]['code'] ) {
 						if ( ! $this->has_whitelist_comment( 'override', $next ) ) {
 							$phpcsFile->addError( 'Overriding WordPress globals is prohibited', $ptr, 'OverrideProhibited' );

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -336,5 +336,6 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				}
 			}
 		}
-	}
-}
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Restricts usage of some variables.
  *
  * @category PHP

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -26,7 +26,6 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	 */
 	public static $groups = array();
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -62,7 +61,6 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	public function getGroups() {
 		return self::$groups;
 	}
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -168,5 +166,6 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 			$pattern
 		);
 		return $pattern;
-	}
+	} // end test_patterns()
+
 } // end class

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Restricts usage of some variables
+ * Restricts usage of some variables.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
-	 * Exclude groups
+	 * Exclude groups.
 	 *
 	 * Example: 'foo,bar'
-	 * 
-	 * @var string Comma-delimited group list 
+	 *
+	 * @var string Comma-delimited group list.
 	 */
 	public $exclude = '';
 
@@ -22,7 +21,7 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	 * Groups of variable data to check against.
 	 * Don't use this in extended classes, override getGroups() instead.
 	 * This is only used for Unit tests.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $groups = array();
@@ -33,20 +32,19 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
-				T_VARIABLE,
-				T_OBJECT_OPERATOR,
-				T_DOUBLE_COLON,
-				T_OPEN_SQUARE_BRACKET,
-				T_DOUBLE_QUOTED_STRING,
-			   );
+			T_VARIABLE,
+			T_OBJECT_OPERATOR,
+			T_DOUBLE_COLON,
+			T_OPEN_SQUARE_BRACKET,
+			T_DOUBLE_QUOTED_STRING,
+		);
 
-	}//end register()
+	} // end register()
 
 	/**
-	 * Groups of variables to restrict
+	 * Groups of variables to restrict.
 	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
@@ -75,59 +73,54 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
-		$tokens = $phpcsFile->getTokens();
-
-		$token = $tokens[$stackPtr];
-
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens  = $phpcsFile->getTokens();
+		$token   = $tokens[ $stackPtr ];
 		$exclude = explode( ',', $this->exclude );
-
-		$groups = $this->getGroups();
+		$groups  = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			return count( $tokens ) + 1;
+			return ( count( $tokens ) + 1 );
 		}
 
-		// Check if it is a function not a variable
-		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ) ) ) { // This only works for object vars and array members
-			$method = $phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
-			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, $method + 1, null, true );
-			if ( $tokens[$possible_parenthesis]['code'] == T_OPEN_PARENTHESIS ) {
+		// Check if it is a function not a variable.
+		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
+			$method               = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
+			if ( T_OPEN_PARENTHESIS === $tokens[ $possible_parenthesis ]['code'] ) {
 				return; // So .. it is a function after all !
 			}
 		}
 
 		foreach ( $groups as $groupName => $group ) {
-			
-			if ( in_array( $groupName, $exclude ) ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
 				continue;
 			}
 
 			$patterns = array();
 
-			// Simple variable
-			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING ) ) && ! empty( $group['variables'] ) ) {
+			// Simple variable.
+			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['variables'] ) ) {
 				$patterns = array_merge( $patterns, $group['variables'] );
-				$var = $token['content'];
-			}
-			// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar
-			elseif ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ) ) && ! empty( $group['object_vars'] ) ) {
+				$var      = $token['content'];
+
+			} elseif ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
+				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
 				$owner = $phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
 				$child = $phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
-				$var = implode( '', array( $tokens[$owner]['content'], $token['content'], $tokens[$child]['content'] ) );
-			}
-			// Array members
-			elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ) ) && ! empty( $group['array_members'] ) ) {
+				$var   = implode( '', array( $tokens[ $owner ]['content'], $token['content'], $tokens[ $child ]['content'] ) );
+
+			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
+				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 
-				$owner = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
-				$inside = $phpcsFile->getTokensAsString( $stackPtr, $token['bracket_closer'] - $stackPtr + 1 );
-				$var = implode( '', array( $tokens[$owner]['content'], $inside ) );
-			}
-			else {
+				$owner  = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
+				$inside = $phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+				$var    = implode( '', array( $tokens[ $owner ]['content'], $inside ) );
+			} else {
 				continue;
 			}
 
@@ -136,20 +129,18 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 			}
 
 			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
+			$pattern  = implode( '|', $patterns );
+			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) ? '\b' : '';
 
-			$pattern = implode( '|', $patterns );
-
-			$delim = ( $token['code'] != T_OPEN_SQUARE_BRACKET ) ? '\b' : '';
-
-			if ( $token['code'] == T_DOUBLE_QUOTED_STRING ) {
+			if ( T_DOUBLE_QUOTED_STRING === $token['code'] ) {
 				$var = $token['content'];
 			}
 
-			if ( preg_match( '#(' . $pattern . ')' . $delim .'#', $var, $match ) < 1 ) {
+			if ( preg_match( '#(' . $pattern . ')' . $delim . '#', $var, $match ) !== 1 ) {
 				continue;
 			}
 
-			if ( $group['type'] == 'warning' ) {
+			if ( 'warning' === $group['type'] ) {
 				$addWhat = array( $phpcsFile, 'addWarning' );
 			} else {
 				$addWhat = array( $phpcsFile, 'addError' );
@@ -157,27 +148,25 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 
 			call_user_func(
 				$addWhat,
-				$group['message'], 
-				$stackPtr, 
-				$groupName, 
+				$group['message'],
+				$stackPtr,
+				$groupName,
 				array( $var )
-				);
+			);
 
-			return; // Show one error only
+			return; // Show one error only.
 
 		}
 
-	}//end process()
-	
+	} // end process()
+
 	private function test_patterns( $pattern ) {
 		$pattern = preg_quote( $pattern, '#' );
 		$pattern = preg_replace(
 			array( '#\\\\\*#', '[\'"]' ),
-			array( '.*', '\'' ), 
+			array( '.*', '\'' ),
 			$pattern
-			);
+		);
 		return $pattern;
 	}
-
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -24,7 +24,6 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -8,48 +8,44 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Sniff {
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                T_CONSTANT_ENCAPSED_STRING,
-                T_DOUBLE_QUOTED_STRING,
-                T_INLINE_HTML,
-               );
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+			T_INLINE_HTML,
+		);
 
-    }//end register()
+	} // end register()
 
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $token  = $tokens[$stackPtr];
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
 
-        if ( preg_match( '#rel=[\'"]?stylesheet[\'"]?#', $token['content'], $matches ) > 0 ) {
-            $phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr, 'NonEnqueuedStylesheet' );
-        }
+		if ( preg_match( '#rel=[\'"]?stylesheet[\'"]?#', $token['content'] ) > 0 ) {
+			$phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr, 'NonEnqueuedStylesheet' );
+		}
 
-        if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'], $matches ) > 0 ) {
-            $phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr, 'NonEnqueuedScript' );
-        }
+		if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'] ) > 0 ) {
+			$phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr, 'NonEnqueuedScript' );
+		}
 
-    }//end process()
+	} // end process()
 
-
-}//end class
+} // end class

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -1,8 +1,16 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_WP_Enqueued_Resources_Sniff
  *
- * Makes sure scripts and styles are enqueued and not explicitly echo'd
+ * Makes sure scripts and styles are enqueued and not explicitly echo'd.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -1,8 +1,16 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * WordPress_Sniffs_WP_I18nSniff
  *
- * Makes sure internationalization functions are used properly
+ * Makes sure internationalization functions are used properly.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -48,9 +48,14 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		'_nx_noop'                       => 'noopnumber_context',
 	);
 
-	// These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
+	/**
+	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
+	 */
 	static $sprintf_placeholder_regex = '/(?:%%|(%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFos]))/';
-	// "Unordered" means there's no position specifier: '%s', not '%2$s'
+
+	/**
+	 * "Unordered" means there's no position specifier: '%s', not '%2$s'.
+	 */
 	static $unordered_sprintf_placeholder_regex = '/(?:%%|(?:%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX]))/';
 
 	/**
@@ -94,33 +99,33 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$phpcs_file->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $translation_function ) );
 		}
 
-		$func_open_paren_token = $phpcs_file->findNext( T_WHITESPACE, $stack_ptr + 1, null, true );
+		$func_open_paren_token = $phpcs_file->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
 		if ( ! $func_open_paren_token || T_OPEN_PARENTHESIS !== $tokens[ $func_open_paren_token ]['code'] ) {
 			 return;
 		}
 
 		$arguments_tokens = array();
-		$argument_tokens = array();
+		$argument_tokens  = array();
 
 		// Look at arguments.
-		for ( $i = $func_open_paren_token + 1; $i < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $i += 1 ) {
-			$this_token = $tokens[ $i ];
+		for ( $i = ( $func_open_paren_token + 1 ); $i < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $i += 1 ) {
+			$this_token                = $tokens[ $i ];
 			$this_token['token_index'] = $i;
 			if ( in_array( $this_token['code'], array( T_WHITESPACE, T_COMMENT ), true ) ) {
 				continue;
 			}
 			if ( T_COMMA === $this_token['code'] ) {
 				$arguments_tokens[] = $argument_tokens;
-				$argument_tokens = array();
+				$argument_tokens    = array();
 				continue;
 			}
 
 			// Merge consecutive single or double quoted strings (when they span multiple lines).
 			if ( T_CONSTANT_ENCAPSED_STRING === $this_token['code'] || T_DOUBLE_QUOTED_STRING === $this_token['code'] ) {
-				for ( $j = $i + 1; $j < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $j += 1 ) {
+				for ( $j = ( $i + 1 ); $j < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $j += 1 ) {
 					if ( $this_token['code'] === $tokens[ $j ]['code'] ) {
 						$this_token['content'] .= $tokens[ $j ]['content'];
-						$i = $j;
+						$i                      = $j;
 					} else {
 						break;
 					}
@@ -130,9 +135,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 			// Include everything up to and including the parenthesis_closer if this token has one.
 			if ( ! empty( $this_token['parenthesis_closer'] ) ) {
-				for ( $j = $i + 1; $j <= $this_token['parenthesis_closer']; $j += 1 ) {
+				for ( $j = ( $i + 1 ); $j <= $this_token['parenthesis_closer']; $j += 1 ) {
 					$tokens[ $j ]['token_index'] = $j;
-					$argument_tokens[] = $tokens[ $j ];
+					$argument_tokens[]           = $tokens[ $j ];
 				}
 				$i = $this_token['parenthesis_closer'];
 			}
@@ -198,15 +203,15 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	 * Check if supplied tokens represent a translation text string literal.
 	 *
 	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param array $context
+	 * @param array                $context
 	 * @return bool
 	 */
 	protected function check_argument_tokens( PHP_CodeSniffer_File $phpcs_file, $context ) {
 		$stack_ptr = $context['stack_ptr'];
-		$tokens = $context['tokens'];
-		$arg_name = $context['arg_name'];
-		$method = empty( $context['warning'] ) ? 'addError' : 'addWarning';
-		$content = $tokens[0]['content'];
+		$tokens    = $context['tokens'];
+		$arg_name  = $context['arg_name'];
+		$method    = empty( $context['warning'] ) ? 'addError' : 'addWarning';
+		$content   = $tokens[0]['content'];
 
 		if ( 0 === count( $tokens ) ) {
 			$code = 'MissingArg' . ucfirst( $arg_name );
@@ -225,7 +230,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			return false;
 		}
 
-		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ) ) ) {
+		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
 			$this->check_text( $phpcs_file, $context );
 		}
 
@@ -260,9 +265,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	/**
 	 * Check for inconsistencies between single and plural arguments.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param array $single_context
-	 * @param array $plural_context
+	 * @param PHP_CodeSniffer_File $phpcs_file     The file being scanned.
+	 * @param array                $single_context
+	 * @param array                $plural_context
 	 * @return void
 	 */
 	protected function compare_single_and_plural_arguments( PHP_CodeSniffer_File $phpcs_file, $stack_ptr, $single_context, $plural_context ) {
@@ -294,28 +299,28 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	}
 
 	/**
-	 * Check the string itself for problems
+	 * Check the string itself for problems.
 	 *
 	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param array $single_context
-	 * @param array $plural_context
+	 * @param array                $context
 	 * @return void
 	 */
 	protected function check_text( PHP_CodeSniffer_File $phpcs_file, $context ) {
-		$stack_ptr = $context['stack_ptr'];
-		$arg_name = $context['arg_name'];
-		$content = $context['tokens'][0]['content'];
+		$stack_ptr      = $context['stack_ptr'];
+		$arg_name       = $context['arg_name'];
+		$content        = $context['tokens'][0]['content'];
 		$fixable_method = empty( $context['warning'] ) ? 'addFixableError' : 'addFixableWarning';
 
 		// UnorderedPlaceholders: Check for multiple unordered placeholders.
 		preg_match_all( self::$unordered_sprintf_placeholder_regex, $content, $unordered_matches );
-		$unordered_matches = $unordered_matches[0];
+		$unordered_matches       = $unordered_matches[0];
+		$unordered_matches_count = count( $unordered_matches );
 
-		if ( count( $unordered_matches ) >= 2 ) {
+		if ( $unordered_matches_count >= 2 ) {
 			$code = 'UnorderedPlaceholders' . ucfirst( $arg_name );
 
 			$suggestions = array();
-			for ( $i = 0; $i < count( $unordered_matches ); $i++ ) {
+			for ( $i = 0; $i < $unordered_matches_count; $i++ ) {
 				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], ( $i + 1 ) . '$', 1, 0 );
 			}
 
@@ -335,7 +340,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			}
 		}
 
-		// NoEmptyStrings
+		// NoEmptyStrings.
 
 		// Strip placeholders and surrounding quotes.
 		$non_placeholder_content = trim( $content, "'" );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -349,5 +349,6 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		if ( empty( $non_placeholder_content ) ) {
 			$phpcs_file->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
 		}
-	}
+	} // end check_text()
+
 }

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * Sniff for prepared SQL.
  *
  * Makes sure that variables aren't directly interpolated into SQL statements.

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -232,5 +232,6 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 		}
 
 		return true;
-	}
+	} // is_wpdb_method_call()
+
 } // end class.

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -17,12 +17,12 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 	 * @var array
 	 */
 	protected static $methods = array(
-		'get_var' => true,
-		'get_col' => true,
-		'get_row' => true,
+		'get_var'     => true,
+		'get_col'     => true,
+		'get_row'     => true,
 		'get_results' => true,
-		'prepare' => true,
-		'query' => true,
+		'prepare'     => true,
+		'query'       => true,
 	);
 
 	/**
@@ -33,16 +33,16 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 	 * @var array
 	 */
 	protected $ignored_tokens = array(
-		T_OBJECT_OPERATOR => true,
-		T_OPEN_PARENTHESIS => true,
-		T_CLOSE_PARENTHESIS => true,
-		T_WHITESPACE => true,
-		T_STRING_CONCAT => true,
+		T_OBJECT_OPERATOR          => true,
+		T_OPEN_PARENTHESIS         => true,
+		T_CLOSE_PARENTHESIS        => true,
+		T_WHITESPACE               => true,
+		T_STRING_CONCAT            => true,
 		T_CONSTANT_ENCAPSED_STRING => true,
-		T_OPEN_SQUARE_BRACKET => true,
-		T_CLOSE_SQUARE_BRACKET => true,
-		T_COMMA => true,
-		T_LNUMBER => true,
+		T_OPEN_SQUARE_BRACKET      => true,
+		T_CLOSE_SQUARE_BRACKET     => true,
+		T_COMMA                    => true,
+		T_LNUMBER                  => true,
 	);
 
 	/**
@@ -130,7 +130,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 						'NotPrepared',
 						array(
 							$bad_variable,
-							$tokens[ $this->i ]['content']
+							$tokens[ $this->i ]['content'],
 						)
 					);
 				}
@@ -152,7 +152,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				) {
 
 					// Find the opening parenthesis.
-					$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, $this->i + 1, null, true, null, true );
+					$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, ( $this->i + 1 ), null, true, null, true );
 
 					if (
 						$opening_paren
@@ -163,7 +163,6 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 						$this->i = $this->tokens[ $opening_paren ]['parenthesis_closer'];
 						continue;
 					}
-
 				} elseif ( isset( self::$formattingFunctions[ $tokens[ $this->i ]['content'] ] ) ) {
 					continue;
 				}
@@ -199,16 +198,16 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 	protected function is_wpdb_method_call( $stackPtr ) {
 
 		// Check that this is a method call.
-		$is_object_call = $this->phpcsFile->findNext( array( T_OBJECT_OPERATOR ), $stackPtr + 1, null, null, null, true );
+		$is_object_call = $this->phpcsFile->findNext( array( T_OBJECT_OPERATOR ), ( $stackPtr + 1 ), null, null, null, true );
 		if ( false === $is_object_call ) {
 			return false;
 		}
 
-		$methodPtr = $this->phpcsFile->findNext( array( T_WHITESPACE ), $is_object_call + 1, null, true, null, true );
+		$methodPtr = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
 		$method = $this->tokens[ $methodPtr ]['content'];
 
 		// Find the opening parenthesis.
-		$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, $methodPtr + 1, null, true, null, true );
+		$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, ( $methodPtr + 1 ), null, true, null, true );
 
 		if ( ! $opening_paren ) {
 			return false;
@@ -234,5 +233,4 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 
 		return true;
 	}
-
 } // end class.

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Enforces spacing around casting of variables, based upon Squiz code
+ * Enforces spacing around casting of variables, based upon Squiz code.
  *
-* PHP version 5
+ * PHP version 5
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
@@ -27,65 +27,60 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeSniffer_Sniff{
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return PHP_CodeSniffer_Tokens::$castTokens;
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return PHP_CodeSniffer_Tokens::$castTokens;
 
-    }//end register()
+	} // end register()
 
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
 
-        $content  = $tokens[$stackPtr]['content'];
-        $expected = str_replace(' ', '', $content);
-        $expected = str_replace("\t", '', $expected);
+		$content  = $tokens[ $stackPtr ]['content'];
+		$expected = str_replace( ' ', '', $content );
+		$expected = str_replace( "\t", '', $expected );
 
-        if ($content !== $expected) {
-            $error = 'Cast statements must not contain whitespace; expected "%s" but found "%s"';
-            $data  = array(
-                      $expected,
-                      $content,
-                     );
-            $phpcsFile->addWarning($error, $stackPtr, 'ContainsWhiteSpace', $data);
-        }
+		if ( $content !== $expected ) {
+			$error = 'Cast statements must not contain whitespace; expected "%s" but found "%s"';
+			$data  = array(
+				$expected,
+				$content,
+			);
+			$phpcsFile->addWarning( $error, $stackPtr, 'ContainsWhiteSpace', $data );
+		}
 
-        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-            $error = 'No space before opening casting parenthesis is prohibited';
-            $phpcsFile->addWarning($error, $stackPtr, 'NoSpaceBeforeOpenParenthesis');
-        }
+		if ( T_WHITESPACE !== $tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+			$error = 'No space before opening casting parenthesis is prohibited';
+			$phpcsFile->addWarning( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+		}
 
-        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-            $error = 'No space after closing casting parenthesis is prohibited';
-            $phpcsFile->addWarning($error, $stackPtr, 'NoSpaceAfterCloseParenthesis');
-        }
-	}//end process()
+		if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+			$error = 'No space after closing casting parenthesis is prohibited';
+			$phpcsFile->addWarning( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+		}
+	} // end process()
 
-    /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
+	/**
+	 * If true, an error will be thrown; otherwise a warning.
+	 *
+	 * @var bool
+	 */
+	public $error = false;
 
-}//end class
-
-?>
+} // end class

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Enforces spacing around casting of variables, based upon Squiz code.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -39,7 +39,6 @@ class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeS
 
 	} // end register()
 
-
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Enforces spacing around logical operators and assignments, based upon Squiz code.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   John Godley <john@urbangiraffe.com>

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -63,7 +63,6 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 	 */
 	public $spaces_before_closure_open_paren = -1;
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -85,7 +84,6 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		);
 
 	} // end register()
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces spacing around logical operators and assignments, based upon Squiz code
+ * Enforces spacing around logical operators and assignments, based upon Squiz code.
  *
  * PHP version 5
  *
@@ -24,32 +24,33 @@
  */
 class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress_Sniff {
 
-    /**
-     * A list of tokenizers this sniff supports.
-     *
-     * @var array
-     */
-    public $supportedTokenizers = array( 'PHP' );
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array( 'PHP' );
 
-    /**
-     * Check for blank lines on start/end of control structures
-     * @var boolean
-     */
-    public $blank_line_check = false;
+	/**
+	 * Check for blank lines on start/end of control structures.
+	 *
+	 * @var boolean
+	 */
+	public $blank_line_check = false;
 
-    /**
-     * Check for blank lines after control structures.
-     *
-     * @var boolean
-     */
-    public $blank_line_after_check = true;
+	/**
+	 * Check for blank lines after control structures.
+	 *
+	 * @var boolean
+	 */
+	public $blank_line_after_check = true;
 
-    /**
-     * Require for space before T_COLON when using the alternative syntax for control structures
-     *
-     * @var string one of 'required', 'forbidden', optional'
-     */
-    public $space_before_colon = 'required';
+	/**
+	 * Require for space before T_COLON when using the alternative syntax for control structures.
+	 *
+	 * @var string one of 'required', 'forbidden', optional'
+	 */
+	public $space_before_colon = 'required';
 
 	/**
 	 * How many spaces should be between a T_CLOSURE and T_OPEN_PARENTHESIS.
@@ -62,481 +63,473 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 	 */
 	public $spaces_before_closure_open_paren = -1;
 
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                T_IF,
-                T_WHILE,
-                T_FOREACH,
-                T_FOR,
-                T_SWITCH,
-                T_DO,
-                T_ELSE,
-                T_ELSEIF,
-	            T_FUNCTION,
-	            T_CLOSURE,
-                T_USE,
-               );
-
-    }//end register()
-
-
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $this->blank_line_check       = (bool) $this->blank_line_check;
-        $this->blank_line_after_check = (bool) $this->blank_line_after_check;
-
-        $tokens = $phpcsFile->getTokens();
-
-        $this->init( $phpcsFile );
-
-        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
-            && ! ( $tokens[$stackPtr]['code'] === T_ELSE && $tokens[($stackPtr + 1)]['code'] === T_COLON )
-            && ! (
-                T_CLOSURE === $tokens[ $stackPtr ]['code']
-                && (
-                    0 === (int) $this->spaces_before_closure_open_paren
-                    || -1 === (int) $this->spaces_before_closure_open_paren
-                )
-            )
-        ) {
-            $error = 'Space after opening control structure is required';
-            if (isset($phpcsFile->fixer) === true) {
-                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterStructureOpen');
-                if ($fix === true) {
-                    $phpcsFile->fixer->beginChangeset();
-                    $phpcsFile->fixer->addContent($stackPtr, ' ');
-                    $phpcsFile->fixer->endChangeset();
-                }
-            } else {
-                $phpcsFile->addError($error, $stackPtr, 'NoSpaceAfterStructureOpen');
-            }
-        }
-
-        if ( isset( $tokens[ $stackPtr ]['scope_closer'] ) === false ) {
-
-            if ( T_USE === $tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
-                $scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, $stackPtr + 1 );
-                $scopeCloser = $tokens[ $scopeOpener ]['scope_closer'];
-            } else {
-                return;
-            }
-
-        } else {
-            $scopeOpener = $tokens[ $stackPtr ]['scope_opener'];
-            $scopeCloser = $tokens[ $stackPtr ]['scope_closer'];
-        }
-
-        // alternative syntax
-        if ( $tokens[$scopeOpener]['code'] === T_COLON ) {
-
-            if ( $this->space_before_colon === 'required') {
-
-                if ( $tokens[$scopeOpener - 1]['code'] !== T_WHITESPACE ) {
-                   $error = 'Space between opening control structure and T_COLON is required';
-
-                   if ( isset($phpcsFile->fixer) === true ) {
-                       $fix = $phpcsFile->addFixableError($error, $scopeOpener, 'NoSpaceBetweenStructureColon');
-
-                       if ($fix === true) {
-                           $phpcsFile->fixer->beginChangeset();
-                           $phpcsFile->fixer->addContentBefore($scopeOpener, ' ');
-                           $phpcsFile->fixer->endChangeset();
-                       }
-                   } else {
-                       $phpcsFile->addError($error, $stackPtr, 'NoSpaceBetweenStructureColon');
-                   }
-                }
-
-            } elseif ( $this->space_before_colon === 'forbidden' ) {
-
-                if ( $tokens[$scopeOpener - 1]['code'] === T_WHITESPACE ) {
-                    $error = 'Extra space between opening control structure and T_COLON found';
-
-                    if ( isset($phpcsFile->fixer) === true ) {
-                        $fix = $phpcsFile->addFixableError( $error, $scopeOpener - 1, 'SpaceBetweenStructureColon' );
-
-                        if ($fix === true) {
-                            $phpcsFile->fixer->beginChangeset();
-                            $phpcsFile->fixer->replaceToken( $scopeOpener - 1, '' );
-                            $phpcsFile->fixer->endChangeset();
-                        }
-                    } else {
-                        $phpcsFile->addError( $error, $stackPtr, 'SpaceBetweenStructureColon' );
-                    }
-                }
-            }
-        }
-
-        $parenthesisOpener = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-
-	    // If this is a function declaration.
-	    if ( $tokens[ $stackPtr ]['code'] === T_FUNCTION ) {
-
-		    if ( $tokens[ $parenthesisOpener ]['code'] === T_STRING ) {
-
-			    $function_name_ptr = $parenthesisOpener;
-
-		    } elseif ( $tokens[ $parenthesisOpener ]['code'] === T_BITWISE_AND ) {
-
-			    // This function returns by reference (function &function_name() {}).
-			    $function_name_ptr = $parenthesisOpener = $phpcsFile->findNext(
-				    PHP_CodeSniffer_Tokens::$emptyTokens,
-				    $parenthesisOpener + 1,
-				    null,
-				    true
-			    );
-		    }
-
-		    $parenthesisOpener = $phpcsFile->findNext(
-			    PHP_CodeSniffer_Tokens::$emptyTokens,
-			    $parenthesisOpener + 1,
-			    null,
-			    true
-		    );
-
-		    // Checking this: function my_function[*](...) {}
-		    if ( $parenthesisOpener !== $function_name_ptr + 1 ) {
-
-			    $error = 'Space between function name and opening parenthesis is prohibited.';
-			    $fix = $phpcsFile->addFixableError(
-				    $error,
-				    $stackPtr,
-				    'SpaceBeforeFunctionOpenParenthesis',
-				    $tokens[ $function_name_ptr + 1 ]['content']
-			    );
-
-			    if ( true === $fix ) {
-				    $phpcsFile->fixer->beginChangeset();
-				    $phpcsFile->fixer->replaceToken( $function_name_ptr + 1, '' );
-				    $phpcsFile->fixer->endChangeset();
-			    }
-		    }
-
-        } elseif ( T_CLOSURE === $tokens[ $stackPtr ]['code'] ) {
-
-            // Check if there is a use () statement.
-            if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
-
-                $usePtr = $phpcsFile->findNext(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
-                    $tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1,
-                    null,
-                    true,
-                    null,
-                    true
-                );
-
-                // If it is, we set that as the "scope opener".
-                if ( T_USE === $tokens[ $usePtr ]['code'] ) {
-                    $scopeOpener = $usePtr;
-                }
-            }
-        }
-
-        if (
-            T_COLON !== $tokens[ $parenthesisOpener ]['code']
-            && T_FUNCTION !== $tokens[ $stackPtr ]['code']
-        ) {
-
-            if (
-                T_CLOSURE === $tokens[ $stackPtr ]['code']
-                && 0 === (int) $this->spaces_before_closure_open_paren
-            ) {
-
-                if ( ($stackPtr + 1) !== $parenthesisOpener ) {
-                    // Checking this: function[*](...) {}.
-                    $error = 'Space before closure opening parenthesis is prohibited';
-                    $fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
-                    if ( $fix === true ) {
-                        $phpcsFile->fixer->beginChangeset();
-                        $phpcsFile->fixer->replaceToken( $stackPtr + 1, '' );
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                }
-
-            } elseif (
-                (
-                    T_CLOSURE !== $tokens[ $stackPtr ]['code']
-                    || 1 === (int) $this->spaces_before_closure_open_paren
-                )
-                && ($stackPtr + 1) === $parenthesisOpener
-            ) {
-
-                // Checking this: if[*](...) {}.
-                $error = 'No space before opening parenthesis is prohibited';
-                if ( isset( $phpcsFile->fixer ) === true ) {
-                    $fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
-                    if ( $fix === true ) {
-                        $phpcsFile->fixer->beginChangeset();
-                        $phpcsFile->fixer->addContent( $stackPtr, ' ' );
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                } else {
-                    $phpcsFile->addError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
-                }
-            }
-        }
-
-	    if (
-		    T_WHITESPACE === $tokens[ $stackPtr + 1 ]['code']
-		    && ' ' !== $tokens[ $stackPtr + 1 ]['content']
-	    ) {
-		    // Checking this: if [*](...) {}.
-		    $error = 'Expected exactly one space before opening parenthesis; "%s" found.';
-		    $fix = $phpcsFile->addFixableError(
-			    $error,
-			    $stackPtr,
-			    'ExtraSpaceBeforeOpenParenthesis',
-			    $tokens[ $stackPtr + 1 ]['content']
-		    );
-
-		    if ( true === $fix ) {
-			    $phpcsFile->fixer->beginChangeset();
-			    $phpcsFile->fixer->replaceToken( $stackPtr + 1, ' ' );
-			    $phpcsFile->fixer->endChangeset();
-		    }
-	    }
-
-        if ($tokens[($parenthesisOpener + 1)]['code'] !== T_WHITESPACE
-            && $tokens[($parenthesisOpener + 1)]['code'] !== T_CLOSE_PARENTHESIS
-        ) {
-            // Checking this: $value = my_function([*]...).
-            $error = 'No space after opening parenthesis is prohibited';
-            if (isset($phpcsFile->fixer) === true) {
-                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterOpenParenthesis');
-                if ($fix === true) {
-                    $phpcsFile->fixer->beginChangeset();
-                    $phpcsFile->fixer->addContent($parenthesisOpener, ' ');
-                    $phpcsFile->fixer->endChangeset();
-                }
-            } else {
-                $phpcsFile->addError($error, $stackPtr, 'NoSpaceAfterOpenParenthesis');
-            }
-        }
-
-        if ( isset($tokens[$parenthesisOpener]['parenthesis_closer']) === true ) {
-
-            $parenthesisCloser = $tokens[$parenthesisOpener]['parenthesis_closer'];
-
-	        if ( $tokens[($parenthesisOpener + 1)]['code'] !== T_CLOSE_PARENTHESIS ) {
-
-	            if ($tokens[($parenthesisCloser - 1)]['code'] !== T_WHITESPACE) {
-	                $error = 'No space before closing parenthesis is prohibited';
-	                if (isset($phpcsFile->fixer) === true) {
-	                    $fix = $phpcsFile->addFixableError($error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis');
-	                    if ($fix === true) {
-	                        $phpcsFile->fixer->beginChangeset();
-	                        $phpcsFile->fixer->addContentBefore($parenthesisCloser, ' ');
-	                        $phpcsFile->fixer->endChangeset();
-	                    }
-	                } else {
-	                    $phpcsFile->addError($error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis');
-	                }
-	            }
-
-		        if (
-			        $tokens[ $parenthesisCloser + 1 ]['code'] !== T_WHITESPACE
-		            && $tokens[ $scopeOpener ]['code'] !== T_COLON
-		        ) {
-			        $error = 'Space between opening control structure and closing parenthesis is required';
-
-			        if ( isset( $phpcsFile->fixer ) === true ) {
-				        $fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
-
-				        if ( $fix === true ) {
-					        $phpcsFile->fixer->beginChangeset();
-					        $phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
-					        $phpcsFile->fixer->endChangeset();
-				        }
-			        } else {
-				        $phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
-			        }
-		        }
-	        }
-
-            if (isset($tokens[$parenthesisOpener]['parenthesis_owner']) === true
-                && $tokens[$parenthesisCloser]['line'] !== $tokens[$scopeOpener]['line']
-            ) {
-                $error = 'Opening brace should be on the same line as the declaration';
-                if (isset($phpcsFile->fixer) === true) {
-                    $fix = $phpcsFile->addFixableError($error, $parenthesisOpener, 'OpenBraceNotSameLine');
-                    if ($fix === true) {
-                        $phpcsFile->fixer->beginChangeset();
-
-                        for ($i = ($parenthesisCloser + 1); $i < $scopeOpener; $i++) {
-                            $phpcsFile->fixer->replaceToken($i, '');
-                        }
-
-                        $phpcsFile->fixer->addContent($parenthesisCloser, ' ');
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                } else {
-                    $phpcsFile->addError($error, $parenthesisOpener, 'OpenBraceNotSameLine');
-                }//end if
-                return;
-
-            } elseif (
-		        T_WHITESPACE === $tokens[ $parenthesisCloser + 1 ]['code']
-		        && ' ' !== $tokens[ $parenthesisCloser + 1 ]['content']
-	        ) {
-
-		        // Checking this: if (...) [*]{}
-		        $error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
-		        $fix = $phpcsFile->addFixableError(
-			        $error,
-			        $stackPtr,
-			        'ExtraSpaceAfterCloseParenthesis',
-			        $tokens[ $parenthesisCloser + 1 ]['content']
-		        );
-
-		        if ( true === $fix ) {
-			        $phpcsFile->fixer->beginChangeset();
-			        $phpcsFile->fixer->replaceToken( $parenthesisCloser + 1, ' ' );
-			        $phpcsFile->fixer->endChangeset();
-		        }
-	        }
-        }//end if
-
-        if ($this->blank_line_check === true) {
-            $firstContent = $phpcsFile->findNext(T_WHITESPACE, ($scopeOpener + 1), null, true);
-            if ($tokens[$firstContent]['line'] > ($tokens[$scopeOpener]['line'] + 1)
-                && in_array($tokens[$firstContent]['code'], array(T_CLOSE_TAG, T_COMMENT)) === false
-            ) {
-                $error = 'Blank line found at start of control structure';
-                if (isset($phpcsFile->fixer) === true) {
-                    $fix = $phpcsFile->addFixableError($error, $scopeOpener, 'BlankLineAfterStart');
-                    if ($fix === true) {
-                        $phpcsFile->fixer->beginChangeset();
-
-                        for ($i = ($scopeOpener + 1); $i < $firstContent; $i++) {
-                            $phpcsFile->fixer->replaceToken($i, '');
-                        }
-
-                        $phpcsFile->fixer->addNewline($scopeOpener);
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                } else {
-                    $phpcsFile->addError($error, $scopeOpener, 'BlankLineAfterStart');
-                }
-            }
-
-            $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($scopeCloser - 1), null, true);
-            if ($tokens[$lastContent]['line'] !== ($tokens[$scopeCloser]['line'] - 1)) {
-                $errorToken = $scopeCloser;
-                for ($i = ($scopeCloser - 1); $i > $lastContent; $i--) {
-                    if ($tokens[$i]['line'] < $tokens[$scopeCloser]['line']
-                        && $tokens[$firstContent]['code'] !== T_OPEN_TAG
-                    ) {
-                        // TODO: Reporting error at empty line won't highlight it in IDE.
-                        $error = 'Blank line found at end of control structure';
-                        if (isset($phpcsFile->fixer) === true) {
-                            $fix = $phpcsFile->addFixableError($error, $i, 'BlankLineBeforeEnd');
-                            if ($fix === true) {
-                                $phpcsFile->fixer->beginChangeset();
-
-                                for ($j = ($lastContent + 1); $j < $scopeCloser; $j++) {
-                                    $phpcsFile->fixer->replaceToken($j, '');
-                                }
-
-                                $phpcsFile->fixer->addNewlineBefore($scopeCloser);
-                                $phpcsFile->fixer->endChangeset();
-                            }
-                        } else {
-                            $phpcsFile->addError($error, $i, 'BlankLineBeforeEnd');
-                        }//end if
-                        break;
-                    }//end if
-                }//end for
-            }//end if
-        }//end if
-
-        $trailingContent = $phpcsFile->findNext(T_WHITESPACE, ($scopeCloser + 1), null, true);
-        if ($tokens[$trailingContent]['code'] === T_ELSE) {
-            if ($tokens[$stackPtr]['code'] === T_IF) {
-                // IF with ELSE.
-                return;
-            }
-        }
-
-        if ($tokens[$trailingContent]['code'] === T_COMMENT) {
-            if ($tokens[$trailingContent]['line'] === $tokens[$scopeCloser]['line']) {
-                if (substr($tokens[$trailingContent]['content'], 0, 5) === '//end') {
-                    // There is an end comment, so we have to get the next piece
-                    // of content.
-                    $trailingContent = $phpcsFile->findNext(T_WHITESPACE, ($trailingContent + 1), null, true);
-                }
-            }
-        }
-
-        if ($tokens[$trailingContent]['code'] === T_BREAK) {
-            // If this BREAK is closing a CASE, we don't need the
-            // blank line after this control structure.
-            if (isset($tokens[$trailingContent]['scope_condition']) === true) {
-                $condition = $tokens[$trailingContent]['scope_condition'];
-                if ($tokens[$condition]['code'] === T_CASE || $tokens[$condition]['code'] === T_DEFAULT) {
-                    return;
-                }
-            }
-        }
-
-        if ($tokens[$trailingContent]['code'] === T_CLOSE_TAG) {
-            // At the end of the script or embedded code.
-            return;
-        }
-
-        if ($tokens[$trailingContent]['code'] === T_CLOSE_CURLY_BRACKET) {
-            // Another control structure's closing brace.
-            if (isset($tokens[$trailingContent]['scope_condition']) === true) {
-                $owner = $tokens[$trailingContent]['scope_condition'];
-                if ($tokens[$owner]['code'] === T_FUNCTION) {
-                    // The next content is the closing brace of a function
-                    // so normal function rules apply and we can ignore it.
-                    return;
-                }
-            }
-
-            if ($this->blank_line_after_check === true
-                && $tokens[$trailingContent]['line'] != ($tokens[$scopeCloser]['line'] + 1)
-            ) {
-                // TODO: Won't cover following case: "} echo 'OK';".
-                $error = 'Blank line found after control structure';
-                if (isset($phpcsFile->fixer) === true) {
-                    $fix = $phpcsFile->addFixableError($error, $scopeCloser, 'BlankLineAfterEnd');
-                    if ($fix === true) {
-                        $phpcsFile->fixer->beginChangeset();
-
-                        for ($i = ($scopeCloser + 1); $i < $trailingContent; $i++) {
-                            $phpcsFile->fixer->replaceToken($i, '');
-                        }
-
-                        // TODO: Instead a separate error should be triggered when content comes right after closing brace.
-                        $phpcsFile->fixer->addNewlineBefore($trailingContent);
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                } else {
-                    $phpcsFile->addError($error, $scopeCloser, 'BlankLineAfterEnd');
-                }
-            }
-        }//end if
-
-    }//end process()
-
-
-}//end class
-
-?>
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_IF,
+			T_WHILE,
+			T_FOREACH,
+			T_FOR,
+			T_SWITCH,
+			T_DO,
+			T_ELSE,
+			T_ELSEIF,
+			T_FUNCTION,
+			T_CLOSURE,
+			T_USE,
+		);
+
+	} // end register()
+
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$this->blank_line_check 	  = (bool) $this->blank_line_check;
+		$this->blank_line_after_check = (bool) $this->blank_line_after_check;
+
+		$tokens = $phpcsFile->getTokens();
+
+		$this->init( $phpcsFile );
+
+		if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1) ]['code']
+			&& ! ( T_ELSE === $tokens[ $stackPtr ]['code'] && T_COLON === $tokens[ ( $stackPtr + 1 ) ]['code'] )
+			&& ! (
+				T_CLOSURE === $tokens[ $stackPtr ]['code']
+				&& (
+					0 === (int) $this->spaces_before_closure_open_paren
+					|| -1 === (int) $this->spaces_before_closure_open_paren
+				)
+			)
+		) {
+			$error = 'Space after opening control structure is required';
+			if ( isset( $phpcsFile->fixer ) ) {
+				$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+					$phpcsFile->fixer->endChangeset();
+				}
+			} else {
+				$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+			}
+		}
+
+		if ( ! isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
+
+			if ( T_USE === $tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
+				$scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
+				$scopeCloser = $tokens[ $scopeOpener ]['scope_closer'];
+			} else {
+				return;
+			}
+		} else {
+			$scopeOpener = $tokens[ $stackPtr ]['scope_opener'];
+			$scopeCloser = $tokens[ $stackPtr ]['scope_closer'];
+		}
+
+		// Alternative syntax.
+		if ( T_COLON === $tokens[ $scopeOpener ]['code'] ) {
+
+			if ( 'required' === $this->space_before_colon ) {
+
+				if ( T_WHITESPACE !== $tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+					$error = 'Space between opening control structure and T_COLON is required';
+
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
+
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBetweenStructureColon' );
+					}
+				}
+			} elseif ( 'forbidden' === $this->space_before_colon ) {
+
+				if ( T_WHITESPACE === $tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+					$error = 'Extra space between opening control structure and T_COLON found';
+
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
+
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'SpaceBetweenStructureColon' );
+					}
+				}
+			}
+		}
+
+		$parenthesisOpener = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		// If this is a function declaration.
+		if ( T_FUNCTION === $tokens[ $stackPtr ]['code'] ) {
+
+			if ( T_STRING === $tokens[ $parenthesisOpener ]['code'] ) {
+
+				$function_name_ptr = $parenthesisOpener;
+
+			} elseif ( T_BITWISE_AND === $tokens[ $parenthesisOpener ]['code'] ) {
+
+				// This function returns by reference (function &function_name() {}).
+				$function_name_ptr = $parenthesisOpener = $phpcsFile->findNext(
+					PHP_CodeSniffer_Tokens::$emptyTokens,
+					( $parenthesisOpener + 1 ),
+					null,
+					true
+				);
+			}
+
+			$parenthesisOpener = $phpcsFile->findNext(
+				PHP_CodeSniffer_Tokens::$emptyTokens,
+				( $parenthesisOpener + 1 ),
+				null,
+				true
+			);
+
+			// Checking this: function my_function[*](...) {}.
+			if ( ( $function_name_ptr + 1 ) !== $parenthesisOpener ) {
+
+				$error = 'Space between function name and opening parenthesis is prohibited.';
+				$fix   = $phpcsFile->addFixableError(
+					$error,
+					$stackPtr,
+					'SpaceBeforeFunctionOpenParenthesis',
+					$tokens[ ( $function_name_ptr + 1 ) ]['content']
+				);
+
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->replaceToken( ( $function_name_ptr + 1 ), '' );
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+		} elseif ( T_CLOSURE === $tokens[ $stackPtr ]['code'] ) {
+
+			// Check if there is a use () statement.
+			if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+
+				$usePtr = $phpcsFile->findNext(
+					PHP_CodeSniffer_Tokens::$emptyTokens,
+					( $tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
+					null,
+					true,
+					null,
+					true
+				);
+
+				// If it is, we set that as the "scope opener".
+				if ( T_USE === $tokens[ $usePtr ]['code'] ) {
+					$scopeOpener = $usePtr;
+				}
+			}
+		}
+
+		if (
+			T_COLON !== $tokens[ $parenthesisOpener ]['code']
+			&& T_FUNCTION !== $tokens[ $stackPtr ]['code']
+		) {
+
+			if (
+				T_CLOSURE === $tokens[ $stackPtr ]['code']
+				&& 0 === (int) $this->spaces_before_closure_open_paren
+			) {
+
+				if ( ( $stackPtr + 1) !== $parenthesisOpener ) {
+					// Checking this: function[*](...) {}.
+					$error = 'Space before closure opening parenthesis is prohibited';
+					$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+						$phpcsFile->fixer->endChangeset();
+					}
+				}
+			} elseif (
+				(
+					T_CLOSURE !== $tokens[ $stackPtr ]['code']
+					|| 1 === (int) $this->spaces_before_closure_open_paren
+				)
+				&& ( $stackPtr + 1 ) === $parenthesisOpener
+			) {
+
+				// Checking this: if[*](...) {}.
+				$error = 'No space before opening parenthesis is prohibited';
+				if ( isset( $phpcsFile->fixer ) ) {
+					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+						$phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+				}
+			}
+		}
+
+		if (
+			T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ' ' !== $tokens[ ( $stackPtr + 1 ) ]['content']
+		) {
+			// Checking this: if [*](...) {}.
+			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
+			$fix = $phpcsFile->addFixableError(
+				$error,
+				$stackPtr,
+				'ExtraSpaceBeforeOpenParenthesis',
+				$tokens[ ( $stackPtr + 1 ) ]['content']
+			);
+
+			if ( true === $fix ) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
+				$phpcsFile->fixer->endChangeset();
+			}
+		}
+
+		if ( T_WHITESPACE !== $tokens[ ( $parenthesisOpener + 1) ]['code']
+			&& T_CLOSE_PARENTHESIS !== $tokens[ ( $parenthesisOpener + 1) ]['code']
+		) {
+			// Checking this: $value = my_function([*]...).
+			$error = 'No space after opening parenthesis is prohibited';
+			if ( isset( $phpcsFile->fixer ) ) {
+				$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
+					$phpcsFile->fixer->endChangeset();
+				}
+			} else {
+				$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+			}
+		}
+
+		if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+
+			$parenthesisCloser = $tokens[ $parenthesisOpener ]['parenthesis_closer'];
+
+			if ( T_CLOSE_PARENTHESIS !== $tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+
+				if ( T_WHITESPACE !== $tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
+					$error = 'No space before closing parenthesis is prohibited';
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+					}
+				}
+
+				if (
+					T_WHITESPACE !== $tokens[ ( $parenthesisCloser + 1 ) ]['code']
+					&& T_COLON !== $tokens[ $scopeOpener ]['code']
+				) {
+					$error = 'Space between opening control structure and closing parenthesis is required';
+
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
+
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+					}
+				}
+			}
+
+			if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_owner'] )
+				&& $tokens[ $parenthesisCloser ]['line'] !== $tokens[ $scopeOpener ]['line']
+			) {
+				$error = 'Opening brace should be on the same line as the declaration';
+				if ( isset( $phpcsFile->fixer ) ) {
+					$fix = $phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+
+						for ( $i = ( $parenthesisCloser + 1 ); $i < $scopeOpener; $i++ ) {
+							$phpcsFile->fixer->replaceToken( $i, '' );
+						}
+
+						$phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
+						$phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$phpcsFile->addError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
+				} // end if
+				return;
+
+			} elseif (
+				T_WHITESPACE === $tokens[ ( $parenthesisCloser + 1 ) ]['code']
+				&& ' ' !== $tokens[ ( $parenthesisCloser + 1 ) ]['content']
+			) {
+
+				// Checking this: if (...) [*]{}.
+				$error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
+				$fix = $phpcsFile->addFixableError(
+					$error,
+					$stackPtr,
+					'ExtraSpaceAfterCloseParenthesis',
+					$tokens[ ( $parenthesisCloser + 1 ) ]['content']
+				);
+
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+		} // end if
+
+		if ( true === $this->blank_line_check ) {
+			$firstContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
+			if ( $tokens[ $firstContent ]['line'] > ( $tokens[ $scopeOpener ]['line'] + 1 )
+				&& false === in_array( $tokens[ $firstContent ]['code'], array( T_CLOSE_TAG, T_COMMENT ), true )
+			) {
+				$error = 'Blank line found at start of control structure';
+				if ( isset( $phpcsFile->fixer ) ) {
+					$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+
+						for ( $i = ( $scopeOpener + 1 ); $i < $firstContent; $i++ ) {
+							$phpcsFile->fixer->replaceToken( $i, '' );
+						}
+
+						$phpcsFile->fixer->addNewline( $scopeOpener );
+						$phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$phpcsFile->addError( $error, $scopeOpener, 'BlankLineAfterStart' );
+				}
+			}
+
+			$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
+			if ( ( $tokens[ $scopeCloser ]['line'] - 1 ) !== $tokens[ $lastContent ]['line'] ) {
+				$errorToken = $scopeCloser;
+				for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
+					if ( $tokens[ $i ]['line'] < $tokens[ $scopeCloser ]['line']
+						&& T_OPEN_TAG !== $tokens[ $firstContent ]['code']
+					) {
+						// TODO: Reporting error at empty line won't highlight it in IDE.
+						$error = 'Blank line found at end of control structure';
+						if ( isset( $phpcsFile->fixer ) ) {
+							$fix = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
+							if ( true === $fix ) {
+								$phpcsFile->fixer->beginChangeset();
+
+								for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
+									$phpcsFile->fixer->replaceToken( $j, '' );
+								}
+
+								$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
+								$phpcsFile->fixer->endChangeset();
+							}
+						} else {
+							$phpcsFile->addError( $error, $i, 'BlankLineBeforeEnd' );
+						} // end if
+						break;
+					} // end if
+				} // end for
+			} // end if
+		} // end if
+
+		$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
+		if ( T_ELSE === $tokens[ $trailingContent ]['code'] ) {
+			if ( T_IF === $tokens[ $stackPtr ]['code'] ) {
+				// IF with ELSE.
+				return;
+			}
+		}
+
+		if ( T_COMMENT === $tokens[ $trailingContent ]['code'] ) {
+			if ( $tokens[ $trailingContent ]['line'] === $tokens[ $scopeCloser ]['line'] ) {
+				if ( '//end' === substr( $tokens[ $trailingContent ]['content'], 0, 5 ) ) {
+					// There is an end comment, so we have to get the next piece
+					// of content.
+					$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1), null, true );
+				}
+			}
+		}
+
+		if ( T_BREAK === $tokens[ $trailingContent ]['code'] ) {
+			// If this BREAK is closing a CASE, we don't need the
+			// blank line after this control structure.
+			if ( isset( $tokens[ $trailingContent ]['scope_condition'] ) ) {
+				$condition = $tokens[ $trailingContent ]['scope_condition'];
+				if ( T_CASE === $tokens[ $condition ]['code'] || T_DEFAULT === $tokens[ $condition ]['code'] ) {
+					return;
+				}
+			}
+		}
+
+		if ( T_CLOSE_TAG === $tokens[ $trailingContent ]['code'] ) {
+			// At the end of the script or embedded code.
+			return;
+		}
+
+		if ( T_CLOSE_CURLY_BRACKET === $tokens[ $trailingContent ]['code'] ) {
+			// Another control structure's closing brace.
+			if ( isset( $tokens[ $trailingContent ]['scope_condition'] ) ) {
+				$owner = $tokens[ $trailingContent ]['scope_condition'];
+				if ( T_FUNCTION === $tokens[ $owner ]['code'] ) {
+					// The next content is the closing brace of a function
+					// so normal function rules apply and we can ignore it.
+					return;
+				}
+			}
+
+			if ( true === $this->blank_line_after_check
+				&& ( $tokens[ $scopeCloser ]['line'] + 1 ) !== $tokens[ $trailingContent ]['line']
+			) {
+				// TODO: Won't cover following case: "} echo 'OK';".
+				$error = 'Blank line found after control structure';
+				if ( isset( $phpcsFile->fixer ) ) {
+					$fix = $phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+
+						for ( $i = ( $scopeCloser + 1 ); $i < $trailingContent; $i++ ) {
+							$phpcsFile->fixer->replaceToken( $i, '' );
+						}
+
+						// TODO: Instead a separate error should be triggered when content comes right after closing brace.
+						$phpcsFile->fixer->addNewlineBefore( $trailingContent );
+						$phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$phpcsFile->addError( $error, $scopeCloser, 'BlankLineAfterEnd' );
+				}
+			}
+		} // end if
+
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -82,10 +82,13 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 		if ( T_BITWISE_AND === $tokens[ $stackPtr ]['code'] ) {
 			// If its not a reference, then we expect one space either side of the
 			// bitwise operator.
-			if ( false === $phpcsFile->isReference( $stackPtr ) ) {
-				// @todo Implement ?
+			// if ( false === $phpcsFile->isReference( $stackPtr ) ) {
+				// @todo Implement  or remove ?
 
-			} // end if
+			// } // end if
+
+			return;
+
 		} else {
 			if ( T_MINUS === $tokens[ $stackPtr ]['code'] ) {
 				// Check minus spacing, but make sure we aren't just assigning

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Modified version of Squiz operator white spacing, based upon Squiz code
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Greg Sherwood <gsherwood@squiz.net>
@@ -11,7 +9,7 @@
  */
 
 /**
- * Enforces WordPress array format
+ * Modified version of Squiz operator white spacing.
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -30,7 +30,6 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 		'JS',
 	);
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -47,7 +46,6 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 		return $tokens;
 
 	} // end register()
-
 
 	/**
 	 * Processes this sniff, when one of its tokens is encountered.

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -18,197 +18,192 @@
  * @author   Greg Sherwood <gsherwood@squiz.net>
  * @author   Marc McIntyre <mmcintyre@squiz.net>
  */
-class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sniff
-{
+class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sniff {
 
-    /**
-     * A list of tokenizers this sniff supports.
-     *
-     * @var array
-     */
-    public $supportedTokenizers = array(
-                                   'PHP',
-                                   'JS',
-                                  );
-
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        $comparison = PHP_CodeSniffer_Tokens::$comparisonTokens;
-        $operators  = PHP_CodeSniffer_Tokens::$operators;
-        $assignment = PHP_CodeSniffer_Tokens::$assignmentTokens;
-
-        $tokens   = array_unique(array_merge($comparison, $operators, $assignment));
-        $tokens[] = T_BOOLEAN_NOT;
-
-        return $tokens;
-
-    }//end register()
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+	);
 
 
-    /**
-     * Processes this sniff, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$comparison = PHP_CodeSniffer_Tokens::$comparisonTokens;
+		$operators	= PHP_CodeSniffer_Tokens::$operators;
+		$assignment = PHP_CodeSniffer_Tokens::$assignmentTokens;
 
-        if ($tokens[$stackPtr]['code'] === T_EQUAL) {
-            // Skip for '=&' case.
-            if (isset($tokens[($stackPtr + 1)]) === true && $tokens[($stackPtr + 1)]['code'] === T_BITWISE_AND) {
-                return;
-            }
+		$tokens   = array_unique( array_merge( $comparison, $operators, $assignment ) );
+		$tokens[] = T_BOOLEAN_NOT;
 
-            // Skip default values in function declarations.
-            if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-                $bracket = end($tokens[$stackPtr]['nested_parenthesis']);
-                if (isset($tokens[$bracket]['parenthesis_owner']) === true) {
-                    $function = $tokens[$bracket]['parenthesis_owner'];
-                    if ($tokens[$function]['code'] === T_FUNCTION) {
-                        return;
-                    }
-                }
-            }
-        }
+		return $tokens;
 
-        if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
-            // If its not a reference, then we expect one space either side of the
-            // bitwise operator.
-            if ($phpcsFile->isReference($stackPtr) === false) {
-
-            }//end if
-        } else {
-            if ($tokens[$stackPtr]['code'] === T_MINUS) {
-                // Check minus spacing, but make sure we aren't just assigning
-                // a minus value or returning one.
-                $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-                if ($tokens[$prev]['code'] === T_RETURN) {
-                    // Just returning a negative value; eg. return -1.
-                    return;
-                }
-
-                if (in_array($tokens[$prev]['code'], PHP_CodeSniffer_Tokens::$operators) === true) {
-                    // Just trying to operate on a negative value; eg. ($var * -1).
-                    return;
-                }
-
-                if (in_array($tokens[$prev]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens) === true) {
-                    // Just trying to compare a negative value; eg. ($var === -1).
-                    return;
-                }
-
-                // A list of tokens that indicate that the token is not
-                // part of an arithmetic operation.
-                $invalidTokens = array(
-                                  T_COMMA,
-                                  T_OPEN_PARENTHESIS,
-                                  T_OPEN_SQUARE_BRACKET,
-                                 );
-
-                if (in_array($tokens[$prev]['code'], $invalidTokens) === true) {
-                    // Just trying to use a negative value; eg. myFunction($var, -2).
-                    return;
-                }
-
-                $number = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-                if ($tokens[$number]['code'] === T_LNUMBER) {
-                    $semi = $phpcsFile->findNext(T_WHITESPACE, ($number + 1), null, true);
-                    if ($tokens[$semi]['code'] === T_SEMICOLON) {
-                        if ($prev !== false && (in_array($tokens[$prev]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens) === true)) {
-                            // This is a negative assignment.
-                            return;
-                        }
-                    }
-                }
-            }//end if
-
-            $operator = $tokens[$stackPtr]['content'];
-
-            if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-                $error = 'Expected 1 space before "%s"; 0 found';
-                $data  = array($operator);
-                if (isset($phpcsFile->fixer) === true) {
-                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore', $data);
-                    if ($fix === true) {
-                        $phpcsFile->fixer->beginChangeset();
-                        $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
-                        $phpcsFile->fixer->endChangeset();
-                    }
-                } else {
-                    $phpcsFile->addError($error, $stackPtr, 'NoSpaceBefore', $data);
-                }
-            } else if (strlen($tokens[($stackPtr - 1)]['content']) !== 1 && $tokens[($stackPtr - 1)]['column'] !== 1) {
-                // Don't throw an error for assignments, because other standards allow
-                // multiple spaces there to align multiple assignments.
-                if (in_array($tokens[$stackPtr]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens) === false) {
-                    $found = strlen($tokens[($stackPtr - 1)]['content']);
-                    $error = 'Expected 1 space before "%s"; %s found';
-                    $data  = array(
-                              $operator,
-                              $found,
-                             );
-                    if (isset($phpcsFile->fixer) === true) {
-                        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBefore', $data);
-                        if ($fix === true) {
-                            $phpcsFile->fixer->beginChangeset();
-                            $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
-                            $phpcsFile->fixer->endChangeset();
-                        }
-                    } else {
-                        $phpcsFile->addError($error, $stackPtr, 'SpacingBefore', $data);
-                    }
-                }
-            }//end if
-
-            if ($operator !== '-') {
-                if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-                    $error = 'Expected 1 space after "%s"; 0 found';
-                    $data  = array($operator);
-                    if (isset($phpcsFile->fixer) === true) {
-                        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter', $data);
-                        if ($fix === true) {
-                            $phpcsFile->fixer->beginChangeset();
-                            $phpcsFile->fixer->addContent($stackPtr, ' ');
-                            $phpcsFile->fixer->endChangeset();
-                        }
-                    } else {
-                        $phpcsFile->addError($error, $stackPtr, 'NoSpaceAfter', $data);
-                    }
-                } else if (strlen($tokens[($stackPtr + 1)]['content']) !== 1) {
-                    $found = strlen($tokens[($stackPtr + 1)]['content']);
-                    $error = 'Expected 1 space after "%s"; %s found';
-                    $data  = array(
-                              $operator,
-                              $found,
-                             );
-                    if (isset($phpcsFile->fixer) === true) {
-                        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
-                        if ($fix === true) {
-                            $phpcsFile->fixer->beginChangeset();
-                            $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
-                            $phpcsFile->fixer->endChangeset();
-                        }
-                    } else {
-                        $phpcsFile->addError($error, $stackPtr, 'SpacingAfter', $data);
-                    }
-                }//end if
-            }//end if
-        }//end if
-
-    }//end process()
+	} // end register()
 
 
-}//end class
+	/**
+	 * Processes this sniff, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
 
-?>
+		if ( T_EQUAL === $tokens[ $stackPtr ]['code'] ) {
+			// Skip for '=&' case.
+			if ( isset( $tokens[ ( $stackPtr + 1 ) ] ) && T_BITWISE_AND === $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+				return;
+			}
+
+			// Skip default values in function declarations.
+			if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+				$bracket = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
+				if ( isset( $tokens[ $bracket ]['parenthesis_owner'] ) ) {
+					$function = $tokens[ $bracket ]['parenthesis_owner'];
+					if ( T_FUNCTION === $tokens[ $function ]['code'] ) {
+						return;
+					}
+				}
+			}
+		}
+
+		if ( T_BITWISE_AND === $tokens[ $stackPtr ]['code'] ) {
+			// If its not a reference, then we expect one space either side of the
+			// bitwise operator.
+			if ( false === $phpcsFile->isReference( $stackPtr ) ) {
+				// @todo Implement ?
+
+			} // end if
+		} else {
+			if ( T_MINUS === $tokens[ $stackPtr ]['code'] ) {
+				// Check minus spacing, but make sure we aren't just assigning
+				// a minus value or returning one.
+				$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
+				if ( T_RETURN === $tokens[ $prev ]['code'] ) {
+					// Just returning a negative value; eg. return -1.
+					return;
+				}
+
+				if ( in_array( $tokens[ $prev ]['code'], PHP_CodeSniffer_Tokens::$operators, true ) ) {
+					// Just trying to operate on a negative value; eg. ($var * -1).
+					return;
+				}
+
+				if ( in_array( $tokens[ $prev ]['code'], PHP_CodeSniffer_Tokens::$comparisonTokens, true ) ) {
+					// Just trying to compare a negative value; eg. ($var === -1).
+					return;
+				}
+
+				// A list of tokens that indicate that the token is not
+				// part of an arithmetic operation.
+				$invalidTokens = array(
+					T_COMMA,
+					T_OPEN_PARENTHESIS,
+					T_OPEN_SQUARE_BRACKET,
+				);
+
+				if ( in_array( $tokens[ $prev ]['code'], $invalidTokens, true ) ) {
+					// Just trying to use a negative value; eg. myFunction($var, -2).
+					return;
+				}
+
+				$number = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+				if ( T_LNUMBER === $tokens[ $number ]['code'] ) {
+					$semi = $phpcsFile->findNext( T_WHITESPACE, ( $number + 1 ), null, true );
+					if ( T_SEMICOLON === $tokens[ $semi ]['code'] ) {
+						if ( false !== $prev && in_array( $tokens[ $prev ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true ) ) {
+							// This is a negative assignment.
+							return;
+						}
+					}
+				}
+			} // end if
+
+			$operator = $tokens[ $stackPtr ]['content'];
+
+			if ( T_WHITESPACE !== $tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+				$error = 'Expected 1 space before "%s"; 0 found';
+				$data  = array( $operator );
+				if ( isset( $phpcsFile->fixer ) ) {
+					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBefore', $data );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
+						$phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBefore', $data );
+				}
+			} elseif ( 1 !== strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] ) && 1 !== $tokens[ ( $stackPtr - 1 ) ]['column'] ) {
+				// Don't throw an error for assignments, because other standards allow
+				// multiple spaces there to align multiple assignments.
+				if ( false === in_array( $tokens[ $stackPtr ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true )  ) {
+					$found = strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] );
+					$error = 'Expected 1 space before "%s"; %s found';
+					$data  = array(
+						$operator,
+						$found,
+					);
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacingBefore', $data );
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'SpacingBefore', $data );
+					}
+				}
+			} // end if
+
+			if ( '-' !== $operator ) {
+				if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+					$error = 'Expected 1 space after "%s"; 0 found';
+					$data  = array( $operator );
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfter', $data );
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfter', $data );
+					}
+				} elseif ( 1 !== strlen( $tokens[ ( $stackPtr + 1 ) ]['content'] ) ) {
+					$found = strlen( $tokens[ ( $stackPtr + 1 ) ]['content'] );
+					$error = 'Expected 1 space after "%s"; %s found';
+					$data  = array(
+						$operator,
+						$found,
+					);
+					if ( isset( $phpcsFile->fixer ) ) {
+						$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacingAfter', $data );
+						if ( true === $fix ) {
+							$phpcsFile->fixer->beginChangeset();
+							$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
+							$phpcsFile->fixer->endChangeset();
+						}
+					} else {
+						$phpcsFile->addError( $error, $stackPtr, 'SpacingAfter', $data );
+					}
+				} // end if
+			} // end if
+		} // end if
+
+	} // end process()
+
+} // end class

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -17,8 +17,7 @@
  * @author   Weston Ruter <weston@x-team.com>
  * @link     http://codex.wordpress.org/Data_Validation Data Validation on WordPress Codex
  */
-class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
-{
+class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 	/**
 	 * Custom list of functions which escape values for output.
@@ -65,7 +64,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	 * @var array
 	 */
 	public static $unsafePrintingFunctions = array(
-		'_e' => 'esc_html_e() or esc_attr_e()',
+		'_e'  => 'esc_html_e() or esc_attr_e()',
 		'_ex' => 'esc_html_ex() or esc_attr_ex()',
 	);
 
@@ -76,13 +75,13 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	 */
 	public static $addedCustomFunctions = false;
 
+
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
-	public function register()
-	{
+	public function register() {
 		return array(
 			T_ECHO,
 			T_PRINT,
@@ -90,7 +89,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			T_STRING,
 		);
 
-	}//end register()
+	} // end register()
 
 
 	/**
@@ -102,13 +101,12 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 	 *
 	 * @return int|void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr )
-	{
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
-			WordPress_Sniff::$escapingFunctions = array_merge( WordPress_Sniff::$escapingFunctions, array_flip( $this->customEscapingFunctions ) );
+			WordPress_Sniff::$escapingFunctions    = array_merge( WordPress_Sniff::$escapingFunctions, array_flip( $this->customEscapingFunctions ) );
 			WordPress_Sniff::$autoEscapedFunctions = array_merge( WordPress_Sniff::$autoEscapedFunctions, array_flip( $this->customAutoEscapedFunctions ) );
-			WordPress_Sniff::$printingFunctions = array_merge( WordPress_Sniff::$printingFunctions, array_flip( $this->customPrintingFunctions ) );
+			WordPress_Sniff::$printingFunctions    = array_merge( WordPress_Sniff::$printingFunctions, array_flip( $this->customPrintingFunctions ) );
 
 			if ( ! empty( $this->customSanitizingFunctions ) ) {
 				WordPress_Sniff::$escapingFunctions = array_merge( WordPress_Sniff::$escapingFunctions, array_flip( $this->customSanitizingFunctions ) );
@@ -124,10 +122,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		$function = $tokens[ $stackPtr ]['content'];
 
 		// Find the opening parenthesis (if present; T_ECHO might not have it).
-		$open_paren = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true );
+		$open_paren = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-		// If function, not T_ECHO nor T_PRINT
-		if ( $tokens[$stackPtr]['code'] == T_STRING ) {
+		// If function, not T_ECHO nor T_PRINT.
+		if ( T_STRING === $tokens[ $stackPtr ]['code'] ) {
 			// Skip if it is a function but is not of the printing functions.
 			if ( ! isset( self::$printingFunctions[ $tokens[ $stackPtr ]['content'] ] ) ) {
 				return;
@@ -138,12 +136,12 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			}
 
 			// These functions only need to have the first argument escaped.
-			if ( in_array( $function, array( 'trigger_error', 'user_error' ) ) ) {
+			if ( in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
 				$end_of_statement = $phpcsFile->findEndOfStatement( $open_paren + 1 );
 			}
 		}
 
-		// Checking for the ignore comment, ex: //xss ok
+		// Checking for the ignore comment, ex: //xss ok.
 		if ( $this->has_whitelist_comment( 'xss', $stackPtr ) ) {
 			return;
 		}
@@ -163,7 +161,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 		if ( ! isset( $end_of_statement ) ) {
 
 			$end_of_statement = $phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
-			$last_token = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, $end_of_statement - 1, null, true );
+			$last_token       = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
 
 			// Check for the ternary operator. We only need to do this here if this
 			// echo is lacking parenthesis. Otherwise it will be handled below.
@@ -184,12 +182,12 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 		$in_cast = false;
 
-		// looping through echo'd components
+		// Looping through echo'd components.
 		$watch = true;
 		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
 
 			// Ignore whitespaces and comments.
-			if ( in_array( $tokens[ $i ]['code'], array( T_WHITESPACE, T_COMMENT ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_WHITESPACE, T_COMMENT ), true ) ) {
 				continue;
 			}
 
@@ -208,7 +206,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 					if ( $ternary ) {
 
-						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $i + 1, $tokens[ $i ]['parenthesis_closer'] );
+						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $tokens[ $i ]['parenthesis_closer'] );
 
 						// We only do it if the ternary isn't within a subset of parentheses.
 						if ( ! $next_paren || $ternary > $tokens[ $next_paren ]['parenthesis_closer'] ) {
@@ -221,52 +219,53 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			}
 
 			// Handle arrays for those functions that accept them.
-			if ( $tokens[ $i ]['code'] === T_ARRAY ) {
+			if ( T_ARRAY === $tokens[ $i ]['code'] ) {
 				$i++; // Skip the opening parenthesis.
 				continue;
 			}
 
-			if ( in_array( $tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ), true ) ) {
 				continue;
 			}
 
 			// Handle magic constants for debug functions.
-			if ( in_array( $tokens[ $i ]['code'], array( T_METHOD_C, T_FUNC_C, T_FILE, T_CLASS_C ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_METHOD_C, T_FUNC_C, T_FILE, T_CLASS_C ), true ) ) {
 				continue;
 			}
 
-			// Wake up on concatenation characters, another part to check
-			if ( in_array( $tokens[$i]['code'], array( T_STRING_CONCAT ) ) ) {
+			// Wake up on concatenation characters, another part to check.
+			if ( in_array( $tokens[ $i ]['code'], array( T_STRING_CONCAT ), true ) ) {
 				$watch = true;
 				continue;
 			}
 
 			// Wake up after a ternary else (:).
-			if ( $ternary && in_array( $tokens[$i]['code'], array( T_INLINE_ELSE ) ) ) {
+			if ( $ternary && in_array( $tokens[ $i ]['code'], array( T_INLINE_ELSE ), true ) ) {
 				$watch = true;
 				continue;
 			}
 
 			// Wake up for commas.
-			if ( $tokens[ $i ]['code'] === T_COMMA ) {
+			if ( T_COMMA === $tokens[ $i ]['code'] ) {
 				$in_cast = false;
-				$watch = true;
+				$watch   = true;
 				continue;
 			}
 
-			if ( $watch === false )
+			if ( false === $watch ) {
 				continue;
+			}
 
 			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
 			// Also T_LNUMBER, e.g.: echo 45; exit -1; and booleans.
-			if ( in_array( $tokens[$i]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_MINUS, T_TRUE, T_FALSE, T_NULL ) ) ) {
+			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_MINUS, T_TRUE, T_FALSE, T_NULL ), true ) ) {
 				continue;
 			}
 
 			$watch = false;
 
-			// Allow int/double/bool casted variables
-			if ( in_array( $tokens[$i]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ) ) ) {
+			// Allow int/double/bool casted variables.
+			if ( in_array( $tokens[ $i ]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ), true ) ) {
 				$in_cast = true;
 				continue;
 			}
@@ -274,12 +273,9 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 			// Now check that next token is a function call.
 			if ( T_STRING === $this->tokens[ $i ]['code'] ) {
 
-				$ptr = $i;
-
-				$functionName = $this->tokens[ $i ]['content'];
-
-				$function_opener = $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS ), $i + 1, null, null, null, true );
-
+				$ptr                    = $i;
+				$functionName           = $this->tokens[ $i ]['content'];
+				$function_opener        = $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS ), ( $i + 1 ), null, null, null, true );
 				$is_formatting_function = isset( self::$formattingFunctions[ $functionName ] );
 
 				if ( $function_opener ) {
@@ -289,7 +285,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 						// Get the first parameter (name of function being used on the array).
 						$mapped_function = $this->phpcsFile->findNext(
 							PHP_CodeSniffer_Tokens::$emptyTokens,
-							$function_opener + 1,
+							( $function_opener + 1 ),
 							$tokens[ $function_opener ]['parenthesis_closer'],
 							true
 						);
@@ -305,7 +301,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 					// If this is a formatting function we just skip over the opening
 					// parenthesis. Otherwise we skip all the way to the closing.
 					if ( $is_formatting_function ) {
-						$i     = $function_opener + 1;
+						$i     = ( $function_opener + 1 );
 						$watch = true;
 					} else {
 						$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
@@ -325,7 +321,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 			} else {
 				$content = $this->tokens[ $i ]['content'];
-				$ptr = $i;
+				$ptr     = $i;
 			}
 
 			$this->phpcsFile->addError(
@@ -338,8 +334,6 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff
 
 		return $end_of_statement;
 
-	}//end process()
+	} // end process()
 
-}//end class
-
-?>
+} // end class

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -2,8 +2,6 @@
 /**
  * Squiz_Sniffs_XSS_EscapeOutputSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Weston Ruter <weston@x-team.com>
@@ -12,10 +10,11 @@
 /**
  * Verifies that all outputted strings are escaped.
  *
+ * @link     http://codex.wordpress.org/Data_Validation Data Validation on WordPress Codex
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Weston Ruter <weston@x-team.com>
- * @link     http://codex.wordpress.org/Data_Validation Data Validation on WordPress Codex
  */
 class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -75,7 +75,6 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	 */
 	public static $addedCustomFunctions = false;
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -90,7 +89,6 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		);
 
 	} // end register()
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -7,57 +7,53 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	protected function setUp() {
 		parent::setUp();
 
 		WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff::$groups = array(
 			'posts_per_page' => array(
-				'type' => 'error',
+				'type'    => 'error',
 				'message' => 'Found assignment value of %s to be %s',
-				'keys' => array(
+				'keys'    => array(
 					'foo',
 					'bar',
-					),
 				),
-			);
+			),
+		);
 	}
 
-		/**
-		 * Returns the lines where errors should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of errors that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getErrorList()
-		{
-				return array(
-					3 => 1,
-					5 => 1,
-					7 => 2,
-							 );
 
-		}//end getErrorList()
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			5 => 1,
+			7 => 2,
+		 );
 
-
-		/**
-		 * Returns the lines where warnings should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of warnings that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getWarningList()
-		{
-				return array(
-						);
-
-		}//end getWarningList()
+	} // end getErrorList()
 
 
-}//end class
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -24,7 +24,6 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 		);
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -41,7 +40,6 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 		 );
 
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -28,49 +28,41 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			7 => 1,
+			9 => 1,
+			12 => 2,
+			16 => 1,
+			40 => 2,
+			208 => 2,
+		);
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-                3 => 1,
-                7 => 1,
-                9 => 1,
-                12 => 2,
-                16 => 1,
-                40 => 2,
-                208 => 2,
-               );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-                );
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -51,7 +51,6 @@ class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitT
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the ArrayDeclaration sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -35,7 +35,6 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 		);
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
@@ -46,7 +45,7 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 	 */
 	public function getWarningList() {
 		return array();
-	} // end getWarningList()
 
+	} // end getWarningList()
 
 } // end class

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -7,8 +7,7 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -18,8 +17,7 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			4 => 1,
 			5 => 1,
@@ -35,7 +33,7 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 			29 => 1,
 			31 => 1,
 		);
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -46,10 +44,9 @@ class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends Abstrac
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
-	}//end getWarningList()
+	} // end getWarningList()
 
 
-}//end class
+} // end class

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -34,7 +34,8 @@ class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTe
 			113 => 1,
 			114 => 1,
 		);
-	}
+	} // end getErrorList()
+
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -46,6 +47,6 @@ class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTe
 	 */
 	public function getWarningList() {
 		return array();
-	}
+	} // end getWarningList()
 
 } // end class

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -1,16 +1,20 @@
 <?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
 
 /**
  * Unit test class for the NonceVerification Sniff.
- *
- * PHP version 5
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    J.D. Grimes <jdg@codesymphony.co>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -36,7 +36,6 @@ class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTe
 		);
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
@@ -47,6 +46,7 @@ class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTe
 	 */
 	public function getWarningList() {
 		return array();
+
 	} // end getWarningList()
 
 } // end class

--- a/WordPress/Tests/Classes/ValidClassNameUnitTest.php
+++ b/WordPress/Tests/Classes/ValidClassNameUnitTest.php
@@ -45,7 +45,6 @@ class WordPress_Tests_Classes_ValidClassNameUnitTest extends AbstractSniffUnitTe
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/Classes/ValidClassNameUnitTest.php
+++ b/WordPress/Tests/Classes/ValidClassNameUnitTest.php
@@ -28,42 +28,35 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_Classes_ValidClassNameUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Classes_ValidClassNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			7 => 1,
+		);
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-                7 => 1,
-               );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/Classes/ValidClassNameUnitTest.php
+++ b/WordPress/Tests/Classes/ValidClassNameUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the ValidClassName sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the FileName sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -28,40 +28,33 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -43,7 +43,6 @@ class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -28,44 +28,37 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_NamingConventions_ValidFunctionNameUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_NamingConventions_ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			13 => 1,
+			15 => 1,
+		);
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-                3 => 1,
-                13 => 1,
-                15 => 1,
-               );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the ValidFunctionName sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -47,7 +47,6 @@ class WordPress_Tests_NamingConventions_ValidFunctionNameUnitTest extends Abstra
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -87,7 +87,8 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 
 		return $errors;
 
-	}//end getErrorList()
+	} // end getErrorList()
+
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -99,5 +100,6 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 	 */
 	public function getWarningList() {
 		return array();
-	}
-}//end class
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -89,7 +89,6 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
@@ -100,6 +99,7 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 	 */
 	public function getWarningList() {
 		return array();
+
 	} // end getWarningList()
 
 } // end class

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -1,17 +1,10 @@
 <?php
 /**
- * Unit test class for WordPress_Sniffs_NamingConventions_ValidVariableNameSniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @author    Weston Ruter
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -28,64 +28,57 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			8 => 1,
+			9 => 1,
+			17 => 1,
+			20 => 1,
+			23 => 1,
+			25 => 1,
+			27 => 1,
+			33 => 1,
+			35 => 1,
+			37 => 1,
+			39 => 1,
+			41 => 1,
+			43 => 1,
+			45 => 1,
+			47 => 1,
+			49 => 1,
+			51 => 1,
+			53 => 1,
+			55 => 1,
+			63 => 1,
+			65 => 1,
+			70 => 1,
+			72 => 1,
+		);
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-            8 => 1,
-            9 => 1,
-            17 => 1,
-            20 => 1,
-            23 => 1,
-            25 => 1,
-            27 => 1,
-            33 => 1,
-            35 => 1,
-            37 => 1,
-            39 => 1,
-            41 => 1,
-            43 => 1,
-            45 => 1,
-            47 => 1,
-            49 => 1,
-            51 => 1,
-            53 => 1,
-            55 => 1,
-            63 => 1,
-            65 => 1,
-            70 => 1,
-	        72 => 1,
-        );
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -43,7 +43,6 @@ class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnit
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the DiscouragedFunctions sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -24,42 +24,37 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_PHP_StrictComparisonsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_PHP_StrictComparisonsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			3 => 1,
+			10 => 1,
+			12 => 1,
+		);
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-            3 => 1,
-            10 => 1,
-            12 => 1,
-        );
-
-    }//end getWarningList()
-
-
-}//end class
+} // end class

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -39,7 +39,6 @@ class WordPress_Tests_PHP_StrictComparisonsUnitTest extends AbstractSniffUnitTes
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -1,14 +1,10 @@
 <?php
 /**
- * Unit test class for the StrictComparisons sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Matt Robinson
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -1,14 +1,10 @@
 <?php
 /**
- * Unit test class for the StrictInArray sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Matt Robinson
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -35,7 +35,7 @@ class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
 			7 => 1,
 			20 => 1,
 		);
-	}
+	} // end getErrorList()
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -51,5 +51,6 @@ class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
 			9 => 1,
 			10 => 1,
 		);
-	}
-}
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -1,14 +1,10 @@
 <?php
 /**
- * Unit test class for the YodaConditions sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Matt Robinson
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -24,54 +24,47 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			2 => 2,
+			4 => 2,
+			11 => 1,
+			18 => 1,
+			25 => 1,
+			32 => 1,
+			49 => 1,
+			55 => 1,
+			62 => 1,
+			68 => 1,
+			84 => 1,
+			88 => 1,
+			90 => 1,
+		);
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-            2 => 2,
-            4 => 2,
-            11 => 1,
-            18 => 1,
-            25 => 1,
-            32 => 1,
-            49 => 1,
-            55 => 1,
-            62 => 1,
-            68 => 1,
-            84 => 1,
-            88 => 1,
-            90 => 1,
-        );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -53,7 +53,6 @@ class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -7,42 +7,36 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_VIP_AdminBarRemovalUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-                3 => 1,
-                5 => 1,
-               );
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			5 => 1,
+		);
 
-    }//end getErrorList()
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -25,7 +25,6 @@ class WordPress_Tests_VIP_AdminBarRemovalUnitTest extends AbstractSniffUnitTest 
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -27,7 +27,6 @@ class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -7,44 +7,40 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest {
 
-		/**
-		 * Returns the lines where errors should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of errors that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getErrorList()
-		{
-			return array(
-				10 => 1,
-				15 => 1,
-				35 => 1,
-				39 => 1,
-				);
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			10 => 1,
+			15 => 1,
+			35 => 1,
+			39 => 1,
+		);
 
-		}//end getErrorList()
+	} // end getErrorList()
 
 
-		/**
-		 * Returns the lines where warnings should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of warnings that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getWarningList()
-		{
-			return array(
-				37 => 1,
-					);
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			37 => 1,
+		);
 
-		}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -34,7 +34,6 @@ class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitT
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,8 +20,7 @@ class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitT
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			6  => 1,
 			8  => 1,
@@ -33,9 +30,9 @@ class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitT
 			78 => 1,
 			79 => 1,
 			80 => 1,
-			);
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -46,16 +43,14 @@ class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitT
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array(
 			6  => 1,
 			17 => 1,
 			38 => 1,
 			50 => 1,
-			);
+		);
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * Unit test class for the Direct Database Query.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the Direct Database Query.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * Unit test class for the Filesystem writes sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the Filesystem writes sniff.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
@@ -30,7 +30,6 @@ class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniff
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,16 +20,15 @@ class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniff
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3  => 1,
 			9  => 1,
 			10 => 1,
 			12 => 1,
-			);
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -42,13 +39,9 @@ class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniff
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/OrderByRandUnitTest.php
+++ b/WordPress/Tests/VIP/OrderByRandUnitTest.php
@@ -27,7 +27,6 @@ class WordPress_Tests_VIP_OrderByRandUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/OrderByRandUnitTest.php
+++ b/WordPress/Tests/VIP/OrderByRandUnitTest.php
@@ -8,37 +8,37 @@
  */
 class WordPress_Tests_VIP_OrderByRandUnitTest extends AbstractSniffUnitTest {
 
-		/**
-		 * Returns the lines where errors should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of errors that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getErrorList() {
-			return array(
-				4  => 1,
-				5  => 1,
-				6  => 1,
-				9  => 1,
-				11 => 1,
-			);
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			4  => 1,
+			5  => 1,
+			6  => 1,
+			9  => 1,
+			11 => 1,
+		);
 
-		}//end getErrorList()
+	} // end getErrorList()
 
 
-		/**
-		 * Returns the lines where warnings should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of warnings that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getWarningList() {
-			return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-		} //end getWarningList()
+	} // end getWarningList()
 
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/OrderByRandUnitTest.php
+++ b/WordPress/Tests/VIP/OrderByRandUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -7,41 +7,36 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_VIP_PluginMenuSlugUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 
-		/**
-		 * Returns the lines where errors should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of errors that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getErrorList()
-		{
-			return array(
-				3 => 1,
-				5 => 1,
-				);
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			5 => 1,
+		);
 
-		}//end getErrorList()
+	} // end getErrorList()
 
 
-		/**
-		 * Returns the lines where warnings should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of warnings that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getWarningList()
-		{
-			return array(
-					);
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-		}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -25,7 +25,6 @@ class WordPress_Tests_VIP_PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -7,45 +7,40 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_VIP_PostsPerPageUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_PostsPerPageUnitTest extends AbstractSniffUnitTest {
 
-		/**
-		 * Returns the lines where errors should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of errors that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getErrorList()
-		{
-			return array(
-				4  => 1,
-				5  => 1,
-				6  => 1,
-				11  => 2,
-				13 => 1,
-				16 => 1,
-				);
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			4  => 1,
+			5  => 1,
+			6  => 1,
+			11  => 2,
+			13 => 1,
+			16 => 1,
+		);
 
-		}//end getErrorList()
+	} // end getErrorList()
 
 
-		/**
-		 * Returns the lines where warnings should occur.
-		 *
-		 * The key of the array should represent the line number and the value
-		 * should represent the number of warnings that should occur on that line.
-		 *
-		 * @return array(int => int)
-		 */
-		public function getWarningList()
-		{
-			return array(
-					);
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-		}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -29,7 +29,6 @@ class WordPress_Tests_VIP_PostsPerPageUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -67,7 +67,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -12,89 +12,85 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-            3  => 1,
-            5  => 1,
-            21 => 1,
-            34 => version_compare( PHP_VERSION, '5.3.0', '>=' ) ? 0 : 1,
-            36 => 1,
-            38 => 1,
-            40 => 1,
-            42 => 1,
-            44 => 1,
-            46 => 1,
-            48 => 1,
-            50 => 1,
-            53 => 1,
-            54 => 1,
-            55 => 1,
-            56 => 1,
-            57 => 1,
-            62 => 1,
-            63 => 1,
-            64 => 1,
-            65 => 1,
-            66 => 1,
-            67 => 1,
-            68 => 1,
-            69 => 1,
-            70 => 1,
-            71 => 1,
-            74 => 1,
-            75 => 2,
-            76 => 1,
-            77 => 1,
-            78 => 1,
-            79 => 1,
-            80 => 1,
-            81 => 1,
-            82 => 1,
-            83 => 1,
-            84 => 1,
-            85 => 1,
-        );
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3  => 1,
+			5  => 1,
+			21 => 1,
+			34 => version_compare( PHP_VERSION, '5.3.0', '>=' ) ? 0 : 1,
+			36 => 1,
+			38 => 1,
+			40 => 1,
+			42 => 1,
+			44 => 1,
+			46 => 1,
+			48 => 1,
+			50 => 1,
+			53 => 1,
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
+			62 => 1,
+			63 => 1,
+			64 => 1,
+			65 => 1,
+			66 => 1,
+			67 => 1,
+			68 => 1,
+			69 => 1,
+			70 => 1,
+			71 => 1,
+			74 => 1,
+			75 => 2,
+			76 => 1,
+			77 => 1,
+			78 => 1,
+			79 => 1,
+			80 => 1,
+			81 => 1,
+			82 => 1,
+			83 => 1,
+			84 => 1,
+			85 => 1,
+		);
 
-    }//end getErrorList()
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-            7  => 1,
-            9  => 1,
-            11 => 1,
-            13 => 1,
-            15 => 1,
-            17 => 1,
-            19 => 1,
-            58 => 1,
-            59 => 1,
-            61 => 1,
-            72 => 1,
-            );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			7  => 1,
+			9  => 1,
+			11 => 1,
+			13 => 1,
+			15 => 1,
+			17 => 1,
+			19 => 1,
+			58 => 1,
+			59 => 1,
+			61 => 1,
+			72 => 1,
+		);
 
-    }//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -12,9 +12,7 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -24,16 +22,15 @@ class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitT
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3 => 1,
 			5 => 1,
 			7 => 1,
 			9 => 1,
-			   );
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -44,16 +41,13 @@ class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitT
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array(
 			13 => 1,
 			14 => 1,
 			17 => 1,
-			);
+		);
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
+} // end class

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -32,7 +32,6 @@ class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitT
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * Unit test class for the PHP Session functions usage
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the PHP Session functions usage
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,13 +20,12 @@ class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3 => 1,
-			);
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -39,13 +36,9 @@ class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
@@ -27,7 +27,6 @@ class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUni
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * WordPress_Tests_VIP_SessionVariableUsageUnitTest
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_VIP_SessionVariableUsageUnitTest
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
@@ -28,7 +28,6 @@ class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnit
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,14 +20,13 @@ class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnit
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3 => 1,
 			4 => 1,
-			);
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -40,13 +37,9 @@ class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnit
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -22,7 +22,6 @@ class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -7,47 +7,40 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-               );
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-            4  => 1,
-            10 => 1,
-            15 => 1,
-            16 => 1,
-            19 => 2,
-            30 => 1,
-            );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			4  => 1,
+			10 => 1,
+			15 => 1,
+			16 => 1,
+			19 => 2,
+			30 => 1,
+		);
 
-    }//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -25,7 +25,6 @@ class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUni
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,12 +20,10 @@ class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
-		return array(
-			);
+	public function getErrorList() {
+		return array();
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -38,16 +34,12 @@ class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array(
 			3 => 1,
 			11 => 1,
 			13 => 1,
-			);
+		);
+	} // end getWarningList()
 
-	}//end getWarningList()
-
-
-}//end class
-
+} // end class

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * Unit test class for the SuperGlobalInputUsage
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the SuperGlobalInputUsage
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -27,7 +27,6 @@ class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,13 +20,12 @@ class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3  => 1,
-			);
+		);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -39,13 +36,9 @@ class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * WordPress_Tests_VIP_TimezoneChangeUnitTest
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_VIP_TimezoneChangeUnitTest
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -1,15 +1,20 @@
 <?php
 /**
- * Unit test class for the ValidatedSanitizedInputSniff
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the ValidatedSanitizedInputSniff
  *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
 class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 
 	/**

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -41,10 +41,9 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			104 => 2,
 			105 => 1,
 			114 => 2,
-			);
+		);
 
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -10,9 +10,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,8 +20,7 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			5 => 3,
 			7 => 1,
@@ -46,7 +43,7 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			114 => 2,
 			);
 
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -57,13 +54,9 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
+	public function getWarningList() {
 		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -7,8 +7,7 @@
  * @package   WordPress_Coding_Standards
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -18,15 +17,13 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getErrorList()
-	{
+	public function getErrorList() {
 		return array(
 			3 => 1,
 			6 => 1,
 		);
 
-
-	}//end getErrorList()
+	} // end getErrorList()
 
 
 	/**
@@ -37,12 +34,9 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 	 *
 	 * @return array(int => int)
 	 */
-	public function getWarningList()
-	{
-		return array(
-		);
+	public function getWarningList() {
+		return array();
 
-	}//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
+} // end class

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -25,7 +25,6 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -32,7 +32,6 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 		);
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -53,7 +52,6 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 		);
 
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -7,70 +7,65 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	protected function setUp() {
 		parent::setUp();
 
 		WordPress_Sniffs_Variables_VariableRestrictionsSniff::$groups = array(
 			'test' => array(
-				'type' => 'error',
-				'message' => 'Detected usage of %s',
-				'object_vars' => array(
+				'type'          => 'error',
+				'message'       => 'Detected usage of %s',
+				'object_vars'   => array(
 					'$foo->bar',
 					'FOO::var',
 					'FOO::reg*',
 					'FOO::$static',
-					),
+				),
 				'array_members' => array(
 					'$foo[\'test\']',
-					),
-				'variables' => array(
-					'$taz',
-					),
-
 				),
-			);
+				'variables'     => array(
+					'$taz',
+				),
+			),
+		);
 	}
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-               3 => 1,
-               5 => 1,
-               11 => 1,
-               15 => 1,
-               17 => 1,
-               21 => 1,
-               23 => 1,
-               );
 
-    }//end getErrorList()
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			3 => 1,
+			5 => 1,
+			11 => 1,
+			15 => 1,
+			17 => 1,
+			21 => 1,
+			23 => 1,
+		);
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-            );
-
-    }//end getWarningList()
+	} // end getErrorList()
 
 
-}//end class
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
  *

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -1,8 +1,14 @@
 <?php
 /**
- * Unit test class for the EnqueuedResources sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the EnqueuedResources sniff.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -8,55 +8,52 @@
  * @package   PHP_CodeSniffer
  * @author    Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 
-    /**
-     * Skip this test on PHP 5.2.
-     *
-     * @since 0.9.0
-     *
-     * @return bool Whether to skip this test.
-     */
-    protected function shouldSkipTest() {
-        return version_compare( PHP_VERSION, '5.3.0', '<' );
-    }
-
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-            1 => 1,
-            2 => 1,
-            6 => 1,
-            7 => 1,
-            10 => 1,
-            11 => 1,
-            );
-
-    }//end getErrorList()
+	/**
+	 * Skip this test on PHP 5.2.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return bool Whether to skip this test.
+	 */
+	protected function shouldSkipTest() {
+		return version_compare( PHP_VERSION, '5.3.0', '<' );
+	}
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			1 => 1,
+			2 => 1,
+			6 => 1,
+			7 => 1,
+			10 => 1,
+			11 => 1,
+		);
 
-    }//end getWarningList()
+	} // end getErrorList()
 
 
-}//end class
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -21,7 +21,6 @@ class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest
 		return version_compare( PHP_VERSION, '5.3.0', '<' );
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -41,7 +40,6 @@ class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest
 		);
 
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -1,8 +1,14 @@
 <?php
 /**
- * Unit test class for the EnqueuedResources sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the I18nUnit sniff.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -16,6 +16,7 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 		parent::setUp();
 	}
 
+
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -76,7 +77,8 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			106 => 1,
 			107 => 1,
 		);
-	}
+	} // end getErrorList()
+
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -95,5 +97,6 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			102 => 1,
 			103 => 1,
 		);
-	}
-}
+	} // end getWarningList()
+
+} // end class.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -16,7 +16,6 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 		parent::setUp();
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -78,7 +77,6 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			107 => 1,
 		);
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -31,7 +31,6 @@ class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
 		);
 	} // end getErrorList()
 
-
 	/**
 	 * @since 0.8.0
 	 */

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Unit test class for the PreparedSQL sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * @package WordPress-Coding-Standards
- * @since 0.8.0
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -29,13 +29,14 @@ class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
 			20 => 1,
 			21 => 1,
 		);
-	}
+	} // end getErrorList()
+
 
 	/**
 	 * @since 0.8.0
 	 */
 	public function getWarningList() {
 		return array();
-	}
+	} // end getWarningList()
 
 } // end class.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -39,7 +39,6 @@ class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSn
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -1,14 +1,10 @@
 <?php
 /**
- * Unit test class for the CastStructureSpacing sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Matt Robinson
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -24,48 +24,41 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			 3 => 1,
+			 6 => 1,
+			 9 => 1,
+			 12 => 2,
+			 15 => 1,
+			 18 => 1,
+			 21 => 1,
+		);
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array(
-                 3 => 1,
-                 6 => 1,
-                 9 => 1,
-                 12 => 2,
-                 15 => 1,
-                 18 => 1,
-                 21 => 1,
-                );
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -28,81 +28,78 @@
  * @version  Release: @package_version@
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 
-    /**
-     * Skip this test on PHP 5.2.
-     *
-     * @since 0.9.0
-     *
-     * @return bool Whether to skip this test.
-     */
-    protected function shouldSkipTest() {
-        return version_compare( PHP_VERSION, '5.3.0', '<' );
-    }
-
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        $ret = array(
-                4  => 2,
-                17 => 2,
-                29 => 5,
-                37 => 1,
-                41 => 1,
-                42 => 1,
-	            49 => 5,
-	            58 => 3,
-	            67 => 1,
-	            68 => 1,
-	            69 => 1,
-	            71 => 1,
-	            72 => 1,
-                81 => 3,
-                82 => 1,
-                85 => 1,
-                91 => 2,
-                92 => 1,
-                94 => 1,
-                95 => 1,
-                97 => 1,
-                98 => 1,
-               );
-
-        // Uncomment when "$blank_line_check" parameter will be "true" by default.
-        /*$ret[29] += 1;
-        $ret[33]  = 1;
-        $ret[36]  = 1;
-        $ret[38]  = 1;*/
-
-        return $ret;
-
-    }//end getErrorList()
+	/**
+	 * Skip this test on PHP 5.2.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return bool Whether to skip this test.
+	 */
+	protected function shouldSkipTest() {
+		return version_compare( PHP_VERSION, '5.3.0', '<' );
+	}
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		$ret = array(
+			4  => 2,
+			17 => 2,
+			29 => 5,
+			37 => 1,
+			41 => 1,
+			42 => 1,
+			49 => 5,
+			58 => 3,
+			67 => 1,
+			68 => 1,
+			69 => 1,
+			71 => 1,
+			72 => 1,
+			81 => 3,
+			82 => 1,
+			85 => 1,
+			91 => 2,
+			92 => 1,
+			94 => 1,
+			95 => 1,
+			97 => 1,
+			98 => 1,
+		);
 
-    }//end getWarningList()
+		// Uncomment when "$blank_line_check" parameter will be "true" by default.
+		/*
+		$ret[29] += 1;
+		$ret[33]  = 1;
+		$ret[36]  = 1;
+		$ret[38]  = 1;
+		 */
+
+		return $ret;
+
+	} // end getErrorList()
 
 
-}//end class
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-?>
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -41,7 +41,6 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 		return version_compare( PHP_VERSION, '5.3.0', '<' );
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -87,7 +86,6 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 		return $ret;
 
 	} // end getErrorList()
-
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the ControlStructureSpacing sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -48,7 +48,6 @@ class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUn
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -28,45 +28,38 @@
  * @version  Release: @package_version@
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			5  => 4,
+			18 => 1,
+			45 => 1,
+			49 => 1,
+		);
+
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
-                5  => 4,
-                18 => 1,
-                45 => 1,
-                49 => 1,
-               );
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getErrorList()
+	} // end getWarningList()
 
-
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
-
-    }//end getWarningList()
-
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the OperatorSpacing sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -28,21 +28,18 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
-{
+class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 
-
-    /**
-     * Returns the lines where errors should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of errors that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getErrorList()
-    {
-        return array(
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
 			17 => 1,
 			19 => 1,
 			36 => 1,
@@ -80,24 +77,20 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest
 			173 => 1,
 		);
 
-    }//end getErrorList()
+	} // end getErrorList()
 
 
-    /**
-     * Returns the lines where warnings should occur.
-     *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
-     *
-     * @return array(int => int)
-     */
-    public function getWarningList()
-    {
-        return array();
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
 
-    }//end getWarningList()
+	} // end getWarningList()
 
-
-}//end class
-
-?>
+} // end class

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * Unit test class for the EscapeOutput sniff.
+ * Unit test class for WordPress Coding Standard.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Akeda Bagus <akeda@x-team.com>
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
 /**

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -79,7 +79,6 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 
 	} // end getErrorList()
 
-
 	/**
 	 * Returns the lines where warnings should occur.
 	 *

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<description>The Coding standard for the WordPress Coding Standards itself.</description>
+
+	<rule ref="WordPress-Core">
+		<exclude name="Generic.Files.LowercasedFilename" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName" />
+	</rule>
+
+</ruleset>

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -7,4 +7,6 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName" />
 	</rule>
 
+	<rule ref="WordPress-Extra" />
+
 </ruleset>


### PR DESCRIPTION
Complies with WP-Core.
As there are only two warnings left when run against WP-Extra, I've activated that as well. Might as well lead by example ;-)

Still would need some work to comply with WP-Docs. When run against Docs PHPCS currently yields some 100 or so issues mostly to do with file vs class docblocks.

Also:
* Removed some large commented out code blocks.
* Minor spelling and punctuation corrections.
* Few minor fixes to do with variable comparisons, mainly changing loose to strict comparisons.
* Applied some best practices from the Docs and Extra standards.
* Variable and array value alignment when I saw it.

Closes #256