### PR TITLE
Fix issue with whitelist comment not being recognized…

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -500,8 +500,8 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// we need to here.
 		$end_of_statement = $this->phpcsFile->findNext( array( T_CLOSE_TAG, T_SEMICOLON ), $stackPtr );
 
-		// Check at the end of the statement if it comes before the end of the line.
-		if ( $end_of_statement < $end_of_line ) {
+		// Check at the end of the statement if it comes before - or is - the end of the line.
+		if ( $end_of_statement <= $end_of_line ) {
 
 			// If the statement was ended by a semicolon, we find the next non-
 			// whitespace token. If the semicolon was left out and it was terminated

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -57,7 +57,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 
 		// Check for whitelisting comment.
 		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
-			$phpcsFile->addWarning( 'Detected access of super global var %s, probably need manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
+			$phpcsFile->addWarning( 'Detected access of super global var %s, probably needs manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
 
 	} // end process()

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.inc
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.inc
@@ -4,6 +4,8 @@ foo( $_GET['bar'] );
 
 foo( $_GET['whitelisted'] ); // input var okay
 
+foo( $_POST['whitelisted_with_prefix'] ); // WPCS: input var okay.
+
 if ( $_GET['test'] && foo() && $bar ) { // input var okay
 	taz();
 }
@@ -13,3 +15,8 @@ bar( $_POST['foo'] ); // warning
 quux( $_REQUEST['quux'] ); // warning
 
 $_REQUEST['wp_customize'] = 'on'; // ok
+
+// Issue: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/542
+if ( isset( $_GET['updated'] ) ) { // input var okay ?>
+
+<?php

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -41,8 +41,8 @@ class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUni
 	public function getWarningList() {
 		return array(
 			3 => 1,
-			11 => 1,
 			13 => 1,
+			15 => 1,
 		);
 	} // end getWarningList()
 


### PR DESCRIPTION
… if inline comment ends with closing PHP tag.

Includes unit test.

Also:
* added additional unit test for prefixed whitelist comment
* minor grammar correction.

Fixes #542

Ref: http://php.net/manual/en/language.basic-syntax.comments.php