### PR TITLE
Add `htmlspecialchars` to the list of valid escaping functions. See #708

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -54,6 +54,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'esc_url'              => true,
 		'filter_input'         => true,
 		'filter_var'           => true,
+		'htmlspecialchars'     => true,
 		'intval'               => true,
 		'json_encode'          => true,
 		'like_escape'          => true,

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -180,3 +180,5 @@ echo '<option name="' . esc_attr( $name ) . '"' .
 
 _deprecated_hook( 'some_filter', '1.3.0', esc_html__( 'The $arg is deprecated.' ), 'some_other_filter' ); // Ok.
 _deprecated_hook( "filter_{$context}", '1.3.0', __( 'The $arg is deprecated.' ), sprintf( __( 'Some parsed message %s', $variable ) ) ); // Bad.
+
+echo htmlspecialchars( 'Something' ); // Ok.


### PR DESCRIPTION
When escaping output with `htmlspecialchars`, WPCS throws an error, as it does not recognize `htmlspecialchars` as an escaping function. This PR adds the function to avoid this false positive.