### PR TITLE
Use Squiz.PHP.DiscouragedFunctions instead

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -35,6 +35,8 @@
 	<rule ref="WordPress.PHP.StrictComparisons" />
 	<rule ref="WordPress.WP.I18n" />
 
+	<rule ref="Squiz.PHP.DiscouragedFunctions" />
+
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
 	<rule ref="WordPress.PHP.StrictInArray" />
 </ruleset>

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -13,6 +13,7 @@
 
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
 	<rule ref="Squiz.PHP.CommentedOutCode" />
+	<rule ref="Squiz.PHP.DiscouragedFunctions" />
 
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
 	<rule ref="WordPress.PHP.StrictInArray" />

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -38,11 +38,7 @@ class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_
 		'split'                    => null,
 		'spliti'                   => null,
 
-		// Development.
-		'print_r'                  => null,
-		'debug_print_backtrace'    => null,
-		'var_dump'                 => null,
-		'var_export'               => null,
+		// Development functions replaced by Squiz.PHP.DiscouragedFunctions.
 
 		// Discouraged.
 		'json_encode'              => 'wp_json_encode',

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -253,11 +253,7 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				'type'      => 'error',
 				'message'   => '%s Debug code is not allowed on VIP Production',
 				'functions' => array(
-					'error_log',
-					'var_dump',
-					'print_r',
-					'trigger_error',
-					'set_error_handler',
+					'wp_debug_backtrace_summary',
 				),
 			),
 


### PR DESCRIPTION
I have made a PR upstream https://github.com/squizlabs/PHP_CodeSniffer/pull/1086 to add a few more development related functions. It would be better to use the sniff `Squiz.PHP.DiscouragedFunctions` then create our own.

Fixes the PHPDevelopment sniffs from https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/582