### PR TITLE
Remove WordPress-Core from WordPress-VIP standard

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress VIP">
-	<description>WordPress VIP Coding Standards</description>
-
-	<rule ref="WordPress-Core"/>
+	<description>WordPress VIP Coding Standards without WordPress-Core. See https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/</description>
 
 	<rule ref="WordPress.VIP"/>
 


### PR DESCRIPTION
There is a lot of noise reported from the `WordPress-Core` standard that the VIP team doesn't care about. They don't care about whitespace and bracket usage, but rather they care about issues like security and not using restricted functions. As such, the `WordPress-VIP` standard should remove `WordPress-Core`. If the `WordPress-Core` are desired alongside the `WordPress-VIP` sniffs then all that is required is for both standards to be used when invoking PHPCS:

```
phpcs --standard=WordPress-Core,WordPress-VIP
```

Either this, or a custom project-specific `ruleset.xml` can be used which calls in both of these standards.