### PR TITLE
Travis CI: Upgrade the HHVM job to use Ubuntu Trusty, and a more recent version of HHVM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
       env: PHPCS_BRANCH=3.0
     # Run against HHVM and PHP nightly.
     - php: hhvm
+      sudo: required
+      dist: trusty 
+      group: edge 
       env: PHPCS_BRANCH=master
     - php: nightly
       env: PHPCS_BRANCH=master


### PR DESCRIPTION
Previously HHVM was version 3.6.6, this was the last release ~12 months ago that Facebook released for Ubuntu Precise. The HHVM job now runs HHVM 3.14.2 on Ubuntu Trusty

https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards/jobs/144369210