### PR TITLE
Rename "variables" whitelist to "properties"

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -60,22 +60,33 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	);
 
 	/**
-	 * Custom list of variables which can have mixed case.
+	 * Custom list of properties which can have mixed case.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string[]
+	 */
+	public $customPropertiesWhitelist = array();
+
+	/**
+	 * Whether the custom whitelisted properties were added to the default list yet.
 	 *
 	 * @since 0.10.0
+	 * @since 0.11.0 Name changed from $addedCustomVariables.
+	 *
+	 * @var bool
+	 */
+	protected $addedCustomProperties = false;
+
+	/**
+	 * Custom list of properties which can have mixed case.
+	 *
+	 * @since 0.10.0
+	 * @deprecated 0.11.0 Use $customPropertiesWhitelist instead.
 	 *
 	 * @var string[]
 	 */
 	public $customVariablesWhitelist = array();
-
-	/**
-	 * Whether the custom whitelisted variables were added to the default list yet.
-	 *
-	 * @since 0.10.0
-	 *
-	 * @var bool
-	 */
-	protected $addedCustomVariables = false;
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -89,7 +100,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	protected function processVariable( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList();
+		$this->mergeWhiteList( $phpcs_file );
 
 		$tokens   = $phpcs_file->getTokens();
 		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
@@ -170,7 +181,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	protected function processMemberVar( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList();
+		$this->mergeWhiteList( $phpcs_file );
 
 		$tokens = $phpcs_file->getTokens();
 
@@ -236,12 +247,34 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 * Merge a custom whitelist provided via a custom ruleset with the predefined whitelist,
 	 * if we haven't already.
 	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 *
 	 * @return void
 	 */
-	protected function mergeWhiteList() {
-		if ( false === $this->addedCustomVariables && ! empty( $this->customVariablesWhitelist ) ) {
-			$this->whitelisted_mixed_case_member_var_names = array_merge( $this->whitelisted_mixed_case_member_var_names, $this->customVariablesWhitelist );
-			$this->addedCustomVariables = true;
+	protected function mergeWhiteList( $phpcs_file ) {
+		if ( $this->addedCustomProperties ) {
+			return;
+		}
+
+		if ( ! empty( $this->customVariablesWhitelist ) ) {
+			$this->customPropertiesWhitelist = array_merge(
+				$this->customPropertiesWhitelist,
+				$this->customVariablesWhitelist
+			);
+
+			$phpcs_file->addWarning(
+				'The customVariablesWhitelist property is deprecated in favor of customPropertiesWhitelist.',
+				0,
+				'DeprecatedCustomVariablesWhitelist'
+			);
+		}
+
+		if ( ! empty( $this->customPropertiesWhitelist ) ) {
+			$this->whitelisted_mixed_case_member_var_names = array_merge(
+				$this->whitelisted_mixed_case_member_var_names,
+				$this->customPropertiesWhitelist
+			);
+			$this->addedCustomProperties = true;
 		}
 	}
 


### PR DESCRIPTION
Only properties can be whitelisted using this, so the name "variables" is confusing. See #691.

The term "member var" is used elsewhere within this sniff, so possibly that should be used here for consistency, rather than "property".

I've kept the old whitelist around for back-compat, but I've marked it as deprecated. The old internal flag `$addedCustomVariables` I removed completely rather than deprecating, though I suppose in theory it is possible that someone has a custom sniff extending from this one that might be referencing it.