### PR TITLE
Add sniff for (no) closing PHP tag at end of file to `core` ruleset.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.2.0
+  - PHPCS_BRANCH=2.4.0
 
 matrix:
   fast_finish: true

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -14,6 +14,7 @@
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#remove-trailing-spaces -->
 	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+	<rule ref="PSR2.Files.ClosingTag"/>
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#no-shorthand-php-tags -->
 	<rule ref="Generic.PHP.DisallowShortOpenTag"/>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "~2.2"
+		"squizlabs/php_codesniffer": "^2.4"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
Closes #588

Added to `extra` as the handbook mentions it as a best practices, not a **_must do_**.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#remove-trailing-spaces

Code style PR has already run against this rule, so should cause no issue when merging in either order.