### PR TITLE
Better cover the regex related rules.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -118,6 +118,6 @@
 	<rule ref="WordPress.DB.RestrictedFunctions"/>
 	<rule ref="WordPress.DB.RestrictedClasses"/>
 
-		<rule ref="WordPress.PHP.POSIXFunctions" />
+	<rule ref="WordPress.PHP.POSIXFunctions" />
 
 </ruleset>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -116,7 +116,8 @@
 	<rule ref="WordPress.Functions.DontExtract"/>
 	<rule ref="WordPress.NamingConventions.ValidHookName"/>
 	<rule ref="WordPress.DB.RestrictedFunctions"/>
-
 	<rule ref="WordPress.DB.RestrictedClasses"/>
+
+		<rule ref="WordPress.PHP.POSIXFunctions" />
 
 </ruleset>

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -31,13 +31,6 @@ class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_
 	 * @var array(string => string|null)
 	 */
 	public $forbiddenFunctions = array(
-		// Deprecated.
-		'ereg_replace'             => 'preg_replace',
-		'ereg'                     => null,
-		'eregi_replace'            => 'preg_replace',
-		'split'                    => null,
-		'spliti'                   => null,
-
 		// Development.
 		'print_r'                  => null,
 		'debug_print_backtrace'    => null,

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Perl compatible regular expressions (PCRE, preg_ functions) should be used in preference
+ * to their POSIX counterparts.
+ *
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions
+ * @link     http://php.net/manual/en/ref.regex.php
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_PHP_POSIXFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'ereg' => array(
+				'type'      => 'error',
+				'message'   => '%s has been deprecated since PHP 5.3 and removed in PHP 7.0, please use preg_match() instead.',
+				'functions' => array(
+					'ereg',
+					'eregi',
+					'sql_regcase',
+				),
+			),
+
+			'ereg_replace' => array(
+				'type'      => 'error',
+				'message'   => '%s has been deprecated since PHP 5.3 and removed in PHP 7.0, please use preg_replace() instead.',
+				'functions' => array(
+					'ereg_replace',
+					'eregi_replace',
+				),
+			),
+
+			'split' => array(
+				'type'      => 'error',
+				'message'   => '%s  has been deprecated since PHP 5.3 and removed in PHP 7.0, please use explode(), str_split() or preg_split() instead.',
+				'functions' => array(
+					'split',
+					'spliti',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // end class

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -285,38 +285,6 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				),
 			),
 
-			'ereg' => array(
-				'type'      => 'error',
-				'message'   => '%s is prohibited, please use preg_match() instead. See http://php.net/manual/en/function.ereg.php',
-				'functions' => array(
-					'ereg',
-				),
-			),
-
-			'eregi' => array(
-				'type'      => 'error',
-				'message'   => '%s is prohibited, please use preg_match() with i modifier instead. See http://php.net/manual/en/function.eregi.php',
-				'functions' => array(
-					'eregi',
-				),
-			),
-
-			'ereg_replace' => array(
-				'type'      => 'error',
-				'message'   => '%s is prohibited, please use preg_replace() instead. See http://php.net/manual/en/function.ereg-replace.php',
-				'functions' => array(
-					'ereg_replace',
-				),
-			),
-
-			'split' => array(
-				'type'      => 'error',
-				'message'   => '%s is prohibited, please use explode() or preg_split() instead. See http://php.net/manual/en/function.split.php',
-				'functions' => array(
-					'split',
-				),
-			),
-
 			'runtime_configuration' => array(
 				'type'      => 'error',
 				'message'   => '%s is prohibited, changing configuration at runtime is not allowed on VIP Production.',

--- a/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.inc
@@ -9,24 +9,6 @@ var_dump( $post_id ); // Bad, forbidden use
 print_r( $post_ID ); // Bad, forbidden use
 
 
-// DEPRECATED PHP FUNCTIONS
-// ------------------------
-
-$title = get_the_title();
-
-$title = ereg_replace( 'cool', 'not cool', get_the_title() ); // Bad, ereg_replace has been deprecated. Use preg_replace instead.
-$title = preg_replace( 'cool', 'not cool', get_the_title() ); // Good
-
-if ( ereg( '[A-Za-z]+', $title, $regs ) ) // Bad, ereg also deprecated. Use preg_match instead.
-	die( $regs );
-
-$title = eregi_replace( 'cool', 'not cool', get_the_title() ); // Bad, eregi_replace also deprecated. Use preg_replace instead.
-
-list( $year, $month, $day ) = split( ':', $date ); // Bad, split has been deprecated. Use preg_split or explode instead.
-
-$title_parts = spliti( ' ', get_the_title(), 4 ); // Bad, spliti also deprecated. Use preg_split instead.
-
-
 // DEPRECATED WORDPRESS FUNCTIONS
 // ------------------------------
 

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc
@@ -1,0 +1,26 @@
+<?php
+
+// These are ok.
+$regex = preg_quote( 'cool', '#' ); // Good
+$title = preg_match( 'cool', get_the_title() ); // Good
+$title = preg_match_all( 'cool', get_the_title(), $matches ); // Good
+$title = preg_replace( 'cool', 'not cool', get_the_title() ); // Good
+$title = preg_replace_callback( 'cool', 'callback_function', get_the_title() ); // Good
+$title = preg_split( 'cool', get_the_title() ); // Good
+
+
+// These should all trigger an error.
+if ( ereg( '[A-Za-z]+', $title, $regs ) ) // Bad, ereg deprecated. Use preg_match instead.
+	die( $regs );
+
+if ( eregi( '[a-z]+', $title, $regs ) ) {} // Bad, eregi deprecated. Use preg_match instead.
+
+$title = ereg_replace( 'cool', 'not cool', get_the_title() ); // Bad, ereg_replace has been deprecated. Use preg_replace instead.
+
+$title = eregi_replace( 'cool', 'not cool', get_the_title() ); // Bad, eregi_replace also deprecated. Use preg_replace instead.
+
+list( $year, $month, $day ) = split( ':', $date ); // Bad, split has been deprecated. Use preg_split or explode instead.
+
+$title_parts = spliti( ' ', get_the_title(), 4 ); // Bad, spliti also deprecated. Use preg_split instead.
+
+sql_regcase( 'Foo - bar.'); // Bad. Deprecated.

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -8,7 +8,7 @@
  */
 
 /**
- * Unit test class for the DiscouragedFunctions sniff.
+ * WordPress_Tests_PHP_POSIXFunctionsUnitTest
  *
  * A sniff unit test checks a .inc file for expected violations of a single
  * coding standard. Expected errors and warnings are stored in this class.
@@ -22,7 +22,7 @@
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
+class WordPress_Tests_PHP_POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -33,7 +33,15 @@ class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnit
 	 * @return array(int => int)
 	 */
 	public function getErrorList() {
-		return array();
+		return array(
+			13 => 1,
+			16 => 1,
+			18 => 1,
+			20 => 1,
+			22 => 1,
+			24 => 1,
+			26 => 1,
+		);
 
 	} // end getErrorList()
 
@@ -46,27 +54,7 @@ class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnit
 	 * @return array(int => int)
 	 */
 	public function getWarningList() {
-		return array(
-			8 => 1,
-			9 => 1,
-			15 => 1,
-			17 => 1,
-			19 => 1,
-			21 => 1,
-			23 => 1,
-			25 => 1,
-			27 => 1,
-			29 => 1,
-			31 => 1,
-			33 => 1,
-			35 => 1,
-			37 => 1,
-			39 => 1,
-			45 => 1,
-			47 => 1,
-			52 => 1,
-			54 => 1,
-		);
+		return array();
 
 	} // end getWarningList()
 


### PR DESCRIPTION
From the handbook:
> Perl compatible regular expressions (PCRE, preg_ functions) should be used in preference to their POSIX counterparts. Never use the /e switch, use preg_replace_callback instead.
>
> It’s most convenient to use single-quoted strings for regular expressions since, contrary to double-quoted strings, they have only two metasequences: \' and \\.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions

This can be split into three distinct rules:
1. Don't use `POSIX` functions
2. Don't use the `/e` modifier
3. Prefer single quoted stings.

Rule 1 was up to now not covered in core. Parts of it were covered in `extra` and in `vip`, but the implementations were inconsistent and both were incomplete.
Rule 2 was not covered at all.
Rule 3 is already covered by the single vs double quotes sniff.

This PR fixes the issues with covering rule 1 and 2 with the following two commits:

Split off `POSIX` Functions restrictions to its own sniff.

* Removes similar checks from existing sniffs (`PHP.DiscouragedFunctions` and `VIP.RestrictedFunctions`).
* Makes sure that *all* functions in the `POSIX` extension are covered by this check - they previously were not.
* Add unit tests for the new sniff covering *all* `POSIX` functions.

Copy in the `PregReplaceEModifierSniff` from the `PHPCompatibility` Sniff library.

* Add a new `PHPCompatibility` folder to the `Sniff` folder.
* Copy in the `PregReplaceEModifierSniff`.
* Copy in the related parent class `PHPCompatibility_Sniff`.
* Renamed both classes to follow the PSR1 autoloading pattern.
* Added a readme to the `PHPCompatibility` sniff folder about its usage.
* Excluded the `PHPCompatibility` folder from the PHPCS code style checks - this way we can just drop-in replace the file (ok, except for the class renaming) when there is a new version available.
