### PR TITLE
Add strict type checking for array_search() and array_keys().

### DIFF
--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
@@ -18,3 +18,23 @@ $bar->
 	in_array( 1, array( '1', 1, true ) ); // OK
 
 in_array(); // Error
+
+
+array_search( 1, $array, true ); // Ok.
+$my->array_search( $array, $needle ); // Ok.
+
+array_search( 1, $array, false ); // Warning.
+array_search( 1, $array ); // Warning.
+Array_Search( 1, $array ); // Warning.
+ARRAY_SEARCH( 1, array( '1', 1, true ) ); // Warning.
+
+
+array_keys( $testing ); // Ok.
+array_keys( array( '1', 1, true ) ); // Ok.
+array_keys( $testing, 'my_key', true ); // Ok.
+array_keys( array( '1', 1, true ), 'my_key', true ); // Ok.
+
+array_keys( $testing, 'my_key' ); // Warning.
+array_keys( array( '1', 1, true ), 'my_key' ); // Warning.
+array_keys( $testing, 'my_key', false ); // Warning.
+array_keys( array( '1', 1, true ), 'my_key', false ); // Warning.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -46,6 +46,14 @@ class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
 			5 => 1,
 			9 => 1,
 			10 => 1,
+			26 => 1,
+			27 => 1,
+			28 => 1,
+			29 => 1,
+			37 => 1,
+			38 => 1,
+			39 => 1,
+			40 => 1,
 		);
 	} // end getWarningList()
 


### PR DESCRIPTION
Will only check for the `$strict` parameter for `array_keys()` if the second parameter has been set.

Fixes #503.

The file/sniff name is now a bit dated as the sniff checks for more than just `in_array()`, but changing the file/sniff/classname would break backward compatibility.

What do you think ?