### PR TITLE
Add sniff for Restricted Database Classes.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -114,7 +114,8 @@
 	<rule ref="WordPress.WP.I18n"/>
 	<rule ref="WordPress.Functions.DontExtract"/>
 	<rule ref="WordPress.NamingConventions.ValidHookName"/>
-
 	<rule ref="WordPress.DB.RestrictedFunctions"/>
+
+	<rule ref="WordPress.DB.RestrictedClasses"/>
 
 </ruleset>

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Restricts usage of some classes.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of function data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @var array
+	 */
+	public static $unittest_groups = array();
+
+	/**
+	 * Regex pattern with placeholder for the function names.
+	 *
+	 * @var string
+	 */
+	protected $regex_pattern = '`^\\\\(?:%s)$`i';
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Avoid direct calls to the database.',
+	 * 		'classes'   => array( 'PDO', '\Namespace\Classname' ),
+	 * 	)
+	 * )
+	 *
+	 * You can use * wildcards to target a group of (namespaced) classes.
+	 * Aliased namespaces (use ..) are currently not supported.
+	 *
+	 * Documented here for clarity. Not (re)defined as it is already defined in the parent class.
+	 *
+	 * @return array
+	 */
+	// abstract public function getGroups();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Prepare the function group regular expressions only once.
+		if ( false === $this->setup_groups( 'classes' ) ) {
+			return array();
+		}
+
+		return array(
+			T_DOUBLE_COLON,
+			T_NEW,
+			T_EXTENDS,
+			T_IMPLEMENTS,
+		);
+
+	} // end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens    = $phpcsFile->getTokens();
+		$token     = $tokens[ $stackPtr ];
+		$classname = '';
+
+		if ( in_array( $token['code'], array( T_NEW, T_EXTENDS, T_IMPLEMENTS ), true ) ) {
+			if ( T_NEW === $token['code'] ) {
+				$nameEnd   = ( $phpcsFile->findNext( array( T_OPEN_PARENTHESIS, T_WHITESPACE, T_SEMICOLON, T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
+			} else {
+				$nameEnd   = ( $phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
+			}
+
+			$length    = ( $nameEnd - ( $stackPtr + 1 ) );
+			$classname = $phpcsFile->getTokensAsString( ( $stackPtr + 2 ), $length );
+
+			if ( T_NS_SEPARATOR !== $tokens[ ( $stackPtr + 2 ) ]['code'] ) {
+				$classname = $this->get_namespaced_classname( $classname, $phpcsFile, $tokens, ( $stackPtr - 1 ) );
+			}
+		}
+
+		if ( T_DOUBLE_COLON === $token['code'] ) {
+			$nameEnd   = $phpcsFile->findPrevious( array( T_STRING ), ( $stackPtr - 1 ) );
+			$nameStart = ( $phpcsFile->findPrevious( array( T_STRING, T_NS_SEPARATOR, T_NAMESPACE ), ( $nameEnd - 1 ), null, true, null, true ) + 1 );
+			$length    = ( $nameEnd - ( $nameStart - 1) );
+			$classname = $phpcsFile->getTokensAsString( $nameStart, $length );
+
+			if ( T_NS_SEPARATOR !== $tokens[ $nameStart ]['code'] ) {
+				$classname = $this->get_namespaced_classname( $classname, $phpcsFile, $tokens, ( $nameStart - 1 ) );
+			}
+		}
+
+		// Stop if we couldn't determine a classname.
+		if ( empty( $classname ) ) {
+			return;
+		}
+
+		// Nothing to do if 'parent', 'self' or 'static'.
+		if ( in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
+			return;
+		}
+
+		$exclude   = explode( ',', $this->exclude );
+
+		foreach ( $this->groups as $groupName => $group ) {
+
+			if ( in_array( $groupName, $exclude, true ) ) {
+				continue;
+			}
+
+			if ( preg_match( $group['regex'], $classname ) < 1 ) {
+				continue;
+			}
+
+			if ( 'warning' === $group['type'] ) {
+				$addWhat = array( $phpcsFile, 'addWarning' );
+			} else {
+				$addWhat = array( $phpcsFile, 'addError' );
+			}
+
+			call_user_func(
+				$addWhat,
+				$group['message'],
+				$stackPtr,
+				$groupName,
+				array( $classname )
+			);
+
+		}
+
+	} // end process()
+
+	/**
+	 * Prepare the class name for use in a regular expression.
+	 *
+	 * The getGroups() method allows for providing class names with a wildcard * to target
+	 * a group of classes within a namespace. It also allows for providing class names as
+	 * 'ordinary' names or prefixed with one or more namespaces.
+	 * This prepare routine takes that into account while still safely escaping the
+	 * class name for use in a regular expression.
+	 *
+	 * @param string $classname Class name, potentially prefixed with namespaces.
+	 * @return string Regex escaped class name.
+	 */
+	protected function prepare_name_for_regex( $classname ) {
+		$classname = trim( $classname, '\\' ); // Make sure all classnames have a \ prefix, but only one.
+		$classname = str_replace( array( '.*', '*' ) , '#', $classname ); // Replace wildcards with placeholder.
+		$classname = preg_quote( $classname, '`' );
+		$classname = str_replace( '#', '.*', $classname ); // Replace placeholder with regex wildcard.
+
+		return $classname;
+	}
+
+	/**
+	 * See if the classname was found in a namespaced file and if so, add the namespace to the classname.
+	 *
+	 * @param string $classname   The full classname as found.
+	 * @param object $phpcsFile   Instance of phpcsFile.
+	 * @param array  $tokens      The token stack for this file.
+	 * @param int    $search_from The token position to search up from.
+	 * @return string Classname, potentially prefixed with the namespace.
+	 */
+	protected function get_namespaced_classname( $classname, $phpcsFile, $tokens, $search_from ) {
+		// Don't do anything if this is already a fully qualified classname.
+		if ( empty( $classname ) || '\\' === $classname[0] ) {
+			return $classname;
+		}
+
+		// Remove the namespace keyword if used.
+		if ( 0 === strpos( $classname, 'namespace\\' ) ) {
+			$classname = substr( $classname, 10 );
+		}
+
+		$namespace_keyword = $phpcsFile->findPrevious( T_NAMESPACE, $search_from );
+		if ( false === $namespace_keyword ) {
+			// No namespace keyword found at all, so global namespace.
+			$classname = '\\' . $classname;
+		} else {
+			$namespace = $this->determine_namespace( $phpcsFile, $tokens, $search_from );
+
+			if ( ! empty( $namespace ) ) {
+				$classname = '\\' . $namespace . '\\' . $classname;
+			} else {
+				// No actual namespace found, so global namespace.
+				$classname = '\\' . $classname;
+			}
+		}
+
+		return $classname;
+	}
+
+	/**
+	 * Determine the namespace name based on whether this is a scoped namespace or a file namespace.
+	 *
+	 * @param object $phpcsFile   Instance of phpcsFile.
+	 * @param array  $tokens      The token stack for this file.
+	 * @param int    $search_from The token position to search up from.
+	 * @return string Namespace name or empty string if it couldn't be determined or no namespace applied.
+	 */
+	protected function determine_namespace( $phpcsFile, $tokens, $search_from ) {
+		$namespace = '';
+
+		if ( ! empty( $tokens[ $search_from ]['conditions'] ) ) {
+			// Scoped namespace {}.
+			foreach ( $tokens[ $search_from ]['conditions'] as $pointer => $type ) {
+				if ( T_NAMESPACE === $type && $tokens[ $pointer ]['scope_closer'] > $search_from ) {
+					$namespace = $this->get_namespace_name( $phpcsFile, $tokens, $pointer );
+				}
+				break; // We only need to check the highest level condition.
+			}
+		} else {
+			// Let's see if we can find a file namespace instead.
+			$first = $phpcsFile->findNext( array( T_NAMESPACE ), 0, $search_from );
+
+			if ( empty( $tokens[ $first ]['scope_condition'] ) ) {
+				$namespace = $this->get_namespace_name( $phpcsFile, $tokens, $first );
+			}
+		}
+
+		return $namespace;
+	}
+
+	/**
+	 * Get the namespace name based on the position of the namespace scope opener.
+	 *
+	 * @param object $phpcsFile         Instance of phpcsFile.
+	 * @param array  $tokens            The token stack for this file.
+	 * @param int    $t_namespace_token The token position to search from.
+	 * @return string Namespace name.
+	 */
+	protected function get_namespace_name( $phpcsFile, $tokens, $t_namespace_token ) {
+		$nameEnd = ( $phpcsFile->findNext( array( T_OPEN_CURLY_BRACKET, T_WHITESPACE, T_SEMICOLON ), ( $t_namespace_token + 2 ) ) - 1 );
+		$length    = ( $nameEnd - ( $t_namespace_token + 1 ) );
+		$namespace = $phpcsFile->getTokensAsString( ( $t_namespace_token + 2 ), $length );
+
+		return $namespace;
+	}
+
+} // end class

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Verifies that no database related PHP classes are used.
+ *
+ * "Avoid touching the database directly. If there is a defined function that can get
+ *  the data you need, use it. Database abstraction (using functions instead of queries)
+ *  helps keep your code forward-compatible and, in cases where results are cached in memory,
+ *  it can be many times faster."
+ *
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_DB_RestrictedClassesSniff extends WordPress_AbstractClassRestrictionsSniff {
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Avoid direct calls to the database.',
+	 * 		'classes'   => array( 'PDO', '\Namespace\Classname' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'mysql' => array(
+				'type'      => 'error',
+				'message'   => 'Accessing the database directly should be avoided. Please use the $wpdb object and associated functions instead. Found: %s.',
+				'classes' => array(
+					'mysqli',
+					'PDO',
+					'PDOStatement',
+				),
+			),
+
+		);
+	}
+
+} // end class

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
@@ -1,0 +1,41 @@
+<?php
+
+$db_ok1 = new Mymysqli; // Ok.
+$db_ok2 = new Mymysqli(); // Ok.
+
+echo MyMysqli::$affected_rows; // Ok.
+echo MyMysqli::get_charset(); // Ok.
+
+echo parent::VERSION; // Ok.
+echo self::$property; // Ok.
+echo self::some_function(); // Ok.
+
+/**
+ * All the below should give an error.
+ */
+
+$db1 = new mysqli;
+$db2 = new MYSQLI;
+$db3 = new MySqli();
+$db4 = new \mysqli();
+
+echo mysqli::$affected_rows;
+echo mysqli::$errno;
+echo mysqli::get_charset();
+mysqli::init();
+mysqli::stat();
+\mysqli::use_result();
+
+class MyMysqli extends mysqli {}
+class YourMysqli extends \mysqli {}
+
+class OurMysqli implements mysqli {}
+class TheirMysqli implements \mysqli {}
+
+$db5 = new PDO();
+$db6 - new PDO->exec();
+PDO::getAvailableDrivers()
+
+$db7 = new PDOStatement;
+$db8 = new \PDOStatement();
+

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
@@ -1,0 +1,47 @@
+<?php
+
+// Additional unit tests testing the abstract class with namespace resolution.
+
+namespace My;
+
+class DBlayer {
+	const VERSION = '1.0';
+	
+	public static $property = true;
+
+	public static function connect() {
+	}
+}
+
+class DBextended extends DBlayer { // Bad
+}
+
+class DBextender implements PDO { // Ok -> resolves to \My\PDO
+}
+
+class DBextendes implements \PDO { // Bad -> fully qualified as \PDO
+}
+
+$db0 = new \DBlayer; // Ok - fully qualified as \DBlayer
+$db1 = new DBlayer; // Bad - resolves to \My\DBlayer
+$db2 = new DBlayer(); // Bad - resolves to \My\DBlayer
+
+echo DBlayer::VERSION; // Bad - resolves to \My\DBlayer
+echo DBlayer::$property; // Bad - resolves to \My\DBlayer
+echo DBlayer::connect(); // Bad - resolves to \My\DBlayer
+
+$db3 = new Yours\DBlayer; // Ok - resolves to \My\Yours\DBlayer
+
+echo Yours\DBlayer::VERSION; // Ok - resolves to \My\Yours\DBlayer
+echo Yours\DBlayer::$property; // Ok - resolves to \My\Yours\DBlayer
+echo Yours\DBlayer::connect(); // Ok - resolves to \My\Yours\DBlayer
+
+$db4 = new \My\DBlayer; // Bad - fully qualified as \My\DBlayer
+
+echo \My\DBlayer::VERSION; // Bad - fully qualified as \My\DBlayer
+echo \My\DBlayer::$property; // Bad - fully qualified as \My\DBlayer
+echo \My\DBlayer::connect(); // Bad - fully qualified as \My\DBlayer
+
+echo namespace\DBlayer::VERSION; // Bad - resolves to \My\DBlayer
+echo namespace\DBlayer::$property; // Bad - resolves to \My\DBlayer
+echo namespace\DBlayer::connect(); // Bad - resolves to \My\DBlayer

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
@@ -1,0 +1,92 @@
+<?php
+
+// Additional unit tests testing the abstract class with namespace resolution.
+
+namespace My {
+
+	class DBlayer {
+		const VERSION = '1.0';
+	
+		public static $property = true;
+	
+		public static function connect() {
+		}
+	}
+	
+	class DBextended extends DBlayer { // Bad
+	}
+	
+	class DBextender implements PDO { // Ok -> resolves to \My\PDO
+	}
+	
+	class DBextendes implements \PDO { // Bad -> fully qualified as \PDO
+	}
+	
+	$db0 = new \DBlayer; // Ok - fully qualified as \DBlayer
+	$db1 = new DBlayer; // Bad - resolves to \My\DBlayer
+	$db2 = new DBlayer(); // Bad - resolves to \My\DBlayer
+	
+	echo DBlayer::VERSION; // Bad - resolves to \My\DBlayer
+	echo DBlayer::$property; // Bad - resolves to \My\DBlayer
+	echo DBlayer::connect(); // Bad - resolves to \My\DBlayer
+	
+	$db3 = new Yours\DBlayer; // Ok - resolves to \My\Yours\DBlayer
+	
+	echo Yours\DBlayer::VERSION; // Ok - resolves to \My\Yours\DBlayer
+	echo Yours\DBlayer::$property; // Ok - resolves to \My\Yours\DBlayer
+	echo Yours\DBlayer::connect(); // Ok - resolves to \My\Yours\DBlayer
+	
+	$db4 = new \My\DBlayer; // Bad - fully qualified as \My\DBlayer
+	
+	echo \My\DBlayer::VERSION; // Bad - fully qualified as \My\DBlayer
+	echo \My\DBlayer::$property; // Bad - fully qualified as \My\DBlayer
+	echo \My\DBlayer::connect(); // Bad - fully qualified as \My\DBlayer
+	
+	echo namespace\DBlayer::VERSION; // Bad - resolves to \My\DBlayer
+	echo namespace\DBlayer::$property; // Bad - resolves to \My\DBlayer
+	echo namespace\DBlayer::connect(); // Bad - resolves to \My\DBlayer
+
+}
+
+// Now we're outside the namespace, so things should work differently
+$db0 = new \DBlayer; // Ok.
+$db1 = new DBlayer; // Ok.
+$db2 = new DBlayer(); // Ok.
+
+echo DBlayer::VERSION; // Ok.
+echo DBlayer::$property; // Ok.
+echo DBlayer::connect(); // Ok.
+
+$db3 = new Yours\DBlayer; // Ok - resolves to \Yours\DBlayer
+
+echo Yours\DBlayer::VERSION; // Ok - resolves to \Yours\DBlayer
+echo Yours\DBlayer::$property; // Ok - resolves to \Yours\DBlayer
+echo Yours\DBlayer::connect(); // Ok - resolves to \Yours\DBlayer
+
+$db4 = new \My\DBlayer; // Bad - fully qualified as \My\DBlayer
+
+echo \My\DBlayer::VERSION; // Bad - fully qualified as \My\DBlayer
+echo \My\DBlayer::$property; // Bad - fully qualified as \My\DBlayer
+echo \My\DBlayer::connect(); // Bad - fully qualified as \My\DBlayer
+
+echo namespace\DBlayer::VERSION; // Ok.
+echo namespace\DBlayer::$property; // Ok.
+echo namespace\DBlayer::connect(); // Ok.
+
+
+// Testing second namespace within one file.
+namespace AdoDb {
+
+	class Test {}
+
+	class Tester {}
+
+	class TestAgain extends Test {} // Bad.
+	
+	class TestYetAgain extends Tester {} // Bad.
+
+	$db5 = new Test; // Bad
+	$db6 = new Tester(); // Bad
+}
+
+$db7 = new Test; // Ok

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_DB_RestrictedFunctionsUnitTest
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Akeda Bagus <akeda@x-team.com>
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Add a number of extra restricted classes to unit test the abstract
+	 * ClassRestrictions class.
+	 *
+	 * Note: as that class extends the abstract FunctionRestrictions class, that's
+	 * where we are passing the parameters to.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		WordPress_AbstractFunctionRestrictionsSniff::$unittest_groups = array(
+			'test' => array(
+				'type'      => 'error',
+				'message'   => 'Detected usage of %s.',
+				'classes' => array(
+					'\My\DBlayer',
+					'AdoDb\Test*',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Skip this test on PHP 5.2 as otherwise testing the namespace resolving would fail.
+	 *
+	 * @return bool Whether to skip this test.
+	 */
+	protected function shouldSkipTest() {
+		return version_compare( PHP_VERSION, '5.3.0', '<' );
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'RestrictedClassesUnitTest.1.inc':
+				return array(
+					17 => 1,
+					18 => 1,
+					19 => 1,
+					20 => 1,
+					22 => 1,
+					23 => 1,
+					24 => 1,
+					25 => 1,
+					26 => 1,
+					27 => 1,
+					29 => 1,
+					30 => 1,
+					32 => 1,
+					33 => 1,
+					35 => 1,
+					36 => 1,
+					37 => 1,
+					39 => 1,
+					40 => 1,
+				);
+
+			case 'RestrictedClassesUnitTest.2.inc':
+				return array(
+					16 => 1,
+					22 => 1,
+					26 => 1,
+					27 => 1,
+					29 => 1,
+					30 => 1,
+					31 => 1,
+					39 => 1,
+					41 => 1,
+					42 => 1,
+					43 => 1,
+					45 => 1,
+					46 => 1,
+					47 => 1,
+				);
+
+			case 'RestrictedClassesUnitTest.3.inc':
+				return array(
+					16 => 1,
+					22 => 1,
+					26 => 1,
+					27 => 1,
+					29 => 1,
+					30 => 1,
+					31 => 1,
+					39 => 1,
+					41 => 1,
+					42 => 1,
+					43 => 1,
+					45 => 1,
+					46 => 1,
+					47 => 1,
+					66 => 1,
+					68 => 1,
+					69 => 1,
+					70 => 1,
+					84 => 1,
+					86 => 1,
+					88 => 1,
+					89 => 1,
+				);
+
+			default:
+				return array();
+
+		}
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // end class


### PR DESCRIPTION
* Added `AbstractClassRestrictionsSniff` class which can sniff for the use of (namespaced) classes. The abstract class does currently not support `use` statement aliased namespaces.
* Refactored the `AbstractFunctionRestrictionsSniff` somewhat to make parts more reusable and extended the `AbstractClassRestrictionsSniff` from this class.
	* This refactoring includes a small efficiency improvement where the function regular expressions are no longer rebuild for every token, but only build once.
* Added `DB/RestrictedClassesSniff` to actually sniff for the Restricted DB Classes.
* Added extensive unit tests which test both the `DB/RestrictedClassesSniff` as well as the complete functionality of the Abstract class.

If at some point in the future the `AbstractFunctionRestrictionsSniff` would need to support namespaces too, this will not be too hard to do. Some functions would need to be moved from the `AbstractClassRestrictionsSniff`  to the `AbstractFunctionRestrictionsSniff` and the functionname determination would need to start using them, but the underlying logic has already been build.

This is the sister-PR to #612 which covers the function sniffing for direct DB calls.