### PR TITLE
Add sniff for long conditional end comments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.6.0
+  - PHPCS_BRANCH=2.7.0
 
 matrix:
   fast_finish: true

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -52,9 +52,15 @@
 			<severity>0</severity>
 		</rule>
 
-		<!-- Rule: If you consider a long block unavoidable, please put a short comment at the end ...
-			 - typically this is appropriate for a logic block, longer than about 35 rows.
-			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/606 -->
+		<!-- Covers rule: If you consider a long block unavoidable, please put a short comment at the end ...
+			 - typically this is appropriate for a logic block, longer than about 35 rows. -->
+		<rule ref="Squiz.Commenting.LongConditionClosingComment">
+			<properties>
+				<property name="lineLimit" value="35" />
+				<property name="commentFormat" value="// End %s()." />
+			</properties>
+			<exclude name="Squiz.Commenting.LongConditionClosingComment.SpacingBefore" />
+		</rule>
 
 		<!-- Covers rule: Braces should always be used, even when they are not required. -->
 		<rule ref="Generic.ControlStructures.InlineControlStructure" />
@@ -294,5 +300,6 @@
 	-->
 		<!-- Check for correct usage of the WP i18n functions. -->
 		<rule ref="WordPress.WP.I18n"/>
+
 
 </ruleset>

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -179,11 +179,9 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 					);
 				}
 			}
+		} // End foreach().
 
-			// return; // Show one error only.
-		}
-
-	} // end process()
+	} // End process().
 
 	/**
 	 * Callback to process each confirmed key, to check value.

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -153,7 +153,7 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 
 		}
 
-	} // end process()
+	} // End process().
 
 	/**
 	 * Prepare the class name for use in a regular expression.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -193,7 +193,7 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSn
 
 		}
 
-	} // end process()
+	} // End process().
 
 	/**
 	 * Prepare the function name for use in a regular expression.

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -165,9 +165,9 @@ abstract class WordPress_AbstractVariableRestrictionsSniff implements PHP_CodeSn
 
 			return; // Show one error only.
 
-		}
+		} // End foreach().
 
-	} // end process()
+	} // End process().
 
 	/**
 	 * Transform a wildcard pattern to a usable regex pattern.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1018,7 +1018,8 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 
 			$scope_end = $stackPtr;
-		}
+
+		} // End if().
 
 		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
@@ -1172,6 +1173,6 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			}
 		}
 		return $variables;
-	} // end get_interpolated_variables()
+	}
 
 }

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -54,6 +54,6 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		return true;
-	} // end callback()
+	}
 
 } // End class.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -127,7 +127,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			if ( true === $fix ) {
 				$phpcsFile->fixer->addNewlineBefore( $arrayEnd );
 			}
-		} // end if
+		}
 
 		$nextToken  = $stackPtr;
 		$keyUsed    = false;
@@ -263,11 +263,12 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 					$indices[]  = array( 'value' => $valueContent );
 					$singleUsed = true;
-				} // end if
+				} // End if().
 
 				$lastToken = $nextToken;
 				continue;
-			} // end if
+
+			} // End if().
 
 			if ( T_DOUBLE_ARROW === $tokens[ $nextToken ]['code'] ) {
 
@@ -302,8 +303,8 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				$currentEntry['value'] = $nextContent;
 				$indices[]             = $currentEntry;
 				$lastToken             = $nextToken;
-			} // end if
-		} // end for
+			} // End if().
+		} // End for().
 
 		// Check for mutli-line arrays that should be single-line.
 		$singleValue = false;
@@ -372,11 +373,11 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 
 						$phpcsFile->fixer->addNewlineBefore( $value['value'] );
 					}
-				} // end if
+				}
 
 				$lastValueLine = $tokens[ $value['value'] ]['line'];
-			} // end foreach
-		} // end if
+			}
+		} // End if().
 
 		/*
 			Below the actual indentation of the array is checked.
@@ -486,7 +487,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					$nextComma = $i;
 					break;
 				}
-			} // End for.
+			} // End for().
 
 			if ( false === $nextComma ) {
 				$error = 'Each line in an array declaration must end in a comma';
@@ -519,8 +520,8 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					$phpcsFile->fixer->replaceToken( ( $nextComma - 1 ), '' );
 				}
 			}
-		} // end foreach
+		} // End foreach().
 
-	} // end processMultiLineArray()
+	} // End processMultiLineArray().
 
 } // End class.

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -84,6 +84,6 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 			}
 		}
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -129,6 +129,6 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 			, $severity
 		);
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/Classes/ValidClassNameSniff.php
+++ b/WordPress/Sniffs/Classes/ValidClassNameSniff.php
@@ -70,6 +70,6 @@ class WordPress_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sn
 			$phpcsFile->addError( $error, $stackPtr, 'NotCamelCaps' );
 		}
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -49,6 +49,6 @@ class WordPress_Sniffs_Files_FileNameSniff implements PHP_CodeSniffer_Sniff {
 
 		return ( $phpcsFile->numTokens + 1 );
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -43,6 +43,6 @@ class WordPress_Sniffs_Functions_DontExtractSniff extends WordPress_AbstractFunc
 			),
 
 		);
-	} // end getGroups()
+	} // End getGroups().
 
 } // End class.

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -97,7 +97,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid', $errorData );
 		}
 
-	} // end processTokenOutsideScope()
+	} // End processTokenOutsideScope().
 
 	/**
 	 * Processes the tokens within the scope.
@@ -170,7 +170,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			$phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}
 
-	} // end processTokenWithinScope()
+	} // End processTokenWithinScope().
 
 	/**
 	 * Returns the name of the interface that the specified class implements.
@@ -218,6 +218,6 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			return false;
 		}
 		return $name;
-	} // end findExtendedClassName()
+	} // End findExtendedClassName().
 
 } // End class.

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -168,7 +168,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 					$underscores++;
 				}
 			}
-		}
+		} // End for().
 
 		$data = array(
 			implode( '', $expected ),
@@ -184,7 +184,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 			$phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
 		}
 
-	} // end process()
+	} // End process().
 
 	/**
 	 * Prepare the punctuation regular expression.
@@ -203,7 +203,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 
 		return sprintf( $this->punctuation_regex, $extra );
 
-	} // end prepare_regex()
+	} // End prepare_regex().
 
 	/**
 	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
@@ -227,7 +227,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 			default:
 				return preg_replace( $regex, '_', strtolower( $string ) );
 		}
-	} // end transform()
+	} // End transform().
 
 	/**
 	 * Transform a complex string which may contain variable extrapolation.
@@ -279,6 +279,6 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 		}
 
 		return implode( '', $output );
-	} // end transform_complex_string()
+	} // End transform_complex_string().
 
 } // End class.

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -121,9 +121,9 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 						$data  = array( $original_var_name );
 						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
 					}
-				} // end if
-			} // end if
-		} // end if
+				} // End if().
+			} // End if().
+		} // End if().
 
 		$in_class     = false;
 		$obj_operator = $phpcs_file->findPrevious( array( T_WHITESPACE ), ( $stack_ptr - 1 ), null, true );

--- a/WordPress/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/WordPress/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -48,7 +48,7 @@ class WordPress_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSn
 			T_INLINE_HTML,
 		);
 
-	} // end register()
+	} // End register().
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -148,7 +148,7 @@ class WordPress_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSn
 				$phpcsFile->addWarning( $error, $stackPtr, 'MaybeASPOpenTagFound', $data );
 			}
 		}
-	} // end process()
+	} // End process().
 
 	/**
 	 * Get a snippet from a HTML token.

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -65,6 +65,6 @@ class WordPress_Sniffs_PHP_POSIXFunctionsSniff extends WordPress_AbstractFunctio
 			),
 
 		);
-	} // end getGroups()
+	} // End getGroups().
 
 } // End class.

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -127,6 +127,6 @@ class WordPress_Sniffs_PHP_StrictInArraySniff implements PHP_CodeSniffer_Sniff {
 			$phpcsFile->addWarning( 'Not using strict comparison for %s; supply true for third argument.', $lastToken, 'MissingTrueStrict', $errorData );
 			return;
 		}
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -100,6 +100,6 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 
 		$phpcsFile->addError( 'Use Yoda Condition checks, you must', $stackPtr, 'NotYoda' );
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -47,6 +47,6 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
 		if ( in_array( trim( $tokens[ $stackPtr ]['content'], '"\'' ), array( 'show_admin_bar' ), true ) ) {
 			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
 		}
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -129,7 +129,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
 			return;
 		}
 
-	} // end process()
+	} // End process().
 
 	/**
 	 * Add warning about unclear cron schedule change.

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -210,6 +210,6 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 
 		return $endOfStatement;
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -330,6 +330,6 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 			),
 
 		);
-	} // end getGroups()
+	} // End getGroups().
 
 } // End class.

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -152,6 +152,6 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
 		}
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -348,7 +348,8 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 					}
 				}
 			}
-		}
-	} // end process()
+		} // End if().
+
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -53,6 +53,6 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 			$phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr, 'NonEnqueuedScript' );
 		}
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -374,6 +374,6 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		if ( empty( $non_placeholder_content ) ) {
 			$phpcs_file->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
 		}
-	} // end check_text()
+	} // End check_text().
 
 }

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -183,11 +183,11 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				'NotPrepared',
 				array( $this->tokens[ $this->i ]['content'] )
 			);
-		}
+		} // End for().
 
 		return $this->end;
 
-	} // end process().
+	} // End process().
 
 	/**
 	 * Checks whether this is a call to a $wpdb method that we want to sniff.
@@ -241,6 +241,6 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 		}
 
 		return true;
-	} // is_wpdb_method_call()
+	} // End is_wpdb_method_call().
 
 } // End class.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -172,7 +172,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					}
 				}
 			}
-		}
+		} // End if().
 
 		$parenthesisOpener = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
@@ -237,7 +237,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$scopeOpener = $usePtr;
 				}
 			}
-		}
+		} // End if().
 
 		if (
 			T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
@@ -280,7 +280,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 				}
 			}
-		}
+		} // End if().
 
 		if (
 			T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
@@ -377,7 +377,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					}
 				} else {
 					$phpcsFile->addError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
-				} // end if
+				}
 				return;
 
 			} elseif (
@@ -399,8 +399,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
 					$phpcsFile->fixer->endChangeset();
 				}
-			}
-		} // end if
+			} // End if().
+		} // End if().
 
 		if ( true === $this->blank_line_check ) {
 			$firstContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
@@ -448,12 +448,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 							}
 						} else {
 							$phpcsFile->addError( $error, $i, 'BlankLineBeforeEnd' );
-						} // end if
+						}
 						break;
-					} // end if
-				} // end for
-			} // end if
-		} // end if
+					} // End if().
+				} // End for().
+			} // End if().
+		} // End if().
 
 		$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
 		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] ) {
@@ -522,8 +522,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$phpcsFile->addError( $error, $scopeCloser, 'BlankLineAfterEnd' );
 				}
 			}
-		} // end if
+		} // End if().
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -134,7 +134,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 						}
 					}
 				}
-			} // end if
+			} // End if().
 
 			$operator = $tokens[ $stackPtr ]['content'];
 
@@ -172,7 +172,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 						$phpcsFile->addError( $error, $stackPtr, 'SpacingBefore', $data );
 					}
 				}
-			} // end if
+			} // End if().
 
 			if ( '-' !== $operator ) {
 				if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
@@ -205,10 +205,10 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 					} else {
 						$phpcsFile->addError( $error, $stackPtr, 'SpacingAfter', $data );
 					}
-				} // end if
-			} // end if
-		} // end if
+				} // End if().
+			} // End if().
+		} // End if().
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -337,7 +337,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			} else {
 				$content = $this->tokens[ $i ]['content'];
 				$ptr     = $i;
-			}
+			} // End if().
 
 			$this->phpcsFile->addError(
 				"Expected next thing to be an escaping function (see Codex for 'Data Validation'), not '%s'",
@@ -345,10 +345,10 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 				'OutputNotEscaped',
 				$content
 			);
-		}
+		} // End for().
 
 		return $end_of_statement;
 
-	} // end process()
+	} // End process().
 
 } // End class.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -124,9 +124,9 @@ class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest
 			default:
 				return array();
 
-		}
+		} // End switch().
 
-	} // end getErrorList()
+	} // End getErrorList().
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -69,9 +69,9 @@ class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSn
 			default:
 				return array();
 
-		} // end switch
+		} // End switch().
 
-	} // end getErrorList()
+	} // End getErrorList().
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -73,7 +73,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			103 => 1,
 		);
 
-	} // end getErrorList()
+	} // End getErrorList().
 
 	/**
 	 * Returns the lines where warnings should occur.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.6"
+		"squizlabs/php_codesniffer": "^2.7"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
From the handbook:

> Furthermore, if you have a really long block, consider whether it can be broken into two or more shorter blocks or functions. If you consider such a long block unavoidable, **please put a short comment at the end so people can tell at glance what that ending brace ends – typically this is appropriate for a logic block, longer than about 35 rows**, but any code that’s not intuitively obvious can be commented.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style

This rule was so far not covered.

See https://github.com/squizlabs/PHP_CodeSniffer/pull/1074 .

For this sniff to be added, the minimum PHPCS version needs to be upped as it has only just been added to the master and is expected to be included in the PHPCS 2.7 release.

Closes #606