### PR TITLE
Fix bug in function name comparison.

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -105,10 +105,10 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSn
 				continue;
 			}
 
-			$functions = implode( '|', $group['functions'] );
-			$functions = preg_replace( '#[^\.]\*#', '.*', $functions ); // So you can use * instead of .*
+			$functions = array_map( array( $this, 'prepare_functionname_for_regex' ), $group['functions'] );
+			$functions = implode( '|', $functions );
 
-			if ( preg_match( '#\b(' . $functions . ')\b#', $token['content'] ) < 1 ) {
+			if ( preg_match( '`\b(?:' . $functions . ')\b`i', $token['content'] ) < 1 ) {
 				continue;
 			}
 
@@ -129,5 +129,23 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSn
 		}
 
 	} // end process()
+
+	/**
+	 * Prepare the function name for use in a regular expression.
+	 *
+	 * The getGroups() method allows for providing function with a wildcard * to target
+	 * a group of functions. This prepare routine takes that into account while still safely
+	 * escaping the function name for use in a regular expression.
+	 *
+	 * @param string $function Function name.
+	 * @return string Regex escaped lowercase function name.
+	 */
+	protected function prepare_functionname_for_regex( $function ) {
+		$function = str_replace( array( '.*', '*' ) , '#', $function ); // Replace wildcards with placeholder.
+		$function = preg_quote( $function, '`' );
+		$function = str_replace( '#', '.*', $function ); // Replace placeholder with regex wildcard.
+
+		return $function;
+	}
 
 } // end class

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -83,3 +83,6 @@ putenv(); // error
 set_include_path(); // error
 restore_include_path(); // error
 phpinfo(); // error
+
+PHPINFO(); // error
+CURL_getinfo(); // error

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -86,3 +86,5 @@ phpinfo(); // error
 
 PHPINFO(); // error
 CURL_getinfo(); // error
+
+curlyhair(); // ok

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -71,6 +71,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			83 => 1,
 			84 => 1,
 			85 => 1,
+			87 => 1,
 		);
 
 	} // end getErrorList()
@@ -96,6 +97,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			59 => 1,
 			61 => 1,
 			72 => 1,
+			88 => 1,
 		);
 
 	} // end getWarningList()


### PR DESCRIPTION
`AbstractFunctionRestrictionsSniff` did not allow for case-insensitive comparison of function names.

> **Note**: Function names are case-insensitive, though it is usually good form to call functions as they appear in their declaration.

Ref: http://php.net/manual/en/functions.user-defined.php

Also:
* Better be safe than sorry, so `preg_quote()`-ing the function names passed to this class.
* Minor memory management improvement: no need to remember the matched function name.

The first commit adds a unit test proving the bug. The second commit fixes the bug.