### PR TITLE
Add sniff for bracketed arithmetics to `extra` ruleset.

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -15,7 +15,10 @@
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
 	<rule ref="Generic.Classes.DuplicateClassName"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-	
+
+	<!-- Error prevention: Make sure arithmetics are bracketed -->
+	<rule ref="Squiz.Formatting.OperatorBracket.MissingBrackets" />
+
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
 	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->


### PR DESCRIPTION
Closes #589

Code style PR has already run against this rule, so should cause no issue when merging in either order.