### PR TITLE
Add sniff to detect lowercase CONSTANT definitions.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -21,8 +21,13 @@
 	<!-- important to prevent issues with content being sent before headers -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
 
+	<!-- Lowercase PHP constants, like true, false and null. -->
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions -->
 	<rule ref="Generic.PHP.LowerCaseConstant"/>
+
+	<!-- Dev defined constants should be in all upper-case with underscores separating words -->
+	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions -->
+	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#indentation -->
 	<arg name="tab-width" value="4"/>


### PR DESCRIPTION
> Constants should be in all upper-case with underscores separating words:
> ```php
> define( 'DOING_AJAX', true );
> ```

https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions

This was so far not covered by WPCS.