### PR TITLE
Use PHPCS build in static token arrays.

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -49,7 +49,7 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniff {
 			return;
 		}
 
-		$prevToken = $phpcsFile->findPrevious( array( T_WHITESPACE, T_COMMENT ), ( $stackPtr - 1 ), null, true );
+		$prevToken = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 		// Skip if this is instance of in_array() not a function call.
 		if ( false === $prevToken || in_array( $tokens[ $prevToken ]['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) {
@@ -70,7 +70,7 @@ class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniff {
 
 		// Get last token in the function call.
 		$closeParenthesis = $tokens[ $openParenthesis ]['parenthesis_closer'];
-		$lastToken        = $phpcsFile->findPrevious( array( T_WHITESPACE, T_COMMENT ), ( $closeParenthesis - 1 ), ( $openParenthesis + 1 ), true );
+		$lastToken        = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $closeParenthesis - 1 ), ( $openParenthesis + 1 ), true );
 		if ( false === $lastToken ) {
 			$phpcsFile->addError( 'Missing arguments to in_array().', $openParenthesis, 'MissingArguments' );
 			return;

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -335,7 +335,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			// Check for assignments to collected global vars.
 			foreach ( $tokens as $ptr => $token ) {
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
-					$next = $phpcsFile->findNext( array( T_WHITESPACE, T_COMMENT ), ( $ptr + 1 ), null, true, null, true );
+					$next = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr + 1 ), null, true, null, true );
 					if ( T_EQUAL === $tokens[ $next ]['code'] ) {
 						if ( ! $this->has_whitelist_comment( 'override', $next ) ) {
 							$phpcsFile->addError( 'Overriding WordPress globals is prohibited', $ptr, 'OverrideProhibited' );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -119,7 +119,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		for ( $i = ( $func_open_paren_token + 1 ); $i < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $i += 1 ) {
 			$this_token                = $tokens[ $i ];
 			$this_token['token_index'] = $i;
-			if ( in_array( $this_token['code'], array( T_WHITESPACE, T_COMMENT ), true ) ) {
+			if ( in_array( $this_token['code'], PHP_CodeSniffer_Tokens::$emptyTokens, true ) ) {
 				continue;
 			}
 			if ( T_COMMA === $this_token['code'] ) {

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -184,7 +184,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
 
 			// Ignore whitespaces and comments.
-			if ( in_array( $tokens[ $i ]['code'], array( T_WHITESPACE, T_COMMENT ), true ) ) {
+			if ( in_array( $tokens[ $i ]['code'], PHP_CodeSniffer_Tokens::$emptyTokens, true ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
`PHP_CodeSniffer_Tokens::$emptyTokens` contains `T_WHITESPACE` and all comment tokens making for a more stable check.