### PR TITLE
Increase PHPCS version to 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.7.0
+  - PHPCS_BRANCH=2.7.1
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
We should increase the PHPCS version in travis as composer installs this version on new installs.

The reason for this is that we do not have a `composer.lock` in the project and the version in `composer.json` is set for `^2.7` which will install any minor versions.