### PR TITLE
Allow for classes implementing more than one interface.

### DIFF
--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -102,3 +102,11 @@ class My_Soap extends somethingElse {
 	public function __setSoapHeaders() {} // Ok.
 	public function __soapCall() {} // Ok.
 }
+
+// Test for class implementing more than one interface.
+class Foo implements ArrayAccess, PHP_CodeSniffer_Sniff {
+	function offsetSet( $key, $value ) {} // OK
+	function offsetUnset( $key ) {} // OK
+	function offsetExists( $key ) {} // OK
+	function offsetGet( $key ) {} // OK
+}


### PR DESCRIPTION
This is part of an effort to upstream the method as was suggested in the `@todo`. This now synchronizes the method with what is contained in the upstream PR.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/1098

Includes additional unit tests.