### PR TITLE
Fix I18n placeholder numbering and add error for mixed placeholders

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -331,27 +331,37 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$fixable_method = empty( $context['warning'] ) ? 'addFixableError' : 'addFixableWarning';
 
 		// UnorderedPlaceholders: Check for multiple unordered placeholders.
-		preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
+		$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
 		$unordered_matches       = $unordered_matches[0];
-		$unordered_matches_count = count( $unordered_matches );
 
 		if ( $unordered_matches_count >= 2 ) {
 			$code = 'UnorderedPlaceholders' . ucfirst( $arg_name );
 
-			$suggestions = array();
+			$suggestions     = array();
+			$replace_regexes = array();
+			$replacements    = array();
 			for ( $i = 0; $i < $unordered_matches_count; $i++ ) {
-				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], ( $i + 1 ) . '$', 1, 0 );
+				$to_insert         = ( $i + 1 );
+				$to_insert        .= ( '"' !== $content[0] ) ? '$' : '\$';
+				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], $to_insert, 1, 0 );
+
+				// Prepare the strings for use a regex.
+				$replace_regexes[ $i ] = '`\Q' . $unordered_matches[ $i ] . '\E`';
+				// Note: the initial \\ is a literal \, the four \ in the replacement translate to also to a literal \.
+				$replacements[ $i ]    = str_replace( '\\', '\\\\', $suggestions[ $i ] );
+				// Note: the $ needs escaping to prevent numeric sequences after the $ being interpreted as match replacements.
+				$replacements[ $i ]    = str_replace( '$', '\\$', $replacements[ $i ] );
 			}
 
 			$fix = $phpcs_file->$fixable_method(
 				'Multiple placeholders should be ordered. Expected \'%s\', but got %s.',
 				$stack_ptr,
 				$code,
-				array( join( ', ', $suggestions ), join( ',', $unordered_matches ) )
+				array( implode( ', ', $suggestions ), implode( ', ', $unordered_matches ) )
 			);
 
 			if ( true === $fix ) {
-				$fixed_str = str_replace( $unordered_matches, $suggestions, $content );
+				$fixed_str = preg_replace( $replace_regexes, $replacements, $content, 1 );
 
 				$phpcs_file->fixer->beginChangeset();
 				$phpcs_file->fixer->replaceToken( $stack_ptr, $fixed_str );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -22,12 +22,12 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	/**
 	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
 	 */
-	const SPRINTF_PLACEHOLDER_REGEX = '/(?:%%|(%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFos]))/';
+	const SPRINTF_PLACEHOLDER_REGEX = '/(?:(?<!%)(%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeEufFgGosxX]))/';
 
 	/**
 	 * "Unordered" means there's no position specifier: '%s', not '%2$s'.
 	 */
-	const UNORDERED_SPRINTF_PLACEHOLDER_REGEX = '/(?:(?<!%)%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX])/';
+	const UNORDERED_SPRINTF_PLACEHOLDER_REGEX = '/(?:(?<!%)%[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeEufFgGosxX])/';
 
 	/**
 	 * Text domain.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -333,8 +333,18 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		// UnorderedPlaceholders: Check for multiple unordered placeholders.
 		$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
 		$unordered_matches       = $unordered_matches[0];
+		$all_matches_count       = preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $content, $all_matches );
 
-		if ( $unordered_matches_count >= 2 ) {
+		if ( $unordered_matches_count > 0 && $unordered_matches_count !== $all_matches_count && $all_matches_count > 1 ) {
+			$code = 'MixedOrderedPlaceholders' . ucfirst( $arg_name );
+			$phpcs_file->addError(
+				'Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.',
+				$stack_ptr,
+				$code,
+				array( implode( ', ', $all_matches[0] ) )
+			);
+
+		} elseif ( $unordered_matches_count >= 2 ) {
 			$code = 'UnorderedPlaceholders' . ucfirst( $arg_name );
 
 			$suggestions     = array();
@@ -367,7 +377,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				$phpcs_file->fixer->replaceToken( $stack_ptr, $fixed_str );
 				$phpcs_file->fixer->endChangeset();
 			}
-		}
+		} // End if().
 
 		/*
 		 * NoEmptyStrings.

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -115,3 +115,11 @@ __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are r
 // The domain 'default' was also added to the text domains.
 __( 'String default text domain.', 'default' ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
+
+// Issue #698 - fix for auto-fixing placeholder ordering.
+__( '%s - %s - %s - %s', 'my-slug' ); // Bad - Multiple of the same placeholders.
+__( '%d - %d - %d - %d', 'my-slug' ); // Bad - Multiple of the same placeholders.
+__( '%% - %b - %c - %d - %e - %E - %f - %F - %g - %G - %o - %s - %u - %x - %X', 'my-slug' ); // Bad - All simple variations.
+__( "%d for %d 'item'", 'my-slug' ); // Bad - Multiple of the same placeholders in a double quoted string.
+__( '%04d for %02d item', 'my-slug' ); // Bad - Placeholder with other specifier, but no position.
+__( "%04d for %'.9d item", 'my-slug' ); // Bad - Placeholder with other specifier, but no position, double quoted string.

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -123,3 +123,7 @@ __( '%% - %b - %c - %d - %e - %E - %f - %F - %g - %G - %o - %s - %u - %x - %X', 
 __( "%d for %d 'item'", 'my-slug' ); // Bad - Multiple of the same placeholders in a double quoted string.
 __( '%04d for %02d item', 'my-slug' ); // Bad - Placeholder with other specifier, but no position.
 __( "%04d for %'.9d item", 'my-slug' ); // Bad - Placeholder with other specifier, but no position, double quoted string.
+
+// Related to issue #698 - mixed ordered and non-ordered placeholders.
+__( '%1$d for %d item', 'my-slug' ); // Bad.
+__( '%1$d for %d and %d item', 'my-slug' ); // Bad.

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -123,3 +123,7 @@ __( '%% - %1$b - %2$c - %3$d - %4$e - %5$E - %6$f - %7$F - %8$g - %9$G - %10$o -
 __( "%1\$d for %2\$d 'item'", 'my-slug' ); // Bad - Multiple of the same placeholders in a double quoted string.
 __( '%1$04d for %2$02d item', 'my-slug' ); // Bad - Placeholder with other specifier, but no position.
 __( "%1\$04d for %2\$'.9d item", 'my-slug' ); // Bad - Placeholder with other specifier, but no position, double quoted string.
+
+// Related to issue #698 - mixed ordered and non-ordered placeholders.
+__( '%1$d for %d item', 'my-slug' ); // Bad.
+__( '%1$d for %d and %d item', 'my-slug' ); // Bad.

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -115,3 +115,11 @@ __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are r
 // The domain 'default' was also added to the text domains.
 __( 'String default text domain.', 'default' ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
+
+// Issue #698 - fix for auto-fixing placeholder ordering.
+__( '%1$s - %2$s - %3$s - %4$s', 'my-slug' ); // Bad - Multiple of the same placeholders.
+__( '%1$d - %2$d - %3$d - %4$d', 'my-slug' ); // Bad - Multiple of the same placeholders.
+__( '%% - %1$b - %2$c - %3$d - %4$e - %5$E - %6$f - %7$F - %8$g - %9$G - %10$o - %11$s - %12$u - %13$x - %14$X', 'my-slug' ); // Bad - All simple variations.
+__( "%1\$d for %2\$d 'item'", 'my-slug' ); // Bad - Multiple of the same placeholders in a double quoted string.
+__( '%1$04d for %2$02d item', 'my-slug' ); // Bad - Placeholder with other specifier, but no position.
+__( "%1\$04d for %2\$'.9d item", 'my-slug' ); // Bad - Placeholder with other specifier, but no position, double quoted string.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -80,6 +80,12 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			105 => 1,
 			106 => 1,
 			107 => 1,
+			120 => 1,
+			121 => 1,
+			122 => 1,
+			123 => 1,
+			124 => 1,
+			125 => 1,
 		);
 	} // end getErrorList()
 

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -86,6 +86,8 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 			123 => 1,
 			124 => 1,
 			125 => 1,
+			128 => 1,
+			129 => 1,
 		);
 	} // end getErrorList()
 


### PR DESCRIPTION
I've investigated #698 and discovered a couple of additional issues because of it.

This PR fixed both the original issue as well as the additionally discovered ones.

Fixes #698 

#### Issue #698 - Fix fixing of unordered placeholders.

If several of the same kind of unordered placeholders were found - `%s` -, the `str_replace()` would replace them all with the replacement value for the first, i.e. `%1$s`, resulting in something like `'my %1$s and my %1$s'`.

`preg_replace()` allows for limiting the amount of replacements per match so offers the ability to replace each placeholder with their corresponding replacement.

This does however create some other complexities as a `$` in a regex replacement value can be interpreted as a match replacement, so will need escaping to prevent potential replacement with a numbered match.

Example:
Placeholder found: `'%01d'`
Should become: `'%1$01d'`
But the `$01` within the replacement value in `preg_replace()` will be interpreted as the first submatch - which doesn't exist, so would be replaced by `''` resulting in `'%1d'`
So the dollar in the replacement value needs escaping before passing it on to `preg_replace()`.

#### Using dollars in double quoted strings with placeholders

Along the same lines as the above, if the original string was double quoted, the `$` would also need escaping in the result string to prevent it being interpreted as a PHP variable.

This was currently not done, which could lead to a replacement looking like `"my %1$d pennies"` and `$d` being interpreted as a PHP variable, resulting either in an undefined variable notice or an unintended replacement being made.

The check for double quoted strings I've build in now is quite simplistic, but should be sufficient in 95% of all cases.

#### Not all placeholders were being recognized.

The regexes used throughout the sniff (constants at the top of the file) did not account for all possible placeholders for `sprintf()`.
This has been fixed as well.

Ref: http://php.net/manual/en/function.sprintf.php

#### Mixed ordered and unordered placeholders.

Up to now, a string with mixed ordered and unordered placeholders - `%1$s for %d` - would be disregarded by the check for placeholder ordering.
As these do not lend themselves to automatic fixing, I've chosen to add an error notice whenever a string with mixed placeholders is found.

Includes additional unit tests + adjusted `.fixed` file.