### PR TITLE
Add ability to whitelist functions to the `AbstractFunctionRestrictions` class

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -165,6 +165,10 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSn
 				continue;
 			}
 
+			if ( isset( $group['whitelist'][ $token['content'] ] ) ) {
+				continue;
+			}
+
 			if ( preg_match( $group['regex'], $token['content'] ) < 1 ) {
 				continue;
 			}

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -51,6 +51,9 @@ class WordPress_Sniffs_DB_RestrictedFunctionsSniff extends WordPress_AbstractFun
 					'mysqlnd_memcache_*',
 					'maxdb_*',
 				),
+				'whitelist' => array(
+					'mysql_to_rfc3339' => true,
+				),
 			),
 
 		);

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
@@ -74,3 +74,17 @@ maxdb_num_fields();
 maxdb_prepare();
 maxdb_real_query
 maxdb_stat();
+
+
+/**
+ * And these shouldn't give an error.
+ */
+
+// WP Native function which was named a bit unfortunately.
+mysql_to_rfc3339(); // Ok.
+
+// Other WP Native functions which shouldn't give a problem anyway.
+mysql2date(); // Ok.
+wp_check_mysql_version(); // Ok.
+wp_check_php_mysql_version(); // Ok.
+WP_Date_Query::build_mysql_datetime(); // Ok.


### PR DESCRIPTION
This whitelist options is only useful when used in combination with blocking a function group using a wildcard in the function name.

However, it does make it more forward compatible. This allows to still block all the functions for a complete (PHP) extension , even for new functions being added to the extension, while whitelisting - for instance - a WP native function which was named a bit unfortunately.

This was brought to my attention when @octalmage opened issue https://github.com/wimg/PHPCompatibility/issues/123. The same problem he described there would occur with the new `WP.DB.RestrictedFunctions` sniff. This PR fixes that.