### PR TITLE
Fix bug in VIP restricted functions + unit tests

### DIFF
--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -295,9 +295,9 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#encoding-values-used-when-creating-a-url-or-passed-to-add_query_arg
 			'urlencode' => array(
 				'type'      => 'warning',
-				'message'   => '%s urlencode should only be used when dealing with legacy applications rawurlencode should now be used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html',
+				'message'   => '%s should only be used when dealing with legacy applications, rawurlencode() should now be used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html',
 				'functions' => array(
-					'rawurlencode',
+					'urlencode',
 				),
 			),
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -88,3 +88,18 @@ PHPINFO(); // Error.
 CURL_getinfo(); // Error.
 
 curlyhair(); // Ok.
+
+get_previous_post_link(); // Error.
+get_next_post_link(); // Error.
+get_intermediate_image_sizes(); // Error.
+serialize(); // Warning.
+unserialize(); // Warning.
+error_log(); // Error.
+var_dump(); // Error.
+print_r(); // Error.
+trigger_error(); // Error.
+set_error_handler(); // Error.
+wp_redirect(); // Warning.
+wp_is_mobile(); // Error.
+urlencode(); // Warning.
+rawurlencode(); // Ok.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -62,6 +62,15 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			84 => 1,
 			85 => 1,
 			87 => 1,
+			92 => 1,
+			93 => 1,
+			94 => 1,
+			97 => 1,
+			98 => 1,
+			99 => 1,
+			100 => 1,
+			101 => 1,
+			103 => 1,
 		);
 
 	} // end getErrorList()
@@ -84,6 +93,10 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			61 => 1,
 			72 => 1,
 			88 => 1,
+			95 => 1,
+			96 => 1,
+			102 => 1,
+			104 => 1,
 		);
 
 	}


### PR DESCRIPTION
:exclamation: **This PR should be merged before 0.10.0 is released as it contains a bug fix for a bug which was introduced in one of the 0.10.0 commits.**

The `urlencode` check was checking for `rawurlencode()` instead of `urlencode()` while at the same time advising to use `rawurlencode()`.
The grammar of the error message was incorrect as well.
Both are now fixed.

In the [same commit](e7707b2338e7823a2d14cfbdca8bdc88488d6081) as this was introduced, a number of other restricted functions were added, but none of them were accompanied by unit tests.
This is now fixed as well.