### PR TITLE
Add PHP 7.1 to Travis CI job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
 
 env:
   - PHPCS_BRANCH=master


### PR DESCRIPTION
WordPress now expects PHP 7.1 to pass.

Note: PHP "nightly" is now 7.2-alpha

Aside: Rather than a branch in my own fork this is a WPCS branch,made possible from the recent changes in my access privs here at WPCS, is this ok?