### PR TITLE
Bug work-around for the DiscouragedFunctions sniff.

### DIFF
--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -75,4 +75,24 @@ class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_
 	 */
 	public $error = false;
 
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * {@internal Temporarily overrule the parent register() method until bugfix has
+	 * been merged into PHPCS upstream and WPCS minimum PHPCS version has caught up.
+	 * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1076} }}
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$register = parent::register();
+
+		if ( true !== $this->patternMatch ) {
+			$this->forbiddenFunctionNames = array_map( 'strtolower', $this->forbiddenFunctionNames );
+			$this->forbiddenFunctions     = array_combine( $this->forbiddenFunctionNames, $this->forbiddenFunctions );
+		}
+
+		return $register;
+	}
+
 } // end class

--- a/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -66,6 +66,7 @@ class WordPress_Tests_PHP_DiscouragedFunctionsUnitTest extends AbstractSniffUnit
 			51 => 1,
 			53 => 1,
 			55 => 1,
+			57 => 1,
 			63 => 1,
 			65 => 1,
 			70 => 1,


### PR DESCRIPTION
One of the unit tests for the `WordPress.PHP.DiscouragedFunctions` sniff was disabled as it was failing.
This related to the `get_attachment_innerHTML` function.

I've debugged the failing unit test and send in a [PR upstream](https://github.com/squizlabs/PHP_CodeSniffer/pull/1076) to fix the underlying issue in the `Generic.PHP.ForbiddenFunctions` sniff.

The above in effect meant that WPCS was *not* testing usage of the `get_attachment_innerHTML()` function as the sniff was failing.

The work-around in this PR will:
1. fix the bug and enable sniffing for `get_attachment_innerHTML()`.
2. not clash with PHPCS if the bug fix send in upstream will be merged.
3. can be removed once the minimum PHPCS version required by WPCS has gone beyond the PHPCS version which will contain the bugfix.