### PR TITLE
Add rule to prohibit the use of the backtick shell execution operator…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.6.0
+  - PHPCS_BRANCH=2.7.0
 
 matrix:
   fast_finish: true

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -4,6 +4,7 @@
 
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
+	<rule ref="Generic.PHP.BacktickOperator"/>
 	<rule ref="Generic.Functions.CallTimePassByReference"/>
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement" />

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.6"
+		"squizlabs/php_codesniffer": "^2.7"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
… to `extra`.

Execution of shell commands should be discouraged. A number of the other commands along the same lines are discouraged via function sniffs, however, the backtick operator was so far ignored.

For this sniff to be added, the minimum PHPCS version needs to be upped as it has only just been added to master and is expected to be in the 2.7 release.

See: https://github.com/squizlabs/PHP_CodeSniffer/pull/1073