### PR TITLE
Add `strip_tags` to the list of valid escaping functions. See #706

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -61,6 +61,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'rawurlencode'         => true,
 		'sanitize_html_class'  => true,
 		'sanitize_user_field'  => true,
+		'strip_tags'           => true,
 		'tag_escape'           => true,
 		'urlencode_deep'       => true,
 		'urlencode'            => true,

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -180,3 +180,5 @@ echo '<option name="' . esc_attr( $name ) . '"' .
 
 _deprecated_hook( 'some_filter', '1.3.0', esc_html__( 'The $arg is deprecated.' ), 'some_other_filter' ); // Ok.
 _deprecated_hook( "filter_{$context}", '1.3.0', __( 'The $arg is deprecated.' ), sprintf( __( 'Some parsed message %s', $variable ) ) ); // Bad.
+
+echo strip_tags( 'Something' ); // Ok.


### PR DESCRIPTION
When escaping output with `strip_tags`, WPCS throws an error, as it does not recognize `strip_tags` as an escaping function. This PR adds the function to avoid this false positive.