### PR TITLE
Add $PHP_SELF to mixed case vars

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -52,6 +52,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 */
 	protected $wordpress_mixed_case_vars = array(
 		'EZSQL_ERROR' => true,
+		'PHP_SELF' => true,
 	);
 
 	/**


### PR DESCRIPTION
WordPress sets the `$PHP_SELF` global in [`wp_fix_server_vars()`](https://developer.wordpress.org/reference/functions/wp_fix_server_vars/) in `load.php`.