### PR TITLE
Whitelist $EZSQL_ERROR in variable naming conventions sniff

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -46,6 +46,15 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	);
 
 	/**
+	 * Mixed-case variables used by WordPress.
+	 *
+	 * @var array
+	 */
+	protected $wordpress_mixed_case_vars = array(
+		'EZSQL_ERROR' => true,
+	);
+
+	/**
 	 * List of member variables that can have mixed case.
 	 *
 	 * @var array
@@ -96,6 +105,11 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 
 		// If it's a php reserved var, then its ok.
 		if ( in_array( $var_name, $this->php_reserved_vars, true ) ) {
+			return;
+		}
+
+		// Likewise if it is a mixed-case var used by WordPress core.
+		if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -120,3 +120,5 @@ if ( is_category() ) {
 	$cat_id = $category->cat_ID;
 	$cat_ID = $category->cat_ID; // Bad.
 }
+
+$EZSQL_ERROR = array(); // OK


### PR DESCRIPTION
Though obscure, this global variable is used by WordPress core in `wpdb`, as a remnant of when it was forked from EzSQL. See https://core.trac.wordpress.org/browser/branches/4.6/src/wp-includes/wp-db.php#L1350.

See #691 for previous discussion.