### PR TITLE
Sync the WhiteSpace_CastStructureSpacing sniff with its base class.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -150,6 +150,9 @@
 		<!-- Covers rule: When type casting, do it like so: $foo = (boolean) $bar; -->
 		<rule ref="Generic.Formatting.SpaceAfterCast"/>
 		<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
+		<rule ref="WordPress.WhiteSpace.CastStructureSpacing.ContainsWhiteSpace">
+			<type>warning</type>
+		</rule>
 
 		<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 		<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_CastSpacingSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Squiz_Sniffs_WhiteSpace_CastSpacingSniff not found' );
+}
+
 /**
  * Ensure cast statements don't contain whitespace, but *are* surrounded by whitespace, based upon Squiz code.
  *
@@ -15,21 +19,13 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.11.0 This sniff now extends the Squiz_Sniffs_WhiteSpace_CastSpacingSniff class it was based upon.
+ * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
  *
- * Last synced with base class ?[unknown date]? at commit ?[unknown commit]?.
+ * Last synced with parent class August 2016 at commit 5def2acbe3911e2aea08ac8b8eb4e4d64330021f.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
  */
-class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeSniffer_Sniff {
-
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		return PHP_CodeSniffer_Tokens::$castTokens;
-
-	}
+class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff extends Squiz_Sniffs_WhiteSpace_CastSpacingSniff {
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -41,37 +37,25 @@ class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeS
 	 * @return void
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		parent::process( $phpcsFile, $stackPtr );
+
 		$tokens = $phpcsFile->getTokens();
-
-		$content  = $tokens[ $stackPtr ]['content'];
-		$expected = str_replace( ' ', '', $content );
-		$expected = str_replace( "\t", '', $expected );
-
-		if ( $content !== $expected ) {
-			$error = 'Cast statements must not contain whitespace; expected "%s" but found "%s"';
-			$data  = array(
-				$expected,
-				$content,
-			);
-			$phpcsFile->addWarning( $error, $stackPtr, 'ContainsWhiteSpace', $data );
-		}
 
 		if ( T_WHITESPACE !== $tokens[ ( $stackPtr - 1 ) ]['code'] ) {
 			$error = 'No space before opening casting parenthesis is prohibited';
-			$phpcsFile->addWarning( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+			$fix   = $phpcsFile->addFixableWarning( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+			if ( true === $fix ) {
+				$phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
+			}
 		}
 
 		if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 			$error = 'No space after closing casting parenthesis is prohibited';
-			$phpcsFile->addWarning( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+			$fix   = $phpcsFile->addFixableWarning( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+			if ( true === $fix ) {
+				$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+			}
 		}
-	} // end process()
-
-	/**
-	 * If true, an error will be thrown; otherwise a warning.
-	 *
-	 * @var bool
-	 */
-	public $error = false;
+	}
 
 } // End class.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
@@ -1,22 +1,22 @@
 <?php
 
-$array1 = (array)$array;
+$array1 = (array) $array;
 $array2 = (array) $array;
 
-$bool1 = (bool)$bool;
+$bool1 = (bool) $bool;
 $bool2 = (bool) $bool;
 
-$int1 = (int)$int;
+$int1 = (int) $int;
 $int2 = (int) $int;
 
-$obj1 = ( object )$object;
+$obj1 = (object) $object;
 $obj2 = (object) $object;
 
-$str1 =(string)$string;
+$str1 = (string) $string;
 $str2 = (string) $string;
 
-$unset1 = ( unset)$unset;
+$unset1 = (unset) $unset;
 $unset2 = (unset) $unset;
 
-$float1 = (float )$float;
+$float1 = (float) $float;
 $float2 = (float) $float;

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -36,9 +36,9 @@ class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSn
 			 6 => 1,
 			 9 => 1,
 			 12 => 2,
-			 15 => 1,
-			 18 => 1,
-			 21 => 1,
+			 15 => 2,
+			 18 => 2,
+			 21 => 2,
 		);
 
 	}


### PR DESCRIPTION
The `WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff` is based upon the `Squiz_Sniffs_WhiteSpace_CastSpacingSniff`.

This PR contains the following changes:
* The class now extends the class it is based upon.
   This also means that the class now only contains the WP specific checks and defers to the parent for anything else.
* The check which is covered by the parent was already fixable there. This benefit is now carried over to this sniff.
* Made the two WP specific checks fixable as well and added a `.fixed` file to unit test this.
* Removed the class property which was at the bottom of the class which looks like it was left over from an earlier attempt to use the parent class in combination with making the check covered in the parent a `warning` instead of an `error`. The property did not have the desired effect.
  This is now solved by setting this in the ruleset.