### PR TITLE
Turn the three abstract classes into proper abstracts.

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Restricts array assignment of certain keys.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Shady Sharaf <shady@x-team.com>
+ */
+abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPress_Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'foo,bar'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Groups of variable data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @var array
+	 */
+	public static $groups = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_DOUBLE_ARROW,
+			T_CLOSE_SQUARE_BRACKET,
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+		);
+
+	} // end register()
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 * 	'wpdb' => array(
+	 * 		'type' => 'error' | 'warning',
+	 * 		'message' => 'Dont use this one please!',
+	 * 		'variables' => array( '$val', '$var' ),
+	 * 		'object_vars' => array( '$foo->bar', .. ),
+	 * 		'array_members' => array( '$foo['bar']', .. ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		$groups = $this->getGroups();
+
+		if ( empty( $groups ) ) {
+			$phpcsFile->removeTokenListener( $this, $this->register() );
+			return;
+		}
+
+		$tokens  = $phpcsFile->getTokens();
+		$token   = $tokens[ $stackPtr ];
+		$exclude = explode( ',', $this->exclude );
+
+		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ), true ) ) {
+			$equal = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( T_EQUAL !== $tokens[ $equal ]['code'] ) {
+				return; // This is not an assignment!
+			}
+		}
+
+		// Instances: Multi-dimensional array, keyed by line.
+		$inst = array();
+
+		/*
+		   Covers:
+		   $foo = array( 'bar' => 'taz' );
+		   $foo['bar'] = $taz;
+		 */
+		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
+			if ( T_CLOSE_SQUARE_BRACKET === $token['code']  ) {
+				$operator = $phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
+			} elseif ( T_DOUBLE_ARROW === $token['code'] ) {
+				$operator = $stackPtr;
+			}
+			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			if ( ! is_numeric( $tokens[ $keyIdx ]['content'] ) ) {
+				$key            = trim( $tokens[ $keyIdx ]['content'], '\'"' );
+				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
+				$val            = trim( $val, '\'"' );
+				$inst[ $key ][] = array( $val, $token['line'] );
+			}
+		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			// $foo = 'bar=taz&other=thing';
+			if ( preg_match_all( '#[\'"&]([a-z_]+)=([^\'"&]*)#i', $token['content'], $matches ) <= 0 ) {
+				return; // No assignments here, nothing to check.
+			}
+			foreach ( $matches[1] as $i => $_k ) {
+				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
+			}
+		}
+
+		if ( empty( $inst ) ) {
+			return;
+		}
+
+		foreach ( $groups as $groupName => $group ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
+				continue;
+			}
+
+			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
+
+			foreach ( $inst as $key => $assignments ) {
+				foreach ( $assignments as $occurance ) {
+					list( $val, $line ) = $occurance;
+
+					if ( ! in_array( $key, $group['keys'], true ) ) {
+						continue;
+					}
+
+					$output = call_user_func( $callback, $key, $val, $line, $group );
+
+					if ( ! isset( $output ) || false === $output ) {
+						continue;
+					} elseif ( true === $output ) {
+						$message = $group['message'];
+					} else {
+						$message = $output;
+					}
+
+					if ( 'warning' === $group['type'] ) {
+						$addWhat = array( $phpcsFile, 'addWarning' );
+					} else {
+						$addWhat = array( $phpcsFile, 'addError' );
+					}
+
+					call_user_func(
+						$addWhat,
+						$message,
+						$stackPtr,
+						$groupName,
+						array( $key, $val )
+					);
+				}
+			}
+
+			// return; // Show one error only.
+		}
+
+	} // end process()
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 *
+	 * This method must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	abstract public function callback( $key, $val, $line, $group );
+
+} // end class

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Restricts usage of some functions.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Shady Sharaf <shady@x-team.com>
+ */
+abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'switch_to_blog,user_meta'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+			T_EVAL,
+		);
+
+	} // end register()
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		// Exclude function definitions, class methods, and namespaced calls.
+		if (
+			T_STRING === $token['code']
+			&&
+			( $prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true ) )
+			&&
+			(
+				// Skip sniffing if calling a method, or on function definitions.
+				in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true )
+				||
+				(
+					// Skip namespaced functions, ie: \foo\bar() not \bar().
+					T_NS_SEPARATOR === $tokens[ $prev ]['code']
+					&&
+					( $pprev = $phpcsFile->findPrevious( T_WHITESPACE, ( $prev - 1 ), null, true ) )
+					&&
+					T_STRING === $tokens[ $pprev ]['code']
+				)
+			)
+			) {
+			return;
+		}
+
+		$exclude = explode( ',', $this->exclude );
+
+		$groups = $this->getGroups();
+
+		if ( empty( $groups ) ) {
+			return ( count( $tokens ) + 1 );
+		}
+
+		foreach ( $groups as $groupName => $group ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
+				continue;
+			}
+
+			$functions = implode( '|', $group['functions'] );
+			$functions = preg_replace( '#[^\.]\*#', '.*', $functions ); // So you can use * instead of .*
+
+			if ( preg_match( '#\b(' . $functions . ')\b#', $token['content'] ) < 1 ) {
+				continue;
+			}
+
+			if ( 'warning' === $group['type'] ) {
+				$addWhat = array( $phpcsFile, 'addWarning' );
+			} else {
+				$addWhat = array( $phpcsFile, 'addError' );
+			}
+
+			call_user_func(
+				$addWhat,
+				$group['message'],
+				$stackPtr,
+				$groupName,
+				array( $token['content'] )
+			);
+
+		}
+
+	} // end process()
+
+} // end class

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Restricts usage of some variables.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Shady Sharaf <shady@x-team.com>
+ */
+abstract class WordPress_AbstractVariableRestrictionsSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'foo,bar'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Groups of variable data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @var array
+	 */
+	public static $groups = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+			T_OBJECT_OPERATOR,
+			T_DOUBLE_COLON,
+			T_OPEN_SQUARE_BRACKET,
+			T_DOUBLE_QUOTED_STRING,
+		);
+
+	} // end register()
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 * 	'wpdb' => array(
+	 * 		'type' => 'error' | 'warning',
+	 * 		'message' => 'Dont use this one please!',
+	 * 		'variables' => array( '$val', '$var' ),
+	 * 		'object_vars' => array( '$foo->bar', .. ),
+	 * 		'array_members' => array( '$foo['bar']', .. ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens  = $phpcsFile->getTokens();
+		$token   = $tokens[ $stackPtr ];
+		$exclude = explode( ',', $this->exclude );
+		$groups  = $this->getGroups();
+
+		if ( empty( $groups ) ) {
+			return ( count( $tokens ) + 1 );
+		}
+
+		// Check if it is a function not a variable.
+		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
+			$method               = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
+			if ( T_OPEN_PARENTHESIS === $tokens[ $possible_parenthesis ]['code'] ) {
+				return; // So .. it is a function after all !
+			}
+		}
+
+		foreach ( $groups as $groupName => $group ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
+				continue;
+			}
+
+			$patterns = array();
+
+			// Simple variable.
+			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['variables'] ) ) {
+				$patterns = array_merge( $patterns, $group['variables'] );
+				$var      = $token['content'];
+
+			} elseif ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
+				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar
+				$patterns = array_merge( $patterns, $group['object_vars'] );
+
+				$owner = $phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
+				$child = $phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
+				$var   = implode( '', array( $tokens[ $owner ]['content'], $token['content'], $tokens[ $child ]['content'] ) );
+
+			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
+				// Array members.
+				$patterns = array_merge( $patterns, $group['array_members'] );
+
+				$owner  = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
+				$inside = $phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+				$var    = implode( '', array( $tokens[ $owner ]['content'], $inside ) );
+			} else {
+				continue;
+			}
+
+			if ( empty( $patterns ) ) {
+				continue;
+			}
+
+			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
+			$pattern  = implode( '|', $patterns );
+			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) ? '\b' : '';
+
+			if ( T_DOUBLE_QUOTED_STRING === $token['code'] ) {
+				$var = $token['content'];
+			}
+
+			if ( preg_match( '#(' . $pattern . ')' . $delim . '#', $var, $match ) !== 1 ) {
+				continue;
+			}
+
+			if ( 'warning' === $group['type'] ) {
+				$addWhat = array( $phpcsFile, 'addWarning' );
+			} else {
+				$addWhat = array( $phpcsFile, 'addError' );
+			}
+
+			call_user_func(
+				$addWhat,
+				$group['message'],
+				$stackPtr,
+				$groupName,
+				array( $var )
+			);
+
+			return; // Show one error only.
+
+		}
+
+	} // end process()
+
+	private function test_patterns( $pattern ) {
+		$pattern = preg_quote( $pattern, '#' );
+		$pattern = preg_replace(
+			array( '#\\\\\*#', '[\'"]' ),
+			array( '.*', '\'' ),
+			$pattern
+		);
+		return $pattern;
+	} // end test_patterns()
+
+} // end class

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -10,48 +10,21 @@
 /**
  * Restricts array assignment of certain keys.
  *
+ * @deprecated 0.1.0 The functionality which used to be contained in this class has been moved to
+ *                   the WordPress_AbstractArrayAssignmentRestrictionsSniff class.
+ *                   This class is left here to prevent backward-compatibility breaks for
+ *                   custom sniffs extending the old class and references to this
+ *                   sniff from custom phpcs.xml files.
+ *                   This file is also still used to unit test the abstract class.
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_Sniff {
-
-	/**
-	 * Exclude groups.
-	 *
-	 * Example: 'foo,bar'
-	 *
-	 * @var string Comma-delimited group list.
-	 */
-	public $exclude = '';
-
-	/**
-	 * Groups of variable data to check against.
-	 * Don't use this in extended classes, override getGroups() instead.
-	 * This is only used for Unit tests.
-	 *
-	 * @var array
-	 */
-	public static $groups = array();
-
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		return array(
-			T_DOUBLE_ARROW,
-			T_CLOSE_SQUARE_BRACKET,
-			T_CONSTANT_ENCAPSED_STRING,
-			T_DOUBLE_QUOTED_STRING,
-		);
-
-	} // end register()
+class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
 	 * 	'wpdb' => array(
@@ -66,125 +39,11 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 * @return array
 	 */
 	public function getGroups() {
-		return self::$groups;
+		return parent::$groups;
 	}
 
 	/**
-	 * Processes this test, when one of its tokens is encountered.
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
-	 *
-	 * @return void
-	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-
-		$groups = $this->getGroups();
-
-		if ( empty( $groups ) ) {
-			$phpcsFile->removeTokenListener( $this, $this->register() );
-			return;
-		}
-
-		$tokens  = $phpcsFile->getTokens();
-		$token   = $tokens[ $stackPtr ];
-		$exclude = explode( ',', $this->exclude );
-
-		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ), true ) ) {
-			$equal = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			if ( T_EQUAL !== $tokens[ $equal ]['code'] ) {
-				return; // This is not an assignment!
-			}
-		}
-
-		// Instances: Multi-dimensional array, keyed by line.
-		$inst = array();
-
-		/*
-		   Covers:
-		   $foo = array( 'bar' => 'taz' );
-		   $foo['bar'] = $taz;
-		 */
-		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
-			if ( T_CLOSE_SQUARE_BRACKET === $token['code']  ) {
-				$operator = $phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
-			} elseif ( T_DOUBLE_ARROW === $token['code'] ) {
-				$operator = $stackPtr;
-			}
-			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
-			if ( ! is_numeric( $tokens[ $keyIdx ]['content'] ) ) {
-				$key            = trim( $tokens[ $keyIdx ]['content'], '\'"' );
-				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
-				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
-				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
-				$val            = trim( $val, '\'"' );
-				$inst[ $key ][] = array( $val, $token['line'] );
-			}
-		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
-			// $foo = 'bar=taz&other=thing';
-			if ( preg_match_all( '#[\'"&]([a-z_]+)=([^\'"&]*)#i', $token['content'], $matches ) <= 0 ) {
-				return; // No assignments here, nothing to check.
-			}
-			foreach ( $matches[1] as $i => $_k ) {
-				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
-			}
-		}
-
-		if ( empty( $inst ) ) {
-			return;
-		}
-
-		foreach ( $groups as $groupName => $group ) {
-
-			if ( in_array( $groupName, $exclude, true ) ) {
-				continue;
-			}
-
-			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
-
-			foreach ( $inst as $key => $assignments ) {
-				foreach ( $assignments as $occurance ) {
-					list( $val, $line ) = $occurance;
-
-					if ( ! in_array( $key, $group['keys'], true ) ) {
-						continue;
-					}
-
-					$output = call_user_func( $callback, $key, $val, $line, $group );
-
-					if ( ! isset( $output ) || false === $output ) {
-						continue;
-					} elseif ( true === $output ) {
-						$message = $group['message'];
-					} else {
-						$message = $output;
-					}
-
-					if ( 'warning' === $group['type'] ) {
-						$addWhat = array( $phpcsFile, 'addWarning' );
-					} else {
-						$addWhat = array( $phpcsFile, 'addError' );
-					}
-
-					call_user_func(
-						$addWhat,
-						$message,
-						$stackPtr,
-						$groupName,
-						array( $key, $val )
-					);
-				}
-			}
-
-			// return; // Show one error only.
-		}
-
-	} // end process()
-
-	/**
 	 * Callback to process each confirmed key, to check value.
-	 * This must be extended to add the logic to check assignment value.
 	 *
 	 * @param  string $key   Array index / key.
 	 * @param  mixed  $val   Assigned value.

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -10,33 +10,17 @@
 /**
  * Restricts usage of some functions.
  *
+ * @deprecated 0.1.0 The functionality which used to be contained in this class has been moved to
+ *                   the WordPress_AbstractFunctionRestrictionsSniff class.
+ *                   This class is left here to prevent backward-compatibility breaks for
+ *                   custom sniffs extending the old class and references to this
+ *                   sniff from custom phpcs.xml files.
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSniffer_Sniff {
-
-	/**
-	 * Exclude groups.
-	 *
-	 * Example: 'switch_to_blog,user_meta'
-	 *
-	 * @var string Comma-delimited group list.
-	 */
-	public $exclude = '';
-
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		return array(
-			T_STRING,
-			T_EVAL,
-		);
-
-	} // end register()
+class WordPress_Sniffs_Functions_FunctionRestrictionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.
@@ -54,80 +38,5 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff implements PHP_CodeSn
 	public function getGroups() {
 		return array();
 	}
-
-	/**
-	 * Processes this test, when one of its tokens is encountered.
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
-	 *
-	 * @return void
-	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
-
-		// Exclude function definitions, class methods, and namespaced calls.
-		if (
-			T_STRING === $token['code']
-			&&
-			( $prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true ) )
-			&&
-			(
-				// Skip sniffing if calling a method, or on function definitions.
-				in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true )
-				||
-				(
-					// Skip namespaced functions, ie: \foo\bar() not \bar().
-					T_NS_SEPARATOR === $tokens[ $prev ]['code']
-					&&
-					( $pprev = $phpcsFile->findPrevious( T_WHITESPACE, ( $prev - 1 ), null, true ) )
-					&&
-					T_STRING === $tokens[ $pprev ]['code']
-				)
-			)
-			) {
-			return;
-		}
-
-		$exclude = explode( ',', $this->exclude );
-
-		$groups = $this->getGroups();
-
-		if ( empty( $groups ) ) {
-			return ( count( $tokens ) + 1 );
-		}
-
-		foreach ( $groups as $groupName => $group ) {
-
-			if ( in_array( $groupName, $exclude, true ) ) {
-				continue;
-			}
-
-			$functions = implode( '|', $group['functions'] );
-			$functions = preg_replace( '#[^\.]\*#', '.*', $functions ); // So you can use * instead of .*
-
-			if ( preg_match( '#\b(' . $functions . ')\b#', $token['content'] ) < 1 ) {
-				continue;
-			}
-
-			if ( 'warning' === $group['type'] ) {
-				$addWhat = array( $phpcsFile, 'addWarning' );
-			} else {
-				$addWhat = array( $phpcsFile, 'addError' );
-			}
-
-			call_user_func(
-				$addWhat,
-				$group['message'],
-				$stackPtr,
-				$groupName,
-				array( $token['content'] )
-			);
-
-		}
-
-	} // end process()
 
 } // end class

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -15,7 +15,7 @@
  * @category PHP
  * @package  PHP_CodeSniffer
  */
-class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
+class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -14,7 +14,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
+class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -14,7 +14,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_Sniffs_Functions_FunctionRestrictionsSniff {
+class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -14,7 +14,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_Sniffs_Variables_VariableRestrictionsSniff {
+class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_AbstractVariableRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -14,7 +14,7 @@
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff {
+class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.
@@ -66,5 +66,20 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_Sniffs_Arrays_Arra
 
 		parent::process( $phpcsFile, $stackPtr );
 	} // end process()
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		return true;
+	} // end callback()
 
 } // end class

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -10,49 +10,21 @@
 /**
  * Restricts usage of some variables.
  *
+ * @deprecated 0.1.0 The functionality which used to be contained in this class has been moved to
+ *                   the WordPress_AbstractVariableRestrictionsSniff class.
+ *                   This class is left here to prevent backward-compatibility breaks for
+ *                   custom sniffs extending the old class and references to this
+ *                   sniff from custom phpcs.xml files.
+ *                   This file is also still used to unit test the abstract class.
+ *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSniffer_Sniff {
-
-	/**
-	 * Exclude groups.
-	 *
-	 * Example: 'foo,bar'
-	 *
-	 * @var string Comma-delimited group list.
-	 */
-	public $exclude = '';
-
-	/**
-	 * Groups of variable data to check against.
-	 * Don't use this in extended classes, override getGroups() instead.
-	 * This is only used for Unit tests.
-	 *
-	 * @var array
-	 */
-	public static $groups = array();
-
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		return array(
-			T_VARIABLE,
-			T_OBJECT_OPERATOR,
-			T_DOUBLE_COLON,
-			T_OPEN_SQUARE_BRACKET,
-			T_DOUBLE_QUOTED_STRING,
-		);
-
-	} // end register()
+class WordPress_Sniffs_Variables_VariableRestrictionsSniff extends WordPress_AbstractVariableRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
 	 * 	'wpdb' => array(
@@ -67,113 +39,7 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff implements PHP_CodeSn
 	 * @return array
 	 */
 	public function getGroups() {
-		return self::$groups;
+		return parent::$groups;
 	}
-
-	/**
-	 * Processes this test, when one of its tokens is encountered.
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
-	 *
-	 * @return void
-	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens  = $phpcsFile->getTokens();
-		$token   = $tokens[ $stackPtr ];
-		$exclude = explode( ',', $this->exclude );
-		$groups  = $this->getGroups();
-
-		if ( empty( $groups ) ) {
-			return ( count( $tokens ) + 1 );
-		}
-
-		// Check if it is a function not a variable.
-		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
-			$method               = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
-			if ( T_OPEN_PARENTHESIS === $tokens[ $possible_parenthesis ]['code'] ) {
-				return; // So .. it is a function after all !
-			}
-		}
-
-		foreach ( $groups as $groupName => $group ) {
-
-			if ( in_array( $groupName, $exclude, true ) ) {
-				continue;
-			}
-
-			$patterns = array();
-
-			// Simple variable.
-			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['variables'] ) ) {
-				$patterns = array_merge( $patterns, $group['variables'] );
-				$var      = $token['content'];
-
-			} elseif ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
-				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar
-				$patterns = array_merge( $patterns, $group['object_vars'] );
-
-				$owner = $phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
-				$child = $phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
-				$var   = implode( '', array( $tokens[ $owner ]['content'], $token['content'], $tokens[ $child ]['content'] ) );
-
-			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
-				// Array members.
-				$patterns = array_merge( $patterns, $group['array_members'] );
-
-				$owner  = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
-				$inside = $phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
-				$var    = implode( '', array( $tokens[ $owner ]['content'], $inside ) );
-			} else {
-				continue;
-			}
-
-			if ( empty( $patterns ) ) {
-				continue;
-			}
-
-			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
-			$pattern  = implode( '|', $patterns );
-			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) ? '\b' : '';
-
-			if ( T_DOUBLE_QUOTED_STRING === $token['code'] ) {
-				$var = $token['content'];
-			}
-
-			if ( preg_match( '#(' . $pattern . ')' . $delim . '#', $var, $match ) !== 1 ) {
-				continue;
-			}
-
-			if ( 'warning' === $group['type'] ) {
-				$addWhat = array( $phpcsFile, 'addWarning' );
-			} else {
-				$addWhat = array( $phpcsFile, 'addError' );
-			}
-
-			call_user_func(
-				$addWhat,
-				$group['message'],
-				$stackPtr,
-				$groupName,
-				array( $var )
-			);
-
-			return; // Show one error only.
-
-		}
-
-	} // end process()
-
-	private function test_patterns( $pattern ) {
-		$pattern = preg_quote( $pattern, '#' );
-		$pattern = preg_replace(
-			array( '#\\\\\*#', '[\'"]' ),
-			array( '.*', '\'' ),
-			$pattern
-		);
-		return $pattern;
-	} // end test_patterns()
 
 } // end class

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -20,7 +20,7 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 	protected function setUp() {
 		parent::setUp();
 
-		WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff::$groups = array(
+		WordPress_AbstractArrayAssignmentRestrictionsSniff::$groups = array(
 			'posts_per_page' => array(
 				'type'    => 'error',
 				'message' => 'Found assignment value of %s to be %s',

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -20,7 +20,7 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 	protected function setUp() {
 		parent::setUp();
 
-		WordPress_Sniffs_Variables_VariableRestrictionsSniff::$groups = array(
+		WordPress_AbstractVariableRestrictionsSniff::$groups = array(
 			'test' => array(
 				'type'          => 'error',
 				'message'       => 'Detected usage of %s',


### PR DESCRIPTION
Solves:

> Apart from the main WordPress_Sniff, there are three sniffs in WPCS which do not have native functionality, but look to be intended as abstract classes to be implemented in concrete child classes.
>
>    WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff - 3 child classes
>    WordPress_Sniffs_Functions_FunctionRestrictionsSniff - 1 child class
>    WordPress_Sniffs_Variables_VariableRestrictionsSniff - 1 child class

The solution as implemented in this PR will prevent backward-compatibility breaks from custom sniffs implementing the "old" classes and/or references to these from `phpcs.xml` files.
The three 'interim' classes which allow for this, have all been marked with detailed `@deprecated`  documentation.

It also continues to unit test the two which had (and have) unit tests attached.

Fixes #594

Rationale:
> Reason for my question was that with the Theme Review project, I already ran into one confusion with someone adjusting one of these classes instead of extending it.
> I would hope that having them in the more logical location and being abstract would make it easier to understand for people new to WPCS how to start using them when contributing.