### PR TITLE
Up the minimum required PHPCS version to 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.4.0
+  - PHPCS_BRANCH=2.6.0
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.4"
+		"squizlabs/php_codesniffer": "^2.6"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
PHPCS 2.6 contains a fix for the bug reported in issue https://github.com/squizlabs/PHP_CodeSniffer/issues/698.
PHPCS 2.6 also [contains a fix](https://github.com/squizlabs/PHP_CodeSniffer/pull/581) which will allow for checking that [`include/require` statements have DocBlocks](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#3-requires-and-includes) as required by the handbook.

Closes #566