### PR TITLE
I18n: Always allow text domain of 'default' to facilitate feature plugins

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -25,7 +25,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	 * @todo Eventually this should be able to be auto-supplied via looking at $phpcs_file->getFilename()
 	 * @link https://youtrack.jetbrains.com/issue/WI-17740
 	 *
-	 * @var string
+	 * @var array
 	 */
 	public $text_domain;
 
@@ -102,6 +102,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 		if ( ! empty( self::$text_domain_override ) ) {
 			$this->text_domain = self::$text_domain_override;
+		}
+		if ( is_string( $this->text_domain ) ) {
+			$this->text_domain = explode( ',', $this->text_domain );
 		}
 
 		if ( '_' === $token['content'] ) {
@@ -253,8 +256,8 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), array( $this->text_domain, 'default' ), true ) ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $content ) );
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( join( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
 			return true;
@@ -268,8 +271,8 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			if ( ! empty( $interpolated_variables ) ) {
 				return false;
 			}
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $content, '\'""' ) !== $this->text_domain ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $content ) );
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( join( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
 			return true;

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -253,7 +253,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && trim( $content, '\'""' ) !== $this->text_domain ) {
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), array( $this->text_domain, 'default' ), true ) ) {
 				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( $this->text_domain, $content ) );
 				return false;
 			}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -104,7 +104,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$this->text_domain = self::$text_domain_override;
 		}
 		if ( is_string( $this->text_domain ) ) {
-			$this->text_domain = explode( ',', $this->text_domain );
+			$this->text_domain = array_filter( array_map( 'trim', explode( ',', $this->text_domain ) ) );
 		}
 
 		if ( '_' === $token['content'] ) {

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -257,7 +257,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
 			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( join( "' or '", $this->text_domain ), $content ) );
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( implode( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
 			return true;
@@ -272,7 +272,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				return false;
 			}
 			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
-				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( join( "' or '", $this->text_domain ), $content ) );
+				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( implode( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
 			return true;

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -112,5 +112,6 @@ __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
 
-// Using a text domain of 'default' should be allowed even if the plugin's domain is different. This facilitates feature plugins.
-__( 'String default text domain.', 'default'); // Ok.
+// The domain 'default' was also added to the text domains.
+__( 'String default text domain.', 'default' ); // Ok.
+__( "String default text domain.", "default" ); // Ok.

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -111,3 +111,6 @@ __( '\'%s\'', 'my-slug' ); // OK (ish. this is a technical test, not a great str
 __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single %.
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
+
+// Using a text domain of 'default' should be allowed even if the plugin's domain is different. This facilitates feature plugins.
+__( 'String default text domain.', 'default'); // Ok.

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -112,5 +112,6 @@ __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
 
-// Using a text domain of 'default' should be allowed even if the plugin's domain is different. This facilitates feature plugins.
-__( 'String default text domain.', 'default'); // Ok.
+// The domain 'default' was also added to the text domains.
+__( 'String default text domain.', 'default' ); // Ok.
+__( "String default text domain.", "default" ); // Ok.

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -111,3 +111,6 @@ __( '\'%s\'', 'my-slug' ); // OK (ish. this is a technical test, not a great str
 __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single %.
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
+
+// Using a text domain of 'default' should be allowed even if the plugin's domain is different. This facilitates feature plugins.
+__( 'String default text domain.', 'default'); // Ok.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -20,7 +20,7 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function setUp() {
 		// @todo Should be possible via self::$phpcs->setSniffProperty( 'WordPress_Sniffs_WP_I18nSniff', 'text_domain', 'my-slug' );
-		WordPress_Sniffs_WP_I18nSniff::$text_domain_override = 'my-slug';
+		WordPress_Sniffs_WP_I18nSniff::$text_domain_override = array( 'my-slug', 'default' );
 		parent::setUp();
 	}
 


### PR DESCRIPTION
When developing feature plugins, there is often a need to re-use strings in core. In such cases, the sniff should allow an explicit `default` text domain to allow for core strings to be re-used without being flagged.

For example: https://github.com/xwp/wp-customize-object-selector/blob/c7957ea0e7549a7d3fdc8ef0f811e3e05b4f46e4/php/class-plugin.php#L90