### PR TITLE
Add sniff for consistent function spacing to `extra` ruleset.

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -16,6 +16,12 @@
 	<rule ref="Generic.Classes.DuplicateClassName"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat"/>
 
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<properties>
+			<property name="spacing" value="1"/>
+		</properties>
+	</rule>
+
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
 	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->


### PR DESCRIPTION
See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/590#discussion_r70470515

Please note:

> This rule does conflict with the `WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd` rule for the last method in a class if the function does not have a `} // end myfunction()` comment.
> Still - the fact that it throws a message `Blank line found after control structure` when finding a blank line after the last method in a class might actually be a bug....
