### PR TITLE
Add PHP syntax check sniff to the `core` ruleset.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -2,6 +2,9 @@
 <ruleset name="WordPress Core">
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 
+	<!-- Check for PHP Parse errors -->
+	<rule ref="Generic.PHP.Syntax"/>
+
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#brace-style -->
 	<rule ref="Generic.ControlStructures.InlineControlStructure" />
 	<rule ref="Squiz.ControlStructures.ControlSignature" />


### PR DESCRIPTION
This will let PHPCS run a lint over the PHP files it checks as well.

Closes #522 
