### PR TITLE
Verify extended classes.

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -465,7 +465,14 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @var string[]
 	 */
-	protected static $input_superglobals = array( '$_COOKIE', '$_GET', '$_FILES', '$_POST', '$_REQUEST', '$_SERVER' );
+	protected static $input_superglobals = array(
+		'$_COOKIE',
+		'$_GET',
+		'$_FILES',
+		'$_POST',
+		'$_REQUEST',
+		'$_SERVER',
+	);
 
 	/**
 	 * Initialize the class for the current process.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -9,6 +9,10 @@
  * @author   Marc McIntyre <mmcintyre@squiz.net>
  */
 
+if ( ! class_exists( 'Squiz_Sniffs_Arrays_ArrayDeclarationSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Squiz_Sniffs_Arrays_ArrayDeclarationSniff not found' );
+}
+
 /**
  * Enforces WordPress array format.
  *

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -94,8 +94,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
 		$this->init( $phpcsFile );
 
-		$tokens   = $phpcsFile->getTokens();
-		$instance = $tokens[ $stackPtr ];
+		$instance = $this->tokens[ $stackPtr ];
 
 		$superglobals = array_merge(
 			$this->errorForSuperGlobals

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -7,6 +7,10 @@
  * @author   John Godley <john@urbangiraffe.com>
  */
 
+if ( ! class_exists( 'PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff not found' );
+}
+
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
  *

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -15,7 +15,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if ( class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) === false ) {
+if ( ! class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) ) {
 	throw new PHP_CodeSniffer_Exception( 'Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found' );
 }
 

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -7,7 +7,7 @@
  * @author   John Godley <john@urbangiraffe.com>
  */
 
-if ( false === class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
 	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
 }
 

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -42,8 +42,7 @@ class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff {
 		$this->init( $phpcsFile );
 
 		if ( ! $this->has_whitelist_comment( 'loose comparison', $stackPtr ) ) {
-			$tokens = $phpcsFile->getTokens();
-			$error  = 'Found: ' . $tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
+			$error  = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
 			$phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
 		}
 

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -15,7 +15,7 @@
  * @category PHP
  * @package  PHP_CodeSniffer
  */
-class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_Sniff {
+class WordPress_Sniffs_PHP_StrictInArraySniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * List of array functions to which a $strict parameter can be passed.

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -7,6 +7,10 @@
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
+if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
+}
+
 /**
  * Disallow Filesystem writes.
  *

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -7,6 +7,10 @@
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
+if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
+}
+
 /**
  * WordPress_Sniffs_VIP_SessionFunctionsUsageSniff.
  *

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -7,10 +7,6 @@
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
-if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
-	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
-}
-
 /**
  * WordPress_Sniffs_VIP_SessionVariableUsageSniff
  *
@@ -23,7 +19,7 @@ if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
  * @package  PHP_CodeSniffer
  * @author   Shady Sharaf <shady@x-team.com>
  */
-class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
+class WordPress_Sniffs_VIP_SessionVariableUsageSniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -7,6 +7,10 @@
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
+if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
+}
+
 /**
  * WordPress_Sniffs_VIP_SessionVariableUsageSniff
  *

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -41,14 +41,13 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
-		$tokens = $phpcsFile->getTokens();
 
 		// Check for global input variable.
-		if ( ! in_array( $tokens[ $stackPtr ]['content'], WordPress_Sniff::$input_superglobals, true ) ) {
+		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], self::$input_superglobals, true ) ) {
 			return;
 		}
 
-		$varName = $tokens[ $stackPtr ]['content'];
+		$varName = $this->tokens[ $stackPtr ]['content'];
 
 		// If we're overriding a superglobal with an assignment, no need to test.
 		if ( $this->is_assignment( $stackPtr ) ) {

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -7,6 +7,10 @@
  * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
  */
 
+if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
+}
+
 /**
  * WordPress_Sniffs_VIP_TimezoneChangeSniff.
  *

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -78,13 +78,13 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
 
-			WordPress_Sniff::$sanitizingFunctions = array_merge(
-				WordPress_Sniff::$sanitizingFunctions,
+			self::$sanitizingFunctions = array_merge(
+				self::$sanitizingFunctions,
 				array_flip( $this->customSanitizingFunctions )
 			);
 
-			WordPress_Sniff::$unslashingSanitizingFunctions = array_merge(
-				WordPress_Sniff::$unslashingSanitizingFunctions,
+			self::$unslashingSanitizingFunctions = array_merge(
+				self::$unslashingSanitizingFunctions,
 				array_flip( $this->customUnslashingSanitizingFunctions )
 			);
 
@@ -92,24 +92,23 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 		}
 
 		$this->init( $phpcsFile );
-		$tokens = $phpcsFile->getTokens();
-		$superglobals = WordPress_Sniff::$input_superglobals;
+		$superglobals = self::$input_superglobals;
 
 		// Handling string interpolation.
-		if ( T_DOUBLE_QUOTED_STRING === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
 			$interpolated_variables = array_map(
 				create_function( '$symbol', 'return "$" . $symbol;' ), // Replace with closure when 5.3 is minimum requirement for PHPCS.
-				$this->get_interpolated_variables( $tokens[ $stackPtr ]['content'] )
+				$this->get_interpolated_variables( $this->tokens[ $stackPtr ]['content'] )
 			);
 			foreach ( array_intersect( $interpolated_variables, $superglobals ) as $bad_variable ) {
-				$phpcsFile->addError( 'Detected usage of a non-sanitized, non-validated input variable %s: %s', $stackPtr, 'InputNotValidatedNotSanitized', array( $bad_variable, $tokens[ $stackPtr ]['content'] ) );
+				$phpcsFile->addError( 'Detected usage of a non-sanitized, non-validated input variable %s: %s', $stackPtr, 'InputNotValidatedNotSanitized', array( $bad_variable, $this->tokens[ $stackPtr ]['content'] ) );
 			}
 
 			return;
 		}
 
 		// Check if this is a superglobal.
-		if ( ! in_array( $tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
+		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
 			return;
 		}
 
@@ -129,7 +128,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			return;
 		}
 
-		$error_data = array( $tokens[ $stackPtr ]['content'] );
+		$error_data = array( $this->tokens[ $stackPtr ]['content'] );
 
 		// Check for validation first.
 		if ( ! $this->is_validated( $stackPtr, $array_key, $this->check_validation_in_scope_only ) ) {

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -282,28 +282,27 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
+		$token  = $this->tokens[ $stackPtr ];
 
 		$search = array(); // Array of globals to watch for.
 
 		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
 			$bracketPtr = $phpcsFile->findNext( array( T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
 
-			if ( T_OPEN_SQUARE_BRACKET !== $tokens[ $bracketPtr ]['code'] ) {
+			if ( T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] ) {
 				return;
 			}
 
-			$varPtr   = $phpcsFile->findNext( T_WHITESPACE, ( $bracketPtr + 1 ), $tokens[ $bracketPtr ]['bracket_closer'], true );
-			$varToken = $tokens[ $varPtr ];
+			$varPtr   = $phpcsFile->findNext( T_WHITESPACE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'], true );
+			$varToken = $this->tokens[ $varPtr ];
 
 			if ( ! in_array( trim( $varToken['content'], '\'"' ), $this->globals, true ) ) {
 				return;
 			}
 
-			$assignment = $phpcsFile->findNext( T_WHITESPACE, ( $tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
+			$assignment = $phpcsFile->findNext( T_WHITESPACE, ( $this->tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
 
-			if ( $assignment && T_EQUAL === $tokens[ $assignment ]['code'] ) {
+			if ( $assignment && T_EQUAL === $this->tokens[ $assignment ]['code'] ) {
 				if ( ! $this->has_whitelist_comment( 'override', $assignment ) ) {
 					$phpcsFile->addError( 'Overriding WordPress globals is prohibited', $stackPtr, 'OverrideProhibited' );
 					return;
@@ -316,7 +315,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			$ptr = ( $stackPtr + 1 );
 			while ( $ptr ) {
 				$ptr++;
-				$var = $tokens[ $ptr ];
+				$var = $this->tokens[ $ptr ];
 				if ( T_VARIABLE === $var['code'] ) {
 					$varname = substr( $var['content'], 1 );
 					if ( in_array( $varname, $this->globals, true ) ) {
@@ -333,10 +332,10 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			}
 
 			// Check for assignments to collected global vars.
-			foreach ( $tokens as $ptr => $token ) {
+			foreach ( $this->tokens as $ptr => $token ) {
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
 					$next = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr + 1 ), null, true, null, true );
-					if ( T_EQUAL === $tokens[ $next ]['code'] ) {
+					if ( T_EQUAL === $this->tokens[ $next ]['code'] ) {
 						if ( ! $this->has_whitelist_comment( 'override', $next ) ) {
 							$phpcsFile->addError( 'Overriding WordPress globals is prohibited', $ptr, 'OverrideProhibited' );
 						}

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -101,14 +101,12 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 
-		$tokens = $phpcsFile->getTokens();
+		$this->init( $phpcsFile );
 
 		// Check for $wpdb variable.
-		if ( '$wpdb' !== $tokens[ $stackPtr ]['content'] ) {
+		if ( '$wpdb' !== $this->tokens[ $stackPtr ]['content'] ) {
 			return;
 		}
-
-		$this->init( $phpcsFile );
 
 		if ( ! $this->is_wpdb_method_call( $stackPtr ) ) {
 			return;
@@ -120,14 +118,14 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 
 		for ( $this->i; $this->i < $this->end; $this->i++ ) {
 
-			if ( isset( $this->ignored_tokens[ $tokens[ $this->i ]['code'] ] ) ) {
+			if ( isset( $this->ignored_tokens[ $this->tokens[ $this->i ]['code'] ] ) ) {
 				continue;
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $tokens[ $this->i ]['code'] ) {
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code'] ) {
 
 				$bad_variables = array_filter(
-					$this->get_interpolated_variables( $tokens[ $this->i ]['content'] ),
+					$this->get_interpolated_variables( $this->tokens[ $this->i ]['content'] ),
 					create_function( '$symbol', 'return ! in_array( $symbol, array( "wpdb" ), true );' ) // Replace this with closure once 5.3 is minimum requirement.
 				);
 
@@ -138,25 +136,25 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 						'NotPrepared',
 						array(
 							$bad_variable,
-							$tokens[ $this->i ]['content'],
+							$this->tokens[ $this->i ]['content'],
 						)
 					);
 				}
 				continue;
 			}
 
-			if ( T_VARIABLE === $tokens[ $this->i ]['code'] ) {
-				if ( '$wpdb' === $tokens[ $this->i ]['content'] ) {
+			if ( T_VARIABLE === $this->tokens[ $this->i ]['code'] ) {
+				if ( '$wpdb' === $this->tokens[ $this->i ]['content'] ) {
 					$this->is_wpdb_method_call( $this->i );
 					continue;
 				}
 			}
 
-			if ( T_STRING === $tokens[ $this->i ]['code'] ) {
+			if ( T_STRING === $this->tokens[ $this->i ]['code'] ) {
 
 				if (
-					isset( self::$SQLEscapingFunctions[ $tokens[ $this->i ]['content'] ] )
-					|| isset( self::$SQLAutoEscapedFunctions[ $tokens[ $this->i ]['content'] ] )
+					isset( self::$SQLEscapingFunctions[ $this->tokens[ $this->i ]['content'] ] )
+					|| isset( self::$SQLAutoEscapedFunctions[ $this->tokens[ $this->i ]['content'] ] )
 				) {
 
 					// Find the opening parenthesis.
@@ -171,7 +169,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 						$this->i = $this->tokens[ $opening_paren ]['parenthesis_closer'];
 						continue;
 					}
-				} elseif ( isset( self::$formattingFunctions[ $tokens[ $this->i ]['content'] ] ) ) {
+				} elseif ( isset( self::$formattingFunctions[ $this->tokens[ $this->i ]['content'] ] ) ) {
 					continue;
 				}
 			}
@@ -180,7 +178,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				'Use placeholders and $wpdb->prepare(); found %s',
 				$this->i,
 				'NotPrepared',
-				array( $tokens[ $this->i ]['content'] )
+				array( $this->tokens[ $this->i ]['content'] )
 			);
 		}
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -96,14 +96,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		$this->blank_line_check 	  = (bool) $this->blank_line_check;
 		$this->blank_line_after_check = (bool) $this->blank_line_after_check;
 
-		$tokens = $phpcsFile->getTokens();
-
 		$this->init( $phpcsFile );
 
-		if ( isset( $tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code']
-			&& ! ( T_ELSE === $tokens[ $stackPtr ]['code'] && T_COLON === $tokens[ ( $stackPtr + 1 ) ]['code'] )
+		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ! ( T_ELSE === $this->tokens[ $stackPtr ]['code'] && T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
 			&& ! (
-				T_CLOSURE === $tokens[ $stackPtr ]['code']
+				T_CLOSURE === $this->tokens[ $stackPtr ]['code']
 				&& (
 					0 === (int) $this->spaces_before_closure_open_paren
 					|| -1 === (int) $this->spaces_before_closure_open_paren
@@ -123,25 +121,25 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 		}
 
-		if ( ! isset( $tokens[ $stackPtr ]['scope_closer'] ) ) {
+		if ( ! isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 
-			if ( T_USE === $tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
+			if ( T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
 				$scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
-				$scopeCloser = $tokens[ $scopeOpener ]['scope_closer'];
+				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
 			} else {
 				return;
 			}
 		} else {
-			$scopeOpener = $tokens[ $stackPtr ]['scope_opener'];
-			$scopeCloser = $tokens[ $stackPtr ]['scope_closer'];
+			$scopeOpener = $this->tokens[ $stackPtr ]['scope_opener'];
+			$scopeCloser = $this->tokens[ $stackPtr ]['scope_closer'];
 		}
 
 		// Alternative syntax.
-		if ( T_COLON === $tokens[ $scopeOpener ]['code'] ) {
+		if ( T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
 
 			if ( 'required' === $this->space_before_colon ) {
 
-				if ( T_WHITESPACE !== $tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+				if ( T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Space between opening control structure and T_COLON is required';
 
 					if ( isset( $phpcsFile->fixer ) ) {
@@ -158,7 +156,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 			} elseif ( 'forbidden' === $this->space_before_colon ) {
 
-				if ( T_WHITESPACE === $tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+				if ( T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Extra space between opening control structure and T_COLON found';
 
 					if ( isset( $phpcsFile->fixer ) ) {
@@ -179,13 +177,13 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		$parenthesisOpener = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If this is a function declaration.
-		if ( T_FUNCTION === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
 
-			if ( T_STRING === $tokens[ $parenthesisOpener ]['code'] ) {
+			if ( T_STRING === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
 				$function_name_ptr = $parenthesisOpener;
 
-			} elseif ( T_BITWISE_AND === $tokens[ $parenthesisOpener ]['code'] ) {
+			} elseif ( T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
 				// This function returns by reference (function &function_name() {}).
 				$function_name_ptr = $parenthesisOpener = $phpcsFile->findNext(
@@ -211,7 +209,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$error,
 					$stackPtr,
 					'SpaceBeforeFunctionOpenParenthesis',
-					$tokens[ ( $function_name_ptr + 1 ) ]['content']
+					$this->tokens[ ( $function_name_ptr + 1 ) ]['content']
 				);
 
 				if ( true === $fix ) {
@@ -220,14 +218,14 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$phpcsFile->fixer->endChangeset();
 				}
 			}
-		} elseif ( T_CLOSURE === $tokens[ $stackPtr ]['code'] ) {
+		} elseif ( T_CLOSURE === $this->tokens[ $stackPtr ]['code'] ) {
 
 			// Check if there is a use () statement.
-			if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
 
 				$usePtr = $phpcsFile->findNext(
 					PHP_CodeSniffer_Tokens::$emptyTokens,
-					( $tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
+					( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
 					null,
 					true,
 					null,
@@ -235,19 +233,19 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				);
 
 				// If it is, we set that as the "scope opener".
-				if ( T_USE === $tokens[ $usePtr ]['code'] ) {
+				if ( T_USE === $this->tokens[ $usePtr ]['code'] ) {
 					$scopeOpener = $usePtr;
 				}
 			}
 		}
 
 		if (
-			T_COLON !== $tokens[ $parenthesisOpener ]['code']
-			&& T_FUNCTION !== $tokens[ $stackPtr ]['code']
+			T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
+			&& T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
 		) {
 
 			if (
-				T_CLOSURE === $tokens[ $stackPtr ]['code']
+				T_CLOSURE === $this->tokens[ $stackPtr ]['code']
 				&& 0 === (int) $this->spaces_before_closure_open_paren
 			) {
 
@@ -263,7 +261,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 			} elseif (
 				(
-					T_CLOSURE !== $tokens[ $stackPtr ]['code']
+					T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
 					|| 1 === (int) $this->spaces_before_closure_open_paren
 				)
 				&& ( $stackPtr + 1 ) === $parenthesisOpener
@@ -285,8 +283,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		}
 
 		if (
-			T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code']
-			&& ' ' !== $tokens[ ( $stackPtr + 1 ) ]['content']
+			T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ' ' !== $this->tokens[ ( $stackPtr + 1 ) ]['content']
 		) {
 			// Checking this: if [*](...) {}.
 			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
@@ -294,7 +292,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				$error,
 				$stackPtr,
 				'ExtraSpaceBeforeOpenParenthesis',
-				$tokens[ ( $stackPtr + 1 ) ]['content']
+				$this->tokens[ ( $stackPtr + 1 ) ]['content']
 			);
 
 			if ( true === $fix ) {
@@ -304,8 +302,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 		}
 
-		if ( T_WHITESPACE !== $tokens[ ( $parenthesisOpener + 1) ]['code']
-			&& T_CLOSE_PARENTHESIS !== $tokens[ ( $parenthesisOpener + 1) ]['code']
+		if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1) ]['code']
+			&& T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1) ]['code']
 		) {
 			// Checking this: $value = my_function([*]...).
 			$error = 'No space after opening parenthesis is prohibited';
@@ -321,13 +319,13 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 		}
 
-		if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+		if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
 
-			$parenthesisCloser = $tokens[ $parenthesisOpener ]['parenthesis_closer'];
+			$parenthesisCloser = $this->tokens[ $parenthesisOpener ]['parenthesis_closer'];
 
-			if ( T_CLOSE_PARENTHESIS !== $tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+			if ( T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 
-				if ( T_WHITESPACE !== $tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
+				if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
 					$error = 'No space before closing parenthesis is prohibited';
 					if ( isset( $phpcsFile->fixer ) ) {
 						$fix = $phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
@@ -342,8 +340,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 
 				if (
-					T_WHITESPACE !== $tokens[ ( $parenthesisCloser + 1 ) ]['code']
-					&& T_COLON !== $tokens[ $scopeOpener ]['code']
+					T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+					&& T_COLON !== $this->tokens[ $scopeOpener ]['code']
 				) {
 					$error = 'Space between opening control structure and closing parenthesis is required';
 
@@ -361,8 +359,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 			}
 
-			if ( isset( $tokens[ $parenthesisOpener ]['parenthesis_owner'] )
-				&& $tokens[ $parenthesisCloser ]['line'] !== $tokens[ $scopeOpener ]['line']
+			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
+				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line']
 			) {
 				$error = 'Opening brace should be on the same line as the declaration';
 				if ( isset( $phpcsFile->fixer ) ) {
@@ -383,8 +381,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				return;
 
 			} elseif (
-				T_WHITESPACE === $tokens[ ( $parenthesisCloser + 1 ) ]['code']
-				&& ' ' !== $tokens[ ( $parenthesisCloser + 1 ) ]['content']
+				T_WHITESPACE === $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+				&& ' ' !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
 			) {
 
 				// Checking this: if (...) [*]{}.
@@ -393,7 +391,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$error,
 					$stackPtr,
 					'ExtraSpaceAfterCloseParenthesis',
-					$tokens[ ( $parenthesisCloser + 1 ) ]['content']
+					$this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
 				);
 
 				if ( true === $fix ) {
@@ -406,8 +404,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 		if ( true === $this->blank_line_check ) {
 			$firstContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
-			if ( $tokens[ $firstContent ]['line'] > ( $tokens[ $scopeOpener ]['line'] + 1 )
-				&& false === in_array( $tokens[ $firstContent ]['code'], array( T_CLOSE_TAG, T_COMMENT ), true )
+			if ( $this->tokens[ $firstContent ]['line'] > ( $this->tokens[ $scopeOpener ]['line'] + 1 )
+				&& false === in_array( $this->tokens[ $firstContent ]['code'], array( T_CLOSE_TAG, T_COMMENT ), true )
 			) {
 				$error = 'Blank line found at start of control structure';
 				if ( isset( $phpcsFile->fixer ) ) {
@@ -428,11 +426,11 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 
 			$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
-			if ( ( $tokens[ $scopeCloser ]['line'] - 1 ) !== $tokens[ $lastContent ]['line'] ) {
+			if ( ( $this->tokens[ $scopeCloser ]['line'] - 1 ) !== $this->tokens[ $lastContent ]['line'] ) {
 				$errorToken = $scopeCloser;
 				for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
-					if ( $tokens[ $i ]['line'] < $tokens[ $scopeCloser ]['line']
-						&& T_OPEN_TAG !== $tokens[ $firstContent ]['code']
+					if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
+						&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
 					) {
 						// TODO: Reporting error at empty line won't highlight it in IDE.
 						$error = 'Blank line found at end of control structure';
@@ -458,16 +456,16 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		} // end if
 
 		$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
-		if ( T_ELSE === $tokens[ $trailingContent ]['code'] ) {
-			if ( T_IF === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] ) {
+			if ( T_IF === $this->tokens[ $stackPtr ]['code'] ) {
 				// IF with ELSE.
 				return;
 			}
 		}
 
-		if ( T_COMMENT === $tokens[ $trailingContent ]['code'] ) {
-			if ( $tokens[ $trailingContent ]['line'] === $tokens[ $scopeCloser ]['line'] ) {
-				if ( '//end' === substr( $tokens[ $trailingContent ]['content'], 0, 5 ) ) {
+		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
+			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
+				if ( '//end' === substr( $this->tokens[ $trailingContent ]['content'], 0, 5 ) ) {
 					// There is an end comment, so we have to get the next piece
 					// of content.
 					$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1), null, true );
@@ -475,27 +473,27 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 		}
 
-		if ( T_BREAK === $tokens[ $trailingContent ]['code'] ) {
+		if ( T_BREAK === $this->tokens[ $trailingContent ]['code'] ) {
 			// If this BREAK is closing a CASE, we don't need the
 			// blank line after this control structure.
-			if ( isset( $tokens[ $trailingContent ]['scope_condition'] ) ) {
-				$condition = $tokens[ $trailingContent ]['scope_condition'];
-				if ( T_CASE === $tokens[ $condition ]['code'] || T_DEFAULT === $tokens[ $condition ]['code'] ) {
+			if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] ) ) {
+				$condition = $this->tokens[ $trailingContent ]['scope_condition'];
+				if ( T_CASE === $this->tokens[ $condition ]['code'] || T_DEFAULT === $this->tokens[ $condition ]['code'] ) {
 					return;
 				}
 			}
 		}
 
-		if ( T_CLOSE_TAG === $tokens[ $trailingContent ]['code'] ) {
+		if ( T_CLOSE_TAG === $this->tokens[ $trailingContent ]['code'] ) {
 			// At the end of the script or embedded code.
 			return;
 		}
 
-		if ( T_CLOSE_CURLY_BRACKET === $tokens[ $trailingContent ]['code'] ) {
+		if ( T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code'] ) {
 			// Another control structure's closing brace.
-			if ( isset( $tokens[ $trailingContent ]['scope_condition'] ) ) {
-				$owner = $tokens[ $trailingContent ]['scope_condition'];
-				if ( in_array( $tokens[ $owner ]['code'], array( T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+			if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] ) ) {
+				$owner = $this->tokens[ $trailingContent ]['scope_condition'];
+				if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
 					// The next content is the closing brace of a function, class, interface or trait
 					// so normal function/class rules apply and we can ignore it.
 					return;
@@ -503,7 +501,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 
 			if ( true === $this->blank_line_after_check
-				&& ( $tokens[ $scopeCloser ]['line'] + 1 ) !== $tokens[ $trailingContent ]['line']
+				&& ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line']
 			) {
 				// TODO: Won't cover following case: "} echo 'OK';".
 				$error = 'Blank line found after control structure';


### PR DESCRIPTION
Ensured that any sniff with a dependency on an external sniff has a consistent `class_exists()` check and throws an appropriate error message.

Verified that classes which extend a parent actually *use* that parent and if not, removed the `extend`.
If they use the parent, leverage the properties available in the parent and remove duplicate function calls.