### PR TITLE
Update `ValidFunctionNames` Sniff to allow for non-valid names in extended classes.

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -123,30 +123,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			return;
 		}
 
-		$methodProps	= $phpcsFile->getMethodProperties( $stackPtr );
-		$scope			= $methodProps['scope'];
-		$scopeSpecified = $methodProps['scope_specified'];
-
-		if ( 'private' === $methodProps['scope'] ) {
-			$isPublic = false;
-		} else {
-			$isPublic = true;
-		}
-
-		// If the scope was specified on the method, then the method must be
-		// camel caps and an underscore should be checked for. If it wasn't
-		// specified, treat it like a public method and remove the underscore
-		// prefix if there is one because we can't determine if it is private or
-		// public.
-		$testMethodName = $methodName;
-		if ( false === $scopeSpecified && '_' === $methodName{0} ) {
-			$testMethodName = substr( $methodName, 1 );
-		// Ignore special functions.
-		if ( '' === ltrim( $methodName, '_' ) ) {
-			return;
-		}
-
-		if ( strtolower( $testMethodName ) !== $testMethodName ) {
+		if ( strtolower( $methodName ) !== $methodName ) {
 			$suggested = preg_replace( '/([A-Z])/', '_$1', $methodName );
 			$suggested = strtolower( $suggested );
 			$suggested = str_replace( '__', '_', $suggested );

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enforces WordPress function name format, based upon Squiz code.
+ * Enforces WordPress function name format.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
@@ -8,7 +8,9 @@
  */
 
 /**
- * Enforces WordPress function name format.
+ * Enforces WordPress function name and method name format, based upon Squiz code.
+ *
+ * @link     https://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions
  *
  * Last synced with parent class July 2016 at commit 916b09a.
  * @link     https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -64,7 +66,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			return;
 		}
 
-        // Is this a magic function ? I.e., it is prefixed with "__" ?
+		// Is this a magic function ? I.e., it is prefixed with "__" ?
 		// Outside class scope this basically just means __autoload().
 		if ( 0 === strpos( $functionName, '__' ) ) {
 			$magicPart = strtolower( substr( $functionName, 2 ) );
@@ -81,6 +83,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			$suggested = preg_replace( '/([A-Z])/', '_$1', $functionName );
 			$suggested = strtolower( $suggested );
 			$suggested = str_replace( '__', '_', $suggested );
+			$suggested = trim( $suggested, '_' );
 
 			$error     = 'Function name "%s" is not in snake case format, try "%s"';
 			$errorData = array(
@@ -147,13 +150,20 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			return;
 		}
 
+		// Check for all lowercase.
 		if ( strtolower( $methodName ) !== $methodName ) {
 			$suggested = preg_replace( '/([A-Z])/', '_$1', $methodName );
 			$suggested = strtolower( $suggested );
 			$suggested = str_replace( '__', '_', $suggested );
+			$suggested = trim( $suggested, '_' );
 
-			$error = "Function name \"$methodName\" is in camel caps format, try '{$suggested}'";
-			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid' );
+			$error     = 'Method name "%s" in class %s is not in snake case format, try "%s"';
+			$errorData = array(
+				$methodName,
+				$className,
+				$suggested,
+			);
+			$phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}
 
 	} // end processTokenWithinScope()

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -6,7 +6,7 @@ function my_template_tags() {} // Good
 
 function _my_template_tags() {} // OK
 
-function __my_template_tags() {} // OK
+function __my_template_tags() {} // Bad
 
 class My_Plugin {
 
@@ -21,6 +21,9 @@ class My_Plugin {
 	public function __invoke() {} // OK
 }
 
+/**
+ * Verify that CamelCase is not checked for extended classes or interfaces.
+ */
 class Test extends WP_UnitTestCase {
 
 	public function setUp() {} // OK
@@ -28,10 +31,74 @@ class Test extends WP_UnitTestCase {
 
 class Foo implements ArrayAccess {
 	function offsetSet( $key, $value ) {} // OK
-
 	function offsetUnset( $key ) {} // OK
-
 	function offsetExists( $key ) {} // OK
-
 	function offsetGet( $key ) {} // OK
+}
+
+
+/**
+ * Verify all PHP supported magic methods.
+ */
+class Its_A_Kind_Of_Magic {
+	function __construct() {} // Ok.
+	function __destruct() {} // Ok.
+	function __call() {} // Ok.
+	function __callStatic() {} // Ok.
+	function __get() {} // Ok.
+	function __set() {} // Ok.
+	function __isset() {} // Ok.
+	function __unset() {} // Ok.
+	function __sleep() {} // Ok.
+	function __wakeup() {} // Ok.
+	function __toString() {} // Ok.
+	function __set_state() {} // Ok.
+	function __clone() {} // Ok.
+	function __invoke() {} // Ok.
+	function __debugInfo() {} // Ok.
+}
+
+/**
+ * Verify SoapClient magic methods.
+ */
+class My_Soap extends SoapClient {
+	public function __doRequest() {} // Ok.
+	public function __getFunctions() {} // Ok.
+	public function __getLastRequest() {} // Ok.
+	public function __getLastRequestHeaders() {} // Ok.
+	public function __getLastResponse() {} // Ok.
+	public function __getLastResponseHeaders() {} // Ok.
+	public function __getTypes() {} // Ok.
+	public function __setCookie() {} // Ok.
+	public function __setLocation() {} // Ok.
+	public function __setSoapHeaders() {} // Ok.
+	public function __soapCall() {} // Ok.
+}
+
+class My_Soap {
+	public function __doRequest() {} // Bad.
+	private function __getFunctions() {} // Bad.
+	protected function __getLastRequest() {} // Bad.
+	public function __getLastRequestHeaders() {} // Bad.
+	public function __getLastResponse() {} // Bad.
+	public function __getLastResponseHeaders() {} // Bad.
+	public function __getTypes() {} // Bad.
+	public function __setCookie() {} // Bad.
+	public function __setLocation() {} // Bad.
+	public function __setSoapHeaders() {} // Bad.
+	public function __soapCall() {} // Bad.
+}
+
+class My_Soap extends somethingElse {
+	public function __doRequest() {} // Ok - as somethingElse might be extended from SoapClient again.
+	private function __getFunctions() {} // Ok.
+	protected function __getLastRequest() {} // Ok.
+	public function __getLastRequestHeaders() {} // Ok.
+	public function __getLastResponse() {} // Ok.
+	public function __getLastResponseHeaders() {} // Ok.
+	public function __getTypes() {} // Ok.
+	public function __setCookie() {} // Ok.
+	public function __setLocation() {} // Ok.
+	public function __setSoapHeaders() {} // Ok.
+	public function __soapCall() {} // Ok.
 }

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -35,8 +35,20 @@ class WordPress_Tests_NamingConventions_ValidFunctionNameUnitTest extends Abstra
 	public function getErrorList() {
 		return array(
 			3 => 1,
+			9 => 1,
 			13 => 1,
 			15 => 1,
+			79 => 1,
+			80 => 1,
+			81 => 1,
+			82 => 1,
+			83 => 1,
+			84 => 1,
+			85 => 1,
+			86 => 1,
+			87 => 1,
+			88 => 1,
+			89 => 1,
 		);
 
 	} // end getErrorList()


### PR DESCRIPTION
Fixes #507 

This allows for classes which extend a parent class or implement an interface to use method names which do not comply with the "don't start methods with a double underscore" and snake case rules so they can overload parent methods without an issue being raised.
This was previously already implemented for snake case, but not for double underscore.

I've also synced the class with the parent class it uses and applied any relevant changes to the overloaded methods and removed some code which can defer to the parent.

Also:
* removed some code which was no longer needed (had to do with the private _ method names)
* updated the documentation here and there
* added more extensive unit tests
* fixed a wrongly tagged message and improved the wording of it

Please see the individual commits for more details.

There was one change in the parent class - which I have implemented -, which I was not sure about as it changes the result of one unit test.

Basically, before, function names (outside class scope) were allowed to start with a double underscore.
The change in the parent *does* allow for methods where the name only consists of underscores, like __(), but does not allow function names which also contain other characters to start with a double underscore unless they are a PHP magic function name, i.e. `__autoload()`.