### PR TITLE
Separate out the sniffing for `extract()`.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -111,5 +111,6 @@
 	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
 	<rule ref="WordPress.PHP.YodaConditions"/>
 	<rule ref="WordPress.WP.I18n"/>
+	<rule ref="WordPress.Functions.DontExtract"/>
 
 </ruleset>

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Restricts the usage of extract().
+ *
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#dont-extract
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Shady Sharaf <shady@x-team.com>
+ */
+class WordPress_Sniffs_Functions_DontExtractSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'extract' => array(
+				'type'      => 'error',
+				'message'   => '%s() usage is highly discouraged, due to the complexity and unintended issues it might cause.',
+				'functions' => array(
+					'extract',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // end class

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -139,14 +139,6 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				),
 			),
 
-			'extract' => array(
-				'type'      => 'warning',
-				'message'   => '%s() usage is highly discouraged, due to the complexity and unintended issues it might cause.',
-				'functions' => array(
-					'extract',
-				),
-			),
-
 			'custom_role' => array(
 				'type'      => 'error',
 				'message'   => 'Use wpcom_vip_add_role() instead of add_role()',

--- a/WordPress/Tests/Functions/DontExtractUnitTest.inc
+++ b/WordPress/Tests/Functions/DontExtractUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+extract( array( 'a' => 1 ) ); // bad
+
+// Similarly named functions or methods however are fine.
+my_extract(); // Ok.
+My_Object::extract(); // Ok.
+$this->extract(); // Ok.
+$my_object->extract(); // Ok.

--- a/WordPress/Tests/Functions/DontExtractUnitTest.php
+++ b/WordPress/Tests/Functions/DontExtractUnitTest.php
@@ -20,7 +20,7 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+class WordPress_Tests_Functions_DontExtractUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -33,44 +33,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 	public function getErrorList() {
 		return array(
 			3  => 1,
-			5  => 1,
-			21 => 1,
-			34 => version_compare( PHP_VERSION, '5.3.0', '>=' ) ? 0 : 1,
-			36 => 1,
-			38 => 1,
-			40 => 1,
-			42 => 1,
-			44 => 1,
-			46 => 1,
-			48 => 1,
-			50 => 1,
-			53 => 1,
-			54 => 1,
-			55 => 1,
-			56 => 1,
-			57 => 1,
-			62 => 1,
-			63 => 1,
-			64 => 1,
-			65 => 1,
-			66 => 1,
-			67 => 1,
-			68 => 1,
-			69 => 1,
-			70 => 1,
-			71 => 1,
-			74 => 1,
-			75 => 2,
-			76 => 1,
-			77 => 1,
-			78 => 1,
-			79 => 1,
-			80 => 1,
-			81 => 1,
-			82 => 1,
-			83 => 1,
-			84 => 1,
-			85 => 1,
 		);
 
 	} // end getErrorList()
@@ -84,18 +46,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 	 * @return array(int => int)
 	 */
 	public function getWarningList() {
-		return array(
-			7  => 1,
-			9  => 1,
-			11 => 1,
-			13 => 1,
-			15 => 1,
-			17 => 1,
-			58 => 1,
-			59 => 1,
-			61 => 1,
-			72 => 1,
-		);
+		return array();
 
 	} // end getWarningList()
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -16,7 +16,7 @@ $ch = curl_init(); // bad
 
 curl_close( $ch ); // bad
 
-extract( array( 'a' => 1 ) ); // bad
+// Empty line - function moved to another sniff.
 
 add_role( 'test' ); // bad
 


### PR DESCRIPTION
Currently only VIP checked for the usage of `extract()`, even though it is an explicit rule for core.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#dont-extract

Solves #90 for real ;-)