### PR TITLE
Disallow direct database calls.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -113,4 +113,6 @@
 	<rule ref="WordPress.WP.I18n"/>
 	<rule ref="WordPress.Functions.DontExtract"/>
 
+	<rule ref="WordPress.DB.RestrictedFunctions"/>
+
 </ruleset>

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Verifies that no database related PHP functions are used.
+ *
+ * "Avoid touching the database directly. If there is a defined function that can get
+ *  the data you need, use it. Database abstraction (using functions instead of queries)
+ *  helps keep your code forward-compatible and, in cases where results are cached in memory,
+ *  it can be many times faster."
+ *
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_DB_RestrictedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'mysql' => array(
+				'type'      => 'error',
+				'message'   => 'Accessing the database directly should be avoided. Please use the $wpdb object and associated functions instead. Found: %s.',
+				'functions' => array(
+					'mysql_*',
+					'mysqli_*',
+					'mysqlnd_ms_*',
+					'mysqlnd_qc_*',
+					'mysqlnd_uh_*',
+					'mysqlnd_memcache_*',
+					'maxdb_*',
+				),
+			),
+
+		);
+	}
+
+} // end class

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
@@ -14,7 +14,7 @@ class Bar {
 $x = new Foo();
 $x->mysql_info(); // ok
 $y = Bar::mysql_info(); // ok
-\SomeNamespace\mysql_info(); // ok
+prefix_mysql_info(); // ok
 
 
 /**

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
@@ -1,0 +1,76 @@
+<?php
+
+my_mysql_info(); // ok
+wrap_mysql_info(); // ok
+mysqlnd_msinfo(); // ok
+
+class Foo {
+	function mysql_info() {} // ok
+}
+class Bar {
+	static function mysql_info() {} // ok
+}
+
+$x = new Foo();
+$x->mysql_info(); // ok
+$y = Bar::mysql_info(); // ok
+\SomeNamespace\mysql_info(); // ok
+
+
+/**
+ * All the below should give an error.
+ */
+
+// MYSQL Extension.
+mysql_affected_rows();
+mysql_connect();
+mysql_close();
+mysql_fetch_row();
+mysql_info();
+mysql_numrows();
+mysql_pconnect();
+mysql_query();
+mysql_result();
+
+// MYSQLI Extension.
+mysqli_client_encoding();
+mysqli_connect();
+mysqli_escape_string();
+mysqli_execute();
+mysqli_fetch();
+mysqli_get_metadata();
+mysqli_init();
+mysqli_options();
+mysqli_real_connect();
+
+// MYSQLND_MS Extension.
+mysqlnd_ms_fabric_select_global();
+mysqlnd_ms_get_stats();
+mysqlnd_ms_match_wild();
+mysqlnd_ms_xa_begin();
+mysqlnd_ms_xa_rollback();
+
+// MYSQLND_QC Extension.
+mysqlnd_qc_clear_cache();
+mysqlnd_qc_get_cache_info();
+mysqlnd_qc_get_query_trace_log();
+mysqlnd_qc_set_cache_condition();
+
+// MYSQLND_UH Extension.
+mysqlnd_uh_convert_to_mysqlnd();
+
+// MYSQLND_MEMCACHE Extension.
+mysqlnd_memcache_set();
+
+// MAXDB Extension.
+maxdb_affected_rows();
+maxdb_close();
+maxdb_connect();
+maxdb_errno();
+maxdb_escape_string();
+maxdb_fetch_assoc
+maxdb_init();
+maxdb_num_fields();
+maxdb_prepare();
+maxdb_real_query
+maxdb_stat();

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_DB_RestrictedFunctionsUnitTest
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Akeda Bagus <akeda@x-team.com>
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			25 => 1,
+			26 => 1,
+			27 => 1,
+			28 => 1,
+			29 => 1,
+			30 => 1,
+			31 => 1,
+			32 => 1,
+			33 => 1,
+
+			36 => 1,
+			37 => 1,
+			38 => 1,
+			39 => 1,
+			40 => 1,
+			41 => 1,
+			42 => 1,
+			43 => 1,
+			44 => 1,
+
+			47 => 1,
+			48 => 1,
+			49 => 1,
+			50 => 1,
+			51 => 1,
+
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
+
+			60 => 1,
+
+			63 => 1,
+
+			66 => 1,
+			67 => 1,
+			68 => 1,
+			69 => 1,
+			70 => 1,
+			71 => 1,
+			72 => 1,
+			73 => 1,
+			74 => 1,
+			75 => 1,
+			76 => 1,
+		);
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
From the handbook:
> Avoid touching the database directly. If there is a defined function that can get the data you need, use it. Database abstraction (using functions instead of queries) helps keep your code forward-compatible and, in cases where results are cached in memory, it can be many times faster.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries

This section was, AFAICS, so far not covered.

This PR covers checking for any calls made to PHP functions which can approach mysql type databases.
If any such function is found, an `error` will be thrown.

In a future PR, a similar check should be created for calls to native PHP DB Classes, such as PDO.

To that end, I've created a new sniff sub-folder called `DB` to hold both this as well as the class check sniff at a later date.

------
FYI: travis will fail on this PR because of the second bug in #609 as described here: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/609#issuecomment-233163109

Once #609 is merged and this would be rebased, the unit tests will pass.