### PR TITLE
Fix bug in control structures whitespace sniff triggered on last method of class

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -495,9 +495,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			// Another control structure's closing brace.
 			if ( isset( $tokens[ $trailingContent ]['scope_condition'] ) ) {
 				$owner = $tokens[ $trailingContent ]['scope_condition'];
-				if ( T_FUNCTION === $tokens[ $owner ]['code'] ) {
-					// The next content is the closing brace of a function
-					// so normal function rules apply and we can ignore it.
+				if ( in_array( $tokens[ $owner ]['code'], array( T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+					// The next content is the closing brace of a function, class, interface or trait
+					// so normal function/class rules apply and we can ignore it.
 					return;
 				}
 			}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -107,3 +107,26 @@ function ( $arg ) {} // OK
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // OK
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // OK
+
+/**
+ * Test for bug where this sniff was triggering a "Blank line found after control structure" error
+ * if there is a blank line after the last method in a class.
+ *
+ * Bug did not trigger when a comment was found after the closing brace of the method.
+ *
+ * Neither of the below examples should trigger the error.
+ */
+class Bar_Foo {
+
+	function foo() {
+	} // Now you won't see the bug.
+
+}
+
+class Foo_Bar {
+
+	// Now you will.
+	function bar() {
+	}
+
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -103,3 +103,26 @@ function ( $arg ) {} // OK
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // OK
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // OK
+
+/**
+ * Test for bug where this sniff was triggering a "Blank line found after control structure" error
+ * if there is a blank line after the last method in a class.
+ *
+ * Bug did not trigger when a comment was found after the closing brace of the method.
+ *
+ * Neither of the below examples should trigger the error.
+ */
+class Bar_Foo {
+
+	function foo() {
+	} // Now you won't see the bug.
+
+}
+
+class Foo_Bar {
+
+	// Now you will.
+	function bar() {
+	}
+
+}


### PR DESCRIPTION
As reported here:

> This rule does conflict with the `WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd` rule for the last method in a class if the function does not have a `} // end myfunction()` comment.
Still - the fact that it throws a message `Blank line found after control structure` when finding a blank line after the last method in a class might actually be a bug....

Added separate commits for unit test and fix to let travis demonstrate the bug and the fix.