### PR TITLE
Test XML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
     # Run against HHVM and PHP nightly.
     - php: hhvm
       sudo: required
-      dist: trusty 
-      group: edge 
+      dist: trusty
+      group: edge
       env: PHPCS_BRANCH=master
     - php: nightly
       env: PHPCS_BRANCH=master
@@ -48,6 +48,8 @@ before_script:
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     - phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php
+    # Test the XML rulesets.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -q ./bin/functions.php  --standard=WordPress; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/bin/functions.php
+++ b/bin/functions.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * This is a test function to help test the XML rulesets.
+ */
+function wpcs_test_function() {
+	return true;
+}


### PR DESCRIPTION
In PHPCS 2.7.1 the XML files are not being tested any more.

> XML rulesets were never intentionally tested. It was an accident that they were parsed. But because they were, it meant that tests were not running in isolation (they were running with all the XML ruleset rules and exclusions applied) so they were not accurate.

This mean that if there is syntax error in the XML file or a ruleset is misspelled there will be no error. This simple line of code will help test the XML for this issue and return an error if there are any issues.