### PR TITLE
Add new sniff to check whether a hook name is valid.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -112,5 +112,6 @@
 	<rule ref="WordPress.PHP.YodaConditions"/>
 	<rule ref="WordPress.WP.I18n"/>
 	<rule ref="WordPress.Functions.DontExtract"/>
+	<rule ref="WordPress.NamingConventions.ValidHookName"/>
 
 </ruleset>

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -401,6 +401,44 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	);
 
 	/**
+	 * A list of functions that invoke WP hooks (filters/actions).
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $hookInvokeFunctions = array(
+		'do_action'                => true,
+		'do_action_ref_array'      => true,
+		'do_action_deprecated'     => true,
+		'apply_filters'            => true,
+		'apply_filters_ref_array'  => true,
+		'apply_filters_deprecated' => true,
+	);
+
+	/**
+	 * A list of functions that are used to interact with the WP plugins API.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array <string function name> => <int position of the hook name argument in function signature>
+	 */
+	public static $hookFunctions = array(
+		'has_filter'         => 1,
+		'add_filter'         => 1,
+		'remove_filter'      => 1,
+		'remove_all_filters' => 1,
+		'doing_filter'       => 1, // Hook name optional.
+		'has_action'         => 1,
+		'add_action'         => 1,
+		'doing_action'       => 1, // Hook name optional.
+		'did_action'         => 1,
+		'remove_action'      => 1,
+		'remove_all_actions' => 1,
+		'current_filter'     => 0, // No hook name argument.
+	);
+
+	/**
 	 * The current file being sniffed.
 	 *
 	 * @since 0.4.0

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -10,6 +10,11 @@
 /**
  * Use lowercase letters in action and filter names. Separate words via underscores.
  *
+ * This sniff is only testing the hook invoke functions as when using 'add_action'/'add_filter'
+ * you can't influence the hook name.
+ *
+ * Hook names invoked with `do_action_deprecated()` and `apply_filters_deprecated()` are ignored.
+ *
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
  *
  * @category PHP
@@ -53,21 +58,6 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 	protected $punctuation_regex = '`[^\w%s]`';
 
 	/**
-	 * Functions we're interested in.
-	 *
-	 * Only testing the hook call functions as when using 'add_action'/'add_filter' you can't influence
-	 * the hook name.
-	 *
-	 * @var array
-	 */
-	protected $hook_functions = array(
-		'do_action',
-		'do_action_ref_array',
-		'apply_filters',
-		'apply_filters_ref_array',
-	);
-
-	/**
 	 * Register this sniff.
 	 *
 	 * Prepares the punctuation regex and returns an array of tokens this test wants to listen for.
@@ -96,7 +86,12 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 		$regex  = $this->prepare_regex();
 
 		// Check if one of the hook functions was found.
-		if ( false === in_array( $tokens[ $stackPtr ]['content'], $this->hook_functions, true ) ) {
+		if ( ! isset( WordPress_Sniff::$hookInvokeFunctions[ $tokens[ $stackPtr ]['content'] ] ) ) {
+			return;
+		}
+
+		// Ignore deprecated hook names.
+		if ( strpos( $tokens[ $stackPtr ]['content'], '_deprecated' ) > 0 ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Use lowercase letters in action and filter names. Separate words via underscores.
+ *
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Functions we're interested in.
+	 *
+	 * Only testing the hook call functions as when using 'add_action'/'add_filter' you can't influence
+	 * the hook name.
+	 *
+	 * @var array
+	 */
+	public $hook_functions = array(
+		'do_action',
+		'do_action_ref_array',
+		'apply_filters',
+		'apply_filters_ref_array',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+		);
+
+	} // end register()
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array();
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		// Check if one of the hook functions was found.
+		if ( false === in_array( $tokens[ $stackPtr ]['content'], $this->hook_functions, true ) ) {
+			return;
+		}
+
+		$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
+
+		if ( false !== $prev ) {
+			// Skip sniffing if calling a same-named method, or on function definitions.
+			if ( in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true ) ) {
+				return;
+			}
+
+			// Skip namespaced functions, ie: \foo\bar() not \bar().
+			$pprev = $phpcsFile->findPrevious( T_WHITESPACE, ( $prev - 1 ), null, true );
+			if ( false !== $pprev && T_NS_SEPARATOR === $tokens[ $prev ]['code'] && T_STRING === $tokens[ $pprev ]['code'] ) {
+				return;
+			}
+		}
+		unset( $prev, $pprev );
+
+		/*
+		   Ok, so we have a proper hook call, let's find the position of the tokens
+		   which together comprise the hook name.
+		 */
+		$start = $phpcsFile->findNext( array( T_WHITESPACE, T_OPEN_PARENTHESIS ), ( $stackPtr + 1 ), null, true, null, true );
+		$open  = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $stackPtr + 1 ), null, false, null, true );
+		$end   = $phpcsFile->findNext( T_COMMA, ( $start + 1 ), null, false, null, true );
+		if ( false === $end || $end > $tokens[ $open ]['parenthesis_closer'] ) {
+			$end = $tokens[ $open ]['parenthesis_closer'];
+		}
+		if ( T_WHITESPACE === $tokens[ ( $end - 1 ) ]['code'] ) {
+			$end--;
+		}
+
+		$case_errors = 0;
+		$underscores = 0;
+		$content     = array();
+		$expected    = array();
+
+		for ( $i = $start; $i < $end; $i++ ) {
+			$content[ $i ]  = $tokens[ $i ]['content'];
+			$expected[ $i ] = $tokens[ $i ]['content'];
+
+			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				/*
+				   Here be dragons - a double quoted string can contain extrapolated variables
+				   which don't have to comply with these rules.
+				 */
+				if ( T_DOUBLE_QUOTED_STRING === $tokens[ $i ]['code'] ) {
+					$string          = trim( $tokens[ $i ]['content'], '"' );
+					$transform       = $this->transform_complex_string( $string );
+					$case_transform  = $this->transform_complex_string( $string, 'case' );
+					$punct_transform = $this->transform_complex_string( $string, 'punctuation' );
+				} else {
+					$string          = trim( $tokens[ $i ]['content'], '\'"' );
+					$transform       = $this->transform( $string );
+					$case_transform  = $this->transform( $string, 'case' );
+					$punct_transform = $this->transform( $string, 'punctuation' );
+				}
+
+				if ( $string === $transform ) {
+					continue;
+				}
+
+				if ( T_DOUBLE_QUOTED_STRING === $tokens[ $i ]['code'] ) {
+					$expected[ $i ] = '"' . $transform . '"';
+				} else {
+					$expected[ $i ] = '\'' . $transform . '\'';
+				}
+
+				if ( $string !== $case_transform ) {
+					$case_errors++;
+				}
+				if ( $string !== $punct_transform ) {
+					$underscores++;
+				}
+			}
+		}
+
+		$data = array(
+			implode( '', $expected ),
+			implode( '', $content ),
+		);
+
+		if ( $case_errors > 0 ) {
+			$error = 'Hook names should be lowercase. Expected: %s, but found: %s.';
+			$phpcsFile->addError( $error, $stackPtr, 'NotLowercase', $data );
+		}
+		if ( $underscores > 0 ) {
+			$error = 'Words in hook names should be separated using underscores. Expected: %s, but found: %s.';
+			$phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
+		}
+
+	} // end process()
+
+	/**
+	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
+	 *
+	 * @param string $string         The target string.
+	 * @param string $transform_type Whether to a partial or complete transform.
+	 *                               Valid values are: 'full', 'case', 'punctuation'.
+	 * @return string
+	 */
+	protected function transform( $string, $transform_type = 'full' ) {
+		switch ( $transform_type ) {
+			case 'case':
+				return strtolower( $string );
+
+			case 'punctuation':
+				return preg_replace( '`\W`', '_', $string );
+
+			case 'full':
+			default:
+				return preg_replace( '`\W`', '_', strtolower( $string ) );
+		}
+	} // end transform()
+
+	/**
+	 * Transform a complex string which may contain variable extrapolation.
+	 *
+	 * @param string $string         The target string.
+	 * @param string $transform_type Whether to a partial or complete transform.
+	 *                               Valid values are: 'full', 'case', 'punctuation'.
+	 * @return string
+	 */
+	protected function transform_complex_string( $string, $transform_type = 'full' ) {
+		$output = preg_split( '`([\{\}\$\[\] ])`', $string, -1, PREG_SPLIT_DELIM_CAPTURE );
+
+		$is_variable = false;
+		$has_braces  = false;
+		$braces      = 0;
+
+		foreach ( $output as $i => $part ) {
+			if ( in_array( $part, array( '$', '{' ), true ) ) {
+				$is_variable = true;
+				if ( '{' === $part ) {
+					$has_braces = true;
+					$braces++;
+				}
+				continue;
+			}
+
+			if ( true === $is_variable ) {
+				if ( '[' === $part ) {
+					$has_braces = true;
+					$braces++;
+				}
+				if ( in_array( $part, array( '}', ']' ), true ) ) {
+					$braces--;
+				}
+				if ( false === $has_braces && ' ' === $part ) {
+					$is_variable  = false;
+					$output[ $i ] = $this->transform( $part, $transform_type );
+				}
+
+				if ( ( true === $has_braces && 0 === $braces ) && false === in_array( $output[ ( $i + 1 ) ], array( '{', '[' ), true ) ) {
+					$has_braces  = false;
+					$is_variable = false;
+				}
+				continue;
+			}
+
+			$output[ $i ] = $this->transform( $part, $transform_type );
+		}
+
+		return implode( '', $output );
+	} // end transform_complex_string()
+
+} // end class

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -1,0 +1,17 @@
+<?php
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters -
+
+// These should now be ok.
+do_action( "admin_head-$hook_suffix" );
+do_action( 'admin_head-media-upload_popup' );
+apply_filters( "bulk_actions-{$this->screen->id}", $this->_actions );
+apply_filters( "current_theme-supports-{$feature}", true, $args, $_wp_theme_features[$feature] );
+
+// These should still give warnings.
+do_action( "admin_head*$hook_suffix" ); // Warning - use underscore.
+do_action( 'admin_head.media.upload_popup' ); // Warning - use underscore.
+apply_filters( "bulk_actions {$this->screen->id}", $this->_actions ); // Warning - use underscore.
+apply_filters( "current_theme/supports-{$feature}", true, $args, $_wp_theme_features[$feature] ); // Warning - use underscore.
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters _

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.2.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.2.inc
@@ -1,0 +1,17 @@
+<?php
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters -/.
+
+// These should now be ok.
+do_action( "admin_head-$hook_suffix" );
+do_action( 'admin_head.media-upload_popup' );
+apply_filters( "bulk_actions-{$this->screen->id}", $this->_actions );
+apply_filters( "current_theme/supports-{$feature}", true, $args, $_wp_theme_features[$feature] );
+
+// These should still give warnings.
+do_action( "admin_head*$hook_suffix" ); // Warning - use underscore.
+do_action( 'admin_head&media+upload_popup' ); // Warning - use underscore.
+apply_filters( "bulk_actions {$this->screen->id}", $this->_actions ); // Warning - use underscore.
+apply_filters( "current_theme#supports-{$feature}", true, $args, $_wp_theme_features[$feature] ); // Warning - use underscore.
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters _

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -79,3 +79,7 @@ do_action( "admin_Head_{${$Name}}_Action_{${$Name}}_Action" ); // Error - use lo
 do_action( "admin_Head_{$foo->{$baz[1]}}_Action_{$foo->{$baz[1]}}_Action" ); // Error - use lowercase.
 do_action( "admin_Head_{${getName()}}_Action_{${getName()}}_Action" ); // Error - use lowercase.
 do_action( "admin_Head_{${$object->getName()}}_Action_{${$object->getName()}}_Action" ); // Error - use lowercase.
+
+// Make sure that deprecated hook names are ignored for this sniff.
+do_action_deprecated( "admin_Head_$Post admin_Head_$Post" ); // Ok.
+apply_filters_deprecated( "admin_Head_$Post->ID admin_Head_$Post->ID" ); // Ok.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -2,7 +2,7 @@
 
 $this->do_action( 'someAction' ); // Ok - not WP do_action.
 SomeClass::do_action( 'someAction' ); // Ok - not WP do_action.
-\SomeClass\do_action( 'someAction' ); // Ok - not WP do_action.
+prefix_do_action( 'someAction' ); // Ok - not WP do_action.
 
 // Check for incorrect word separators.
 do_action( "admin_head-$hook_suffix" ); // Warning - use underscore.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -79,4 +79,3 @@ do_action( "admin_Head_{${$Name}}_Action_{${$Name}}_Action" ); // Error - use lo
 do_action( "admin_Head_{$foo->{$baz[1]}}_Action_{$foo->{$baz[1]}}_Action" ); // Error - use lowercase.
 do_action( "admin_Head_{${getName()}}_Action_{${getName()}}_Action" ); // Error - use lowercase.
 do_action( "admin_Head_{${$object->getName()}}_Action_{${$object->getName()}}_Action" ); // Error - use lowercase.
-

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.inc
@@ -1,0 +1,82 @@
+<?php
+
+$this->do_action( 'someAction' ); // Ok - not WP do_action.
+SomeClass::do_action( 'someAction' ); // Ok - not WP do_action.
+\SomeClass\do_action( 'someAction' ); // Ok - not WP do_action.
+
+// Check for incorrect word separators.
+do_action( "admin_head-$hook_suffix" ); // Warning - use underscore.
+do_action( 'admin_head.media.upload_popup' ); // Warning - use underscore.
+apply_filters( "bulk_actions {$this->screen->id}", $this->_actions ); // Warning - use underscore.
+apply_filters( "current_theme/supports-{$feature}", true, $args, $_wp_theme_features[$feature] ); // Warning - use underscore.
+
+// Simple strings.
+do_action( "adminHead" ); // Error - use lowercase.
+do_action_ref_array( 'ADMINHEAD', array( $variable ) ); // Error - use lowercase.
+apply_filters( 'adminHead', $variable ); // Error - use lowercase.
+apply_filters_ref_array( 'ADMINHEAD', array( $variable ) ); // Error - use lowercase.
+
+// Variable hooks.
+do_action( $Hook_name ); // Ok.
+do_action( "{$Hook_Name}" ); // Ok.
+
+// Compound hook names.
+do_action( 'admin_head_' . $Type . '_action' ); // ok.
+do_action( 'admin_head_' .  get_ID() . '_action' ); // Ok.
+do_action( 'admin_head_' . $post->ID . '_action' ); // Ok.
+
+do_action( 'admin_Head_' . $Type . '_Action' ); // Error - use lowercase.
+do_action( 'admin_Head_' .  get_ID() . '_Action' ); // Error - use lowercase.
+do_action( 'admin_Head_' . $post->ID . '_Action' ); // Error - use lowercase.
+
+do_action(
+	'admin_Head_' . $type,
+	$variable
+); // Error - use lowercase.
+
+// More complex strings.
+do_action( "admin_head_$Post" ); // Ok.
+do_action( "admin_head_$Post[1]_action" ); // Ok.
+do_action( "admin_head_$Post[Test]_action" ); // Ok.
+do_action( "admin_head_${Post}_action" ); // Ok.
+do_action( "admin_head_$Post->ID" ); // Ok.
+do_action( "admin_head_{$Post}" ); // Ok.
+do_action( "admin_head_{$Post['Key']}_action" ); // Ok.
+do_action( "admin_head_{$Post[1][2]}_action" ); // Ok.
+do_action( "admin_head_{$post->ID}_action" ); // Ok.
+do_action( "admin_head_{$obj->Values[3]->name}_action" ); // Ok.
+do_action( "admin_head_{${$Name}}_action" ); // Ok.
+do_action( "admin_head_{$foo->{$baz[1]}}_action" ); // Ok.
+do_action( "admin_head_{${getName()}}_action" ); // Ok.
+do_action( "admin_head_{${$object->getName()}}_action" ); // Ok.
+
+do_action( "admin_Head_$Post" ); // Error - use lowercase.
+do_action( "admin_Head_$Post[1]_Action" ); // Error - use lowercase.
+do_action( "admin_Head_$Post[Test]_Action" ); // Error - use lowercase.
+do_action( "admin_Head_${Post}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_$Post->ID" ); // Error - use lowercase.
+do_action( "admin_Head_{$Post}" );  // Error - use lowercase.
+do_action( "admin_Head_{$Post['Key']}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$Post[1][2]}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$post->ID}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$obj->Values[3]->name}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{${$Name}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$foo->{$baz[1]}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{${getName()}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{${$object->getName()}}_Action" ); // Error - use lowercase.
+
+do_action( "admin_Head_$Post admin_Head_$Post" ); // Error - use lowercase + warning about space.
+do_action( "admin_Head_$Post[1]_Action_$Post[1]_Action" ); // Error - use lowercase.
+do_action( "admin_Head_$Post[Test]_Action_$Post[Test]_Action" ); // Error - use lowercase.
+do_action( "admin_Head_${Post}_Action_${Post}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_$Post->ID admin_Head_$Post->ID" ); // Error - use lowercase + warning about space.
+do_action( "admin_Head_{$Post}_admin_Head_{$Post}" );  // Error - use lowercase.
+do_action( "admin_Head_{$Post['Key']}_Action_{$Post['Key']}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$Post[1][2]}_Action_{$Post[1][2]}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$post->ID}_Action_{$post->ID}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$obj->Values[3]->name}-Action_{$obj->Values[3]->name}_Action" ); // Error - use lowercase + warning about dash.
+do_action( "admin_Head_{${$Name}}_Action_{${$Name}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{$foo->{$baz[1]}}_Action_{$foo->{$baz[1]}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{${getName()}}_Action_{${getName()}}_Action" ); // Error - use lowercase.
+do_action( "admin_Head_{${$object->getName()}}_Action_{${$object->getName()}}_Action" ); // Error - use lowercase.
+

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -25,48 +25,61 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 	 * The key of the array should represent the line number and the value
 	 * should represent the number of errors that should occur on that line.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array<int, int>
 	 */
-	public function getErrorList() {
+	public function getErrorList( $testFile = 'ValidHookNameUnitTest.inc' ) {
 
-		return array(
-			14 => 1,
-			15 => 1,
-			16 => 1,
-			17 => 1,
-			28 => 1,
-			29 => 1,
-			30 => 1,
-			32 => 1,
-			53 => 1,
-			54 => 1,
-			55 => 1,
-			56 => 1,
-			57 => 1,
-			58 => 1,
-			59 => 1,
-			60 => 1,
-			61 => 1,
-			62 => 1,
-			63 => 1,
-			64 => 1,
-			65 => 1,
-			66 => 1,
-			68 => 1,
-			69 => 1,
-			70 => 1,
-			71 => 1,
-			72 => 1,
-			73 => 1,
-			74 => 1,
-			75 => 1,
-			76 => 1,
-			77 => 1,
-			78 => 1,
-			79 => 1,
-			80 => 1,
-			81 => 1,
-		);
+		switch ( $testFile ) {
+			case 'ValidHookNameUnitTest.inc':
+				return array(
+					14 => 1,
+					15 => 1,
+					16 => 1,
+					17 => 1,
+					28 => 1,
+					29 => 1,
+					30 => 1,
+					32 => 1,
+					53 => 1,
+					54 => 1,
+					55 => 1,
+					56 => 1,
+					57 => 1,
+					58 => 1,
+					59 => 1,
+					60 => 1,
+					61 => 1,
+					62 => 1,
+					63 => 1,
+					64 => 1,
+					65 => 1,
+					66 => 1,
+					68 => 1,
+					69 => 1,
+					70 => 1,
+					71 => 1,
+					72 => 1,
+					73 => 1,
+					74 => 1,
+					75 => 1,
+					76 => 1,
+					77 => 1,
+					78 => 1,
+					79 => 1,
+					80 => 1,
+					81 => 1,
+				);
+				break;
+
+			case 'ValidHookNameUnitTest.1.inc':
+			case 'ValidHookNameUnitTest.2.inc':
+			default:
+				return array();
+				break;
+
+		} // end switch
 
 	} // end getErrorList()
 
@@ -76,18 +89,39 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 	 * The key of the array should represent the line number and the value
 	 * should represent the number of warnings that should occur on that line.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array<int, int>
 	 */
-	public function getWarningList() {
-		return array(
-			8 => 1,
-			9 => 1,
-			10 => 1,
-			11 => 1,
-			68 => 1,
-			72 => 1,
-			77 => 1,
-		);
+	public function getWarningList( $testFile = 'ValidHookNameUnitTest.inc' ) {
+
+		switch ( $testFile ) {
+			case 'ValidHookNameUnitTest.inc':
+				return array(
+					8 => 1,
+					9 => 1,
+					10 => 1,
+					11 => 1,
+					68 => 1,
+					72 => 1,
+					77 => 1,
+				);
+				break;
+
+			case 'ValidHookNameUnitTest.1.inc':
+			case 'ValidHookNameUnitTest.2.inc':
+				return array(
+					12 => 1,
+					13 => 1,
+					14 => 1,
+					15 => 1,
+				);
+				break;
+
+			default:
+				return array();
+				break;
+		} // end switch
 
 	} // end getWarningList()
 

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -71,13 +71,11 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 					80 => 1,
 					81 => 1,
 				);
-				break;
 
 			case 'ValidHookNameUnitTest.1.inc':
 			case 'ValidHookNameUnitTest.2.inc':
 			default:
 				return array();
-				break;
 
 		} // end switch
 
@@ -106,7 +104,6 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 					72 => 1,
 					77 => 1,
 				);
-				break;
 
 			case 'ValidHookNameUnitTest.1.inc':
 			case 'ValidHookNameUnitTest.2.inc':
@@ -116,11 +113,10 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 					14 => 1,
 					15 => 1,
 				);
-				break;
 
 			default:
 				return array();
-				break;
+
 		} // end switch
 
 	} // end getWarningList()

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the ValidHookName sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList() {
+
+		return array(
+			14 => 1,
+			15 => 1,
+			16 => 1,
+			17 => 1,
+			28 => 1,
+			29 => 1,
+			30 => 1,
+			32 => 1,
+			53 => 1,
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
+			58 => 1,
+			59 => 1,
+			60 => 1,
+			61 => 1,
+			62 => 1,
+			63 => 1,
+			64 => 1,
+			65 => 1,
+			66 => 1,
+			68 => 1,
+			69 => 1,
+			70 => 1,
+			71 => 1,
+			72 => 1,
+			73 => 1,
+			74 => 1,
+			75 => 1,
+			76 => 1,
+			77 => 1,
+			78 => 1,
+			79 => 1,
+			80 => 1,
+			81 => 1,
+		);
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList() {
+		return array(
+			8 => 1,
+			9 => 1,
+			10 => 1,
+			11 => 1,
+			68 => 1,
+			72 => 1,
+			77 => 1,
+		);
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
Covers the `action` part of this rule in the handbook:
> Use lowercase letters in variable, **action**, and function names (never camelCase). Separate words via underscores.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions

Review appreciated.

Also: I've made non-lowercase hook names an `error` and non-underscore punctuation a `warning`. Should that also be an `error` ?