### PR TITLE
Fix a number of bugs in the global var override detection

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -630,10 +630,8 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	protected function is_assignment( $stackPtr ) {
 
-		$tokens = $this->phpcsFile->getTokens();
-
 		// Must be a variable or closing square bracket (see below).
-		if ( ! in_array( $tokens[ $stackPtr ]['code'], array( T_VARIABLE, T_CLOSE_SQUARE_BRACKET ), true ) ) {
+		if ( ! in_array( $this->tokens[ $stackPtr ]['code'], array( T_VARIABLE, T_CLOSE_SQUARE_BRACKET ), true ) ) {
 			return false;
 		}
 
@@ -652,13 +650,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// If the next token is an assignment, that's all we need to know.
-		if ( in_array( $tokens[ $next_non_empty ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true ) ) {
+		if ( isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
 			return true;
 		}
 
 		// Check if this is an array assignment, e.g., `$var['key'] = 'val';` .
-		if ( T_OPEN_SQUARE_BRACKET === $tokens[ $next_non_empty ]['code'] ) {
-			return $this->is_assignment( $tokens[ $next_non_empty ]['bracket_closer'] );
+		if ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_non_empty ]['code'] ) {
+			return $this->is_assignment( $this->tokens[ $next_non_empty ]['bracket_closer'] );
 		}
 
 		return false;

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -597,13 +597,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			return false;
 		}
 
-		// Is method inside of a class ?
+		// Is this a method inside of a class ?
 		$classToken = $this->phpcsFile->getCondition( $functionToken, T_CLASS );
 		if ( false === $classToken ) {
 			return false;
 		}
 
-		// Does the class extend either of the start with 'test_' ?
+		// Does the class extend either of whitelisted test classes ?
 		$extendedClassName = $this->phpcsFile->findExtendedClassName( $classToken );
 		if ( in_array( $extendedClassName, array( 'WP_UnitTestCase', 'PHPUnit_Framework_TestCase' ), true ) ) {
 			return true;

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -352,6 +352,22 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			$start        = ( $phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
 			$end          = count( $this->tokens );
 
+			// Is the global statement within a function call or closure ?
+			// If so, limit the token walking to the function scope.
+			$function_token = $phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			if ( false === $function_token ) {
+				$function_token = $phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			}
+
+			if ( false !== $function_token ) {
+				if ( ! isset( $this->tokens[ $function_token ]['scope_closer'] ) ) {
+					// Live coding, unfinished function.
+					return;
+				}
+
+				$end          = $this->tokens[ $function_token ]['scope_closer'];
+			}
+
 			// Check for assignments to collected global vars.
 			for ( $ptr = $start; $ptr < $end; $ptr++ ) {
 

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -304,9 +304,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				return;
 			}
 
-			$assignment = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $this->tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
-
-			if ( false !== $assignment && T_EQUAL === $this->tokens[ $assignment ]['code'] ) {
+			if ( true === $this->is_assignment( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
 				$this->maybe_add_error( $stackPtr );
 			}
 		} elseif ( T_GLOBAL === $token['code'] ) {
@@ -333,8 +331,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			// Check for assignments to collected global vars.
 			foreach ( $this->tokens as $ptr => $token ) {
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
-					$next = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr + 1 ), null, true, null, true );
-					if ( false !== $next && T_EQUAL === $this->tokens[ $next ]['code'] ) {
+					if ( true === $this->is_assignment( $ptr ) ) {
 						$this->maybe_add_error( $ptr );
 					}
 				}

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -303,10 +303,16 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				return;
 			}
 
-			$varPtr   = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'], true );
-			$varToken = $this->tokens[ $varPtr ];
+			// Retrieve the array key and avoid getting tripped up by some simple obfuscation.
+			$var_name = '';
+			$start    = ( $bracketPtr + 1 );
+			for ( $ptr = $start; $ptr < $this->tokens[ $bracketPtr ]['bracket_closer']; $ptr++ ) {
+				if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $ptr ]['code'] ) {
+					$var_name .= trim( $this->tokens[ $ptr ]['content'], '\'"' );
+				}
+			}
 
-			if ( ! in_array( trim( $varToken['content'], '\'"' ), $this->globals, true ) ) {
+			if ( ! in_array( $var_name, $this->globals, true ) ) {
 				return;
 			}
 

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -297,6 +297,12 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				return;
 			}
 
+			// Bow out if the array key contains a variable.
+			$has_variable = $phpcsFile->findNext( T_VARIABLE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'] );
+			if ( false !== $has_variable ) {
+				return;
+			}
+
 			$varPtr   = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'], true );
 			$varToken = $this->tokens[ $varPtr ];
 

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -348,14 +348,15 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 	} // End process().
 
 	/**
-	 * Add the error if there is no whitelist comment present.
+	 * Add the error if there is no whitelist comment present and the assignment
+	 * is not done from within a test method.
 	 *
 	 * @param int $stackPtr The position of the token to throw the error for.
 	 *
 	 * @return void
 	 */
 	public function maybe_add_error( $stackPtr ) {
-		if ( ! $this->has_whitelist_comment( 'override', $stackPtr ) ) {
+		if ( ! $this->is_token_in_test_method( $stackPtr ) && ! $this->has_whitelist_comment( 'override', $stackPtr ) ) {
 			$this->phpcsFile->addError( 'Overriding WordPress globals is prohibited', $stackPtr, 'OverrideProhibited' );
 		}
 	}

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -323,19 +323,27 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			$search = array(); // Array of globals to watch for.
 			$ptr    = ( $stackPtr + 1 );
 			while ( $ptr ) {
-				$ptr++;
+				if ( ! isset( $this->tokens[ $ptr ] ) ) {
+					break;
+				}
+
 				$var = $this->tokens[ $ptr ];
+
+				// Halt the loop at end of statement.
+				if ( T_SEMICOLON === $var['code'] ) {
+					break;
+				}
+
 				if ( T_VARIABLE === $var['code'] ) {
-					$varname = substr( $var['content'], 1 );
-					if ( in_array( $varname, $this->globals, true ) ) {
-						$search[] = $varname;
+					if ( in_array( substr( $var['content'], 1 ), $this->globals, true ) ) {
+						$search[] = $var['content'];
 					}
 				}
-				// Halt the loop.
-				if ( T_SEMICOLON === $var['code'] ) {
-					$ptr = false;
-				}
+
+				$ptr++;
 			}
+			unset( $var );
+
 			if ( empty( $search ) ) {
 				return;
 			}

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -290,32 +290,28 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 		$this->init( $phpcsFile );
 		$token = $this->tokens[ $stackPtr ];
 
-		$search = array(); // Array of globals to watch for.
-
 		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
-			$bracketPtr = $phpcsFile->findNext( array( T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
+			$bracketPtr = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-			if ( T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] ) {
+			if ( false === $bracketPtr || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] || ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
 				return;
 			}
 
-			$varPtr   = $phpcsFile->findNext( T_WHITESPACE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'], true );
+			$varPtr   = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'], true );
 			$varToken = $this->tokens[ $varPtr ];
 
 			if ( ! in_array( trim( $varToken['content'], '\'"' ), $this->globals, true ) ) {
 				return;
 			}
 
-			$assignment = $phpcsFile->findNext( T_WHITESPACE, ( $this->tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
+			$assignment = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $this->tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
 
 			if ( false !== $assignment && T_EQUAL === $this->tokens[ $assignment ]['code'] ) {
 				$this->maybe_add_error( $stackPtr );
 			}
-
-			return;
-
 		} elseif ( T_GLOBAL === $token['code'] ) {
-			$ptr = ( $stackPtr + 1 );
+			$search = array(); // Array of globals to watch for.
+			$ptr    = ( $stackPtr + 1 );
 			while ( $ptr ) {
 				$ptr++;
 				$var = $this->tokens[ $ptr ];

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -348,9 +348,16 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				return;
 			}
 
+			// Only search from the end of the "global ...;" statement onwards.
+			$start        = ( $phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
+			$end          = count( $this->tokens );
+
 			// Check for assignments to collected global vars.
-			foreach ( $this->tokens as $ptr => $token ) {
-				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
+			for ( $ptr = $start; $ptr < $end; $ptr++ ) {
+
+				if ( T_VARIABLE === $this->tokens[ $ptr ]['code']
+					&& in_array( $this->tokens[ $ptr ]['content'], $search, true )
+				) {
 					// Don't throw false positives for static class properties.
 					$previous = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
 					if ( false !== $previous && T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -288,9 +288,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
-		$token      = $this->tokens[ $stackPtr ];
-		$error      = 'Overriding WordPress globals is prohibited';
-		$error_code = 'OverrideProhibited';
+		$token = $this->tokens[ $stackPtr ];
 
 		$search = array(); // Array of globals to watch for.
 
@@ -311,10 +309,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			$assignment = $phpcsFile->findNext( T_WHITESPACE, ( $this->tokens[ $bracketPtr ]['bracket_closer'] + 1 ), null, true );
 
 			if ( false !== $assignment && T_EQUAL === $this->tokens[ $assignment ]['code'] ) {
-				if ( ! $this->has_whitelist_comment( 'override', $assignment ) ) {
-					$phpcsFile->addError( $error, $stackPtr, $error_code );
-					return;
-				}
+				$this->maybe_add_error( $stackPtr );
 			}
 
 			return;
@@ -344,14 +339,25 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
 					$next = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr + 1 ), null, true, null, true );
 					if ( false !== $next && T_EQUAL === $this->tokens[ $next ]['code'] ) {
-						if ( ! $this->has_whitelist_comment( 'override', $next ) ) {
-							$phpcsFile->addError( $error, $ptr, $error_code );
-						}
+						$this->maybe_add_error( $ptr );
 					}
 				}
 			}
 		} // End if().
 
 	} // End process().
+
+	/**
+	 * Add the error if there is no whitelist comment present.
+	 *
+	 * @param int $stackPtr The position of the token to throw the error for.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_error( $stackPtr ) {
+		if ( ! $this->has_whitelist_comment( 'override', $stackPtr ) ) {
+			$this->phpcsFile->addError( 'Overriding WordPress globals is prohibited', $stackPtr, 'OverrideProhibited' );
+		}
+	}
 
 } // End class.

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -351,6 +351,12 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			// Check for assignments to collected global vars.
 			foreach ( $this->tokens as $ptr => $token ) {
 				if ( T_VARIABLE === $token['code'] && in_array( substr( $token['content'], 1 ), $search, true ) ) {
+					// Don't throw false positives for static class properties.
+					$previous = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
+					if ( false !== $previous && T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {
+						continue;
+					}
+
 					if ( true === $this->is_assignment( $ptr ) ) {
 						$this->maybe_add_error( $ptr );
 					}

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
@@ -57,8 +57,16 @@ add_filter( "comments_open", function( $open, $post_id ) {
 
 $page = 'test'; // Ok, check against cross-contaminiation from within a closure.
 
-// Allow overriding globals in unit tests.
+// Allow overriding globals in functions within unit test classes.
 // https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/300#issuecomment-158778606
+class WP_UnitTestCase {
+
+	public function test_something() {
+		global $tabs;
+		$tabs = 50; // Ok.
+	}
+}
+
 class Test_Class_A extends WP_UnitTestCase {
 
 	public function test_something() {
@@ -68,7 +76,7 @@ class Test_Class_A extends WP_UnitTestCase {
 
 	private function arbitrary_function() {
 		global $post_ID;
-		$post_ID = 50; // Bad - not a test function.
+		$post_ID = 50; // Ok.
 	}
 }
 
@@ -78,18 +86,13 @@ class Test_Class_B extends PHPUnit_Framework_TestCase {
 		global $cat_id;
 		$cat_id = 50; // Ok.
 	}
-
-	private function arbitrary_function() {
-		global $names;
-		$names = 50; // Bad - not a test function.
-	}
 }
 
-interface Test_Class_C extends NonTestClass {
+trait Test_Class_C extends NonTestClass {
 
 	public function test_something() {
 		global $cat_id;
-		$cat_id = 50; // Bad - class does not extend either of the two acceptable testcase classes.
+		$cat_id = 50; // Bad - trait does not extend either of the two acceptable testcase classes.
 	}
 }
 
@@ -103,3 +106,14 @@ trait My_Class {
 		$post = 'test'; // Ok, local variable.
 	}
 }
+
+// Test adding additional test classes to the whitelist.
+// @codingStandardsChangeSetting WordPress.Variables.GlobalVariables custom_test_class_whitelist My_TestClass
+class Test_Class_D extends My_TestClass {
+
+	public function test_something() {
+		global $tabs;
+		$tabs = 50; // Ok.
+	}
+}
+// @codingStandardsChangeSetting WordPress.Variables.GlobalVariables custom_test_class_whitelist null

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
@@ -1,9 +1,105 @@
 <?php
 
-$GLOBALS['wpdb'] = 'test';
+$GLOBALS['wpdb'] = 'test'; // Bad.
 
 global $wpdb;
-$wpdb = 'test';
+$wpdb = 'test'; // Bad.
+
+$post = get_post( 1 ); // Ok, $post has not been made global yet.
 
 global $post;
 $post = get_post( 1 ); // Override ok.
+
+// Bad: Using different types of assignment operators.
+function test_different_assignment_operators() {
+	global $totals, $blogname;
+	$totals   += 10;
+	$totals   /= 2;
+	$blogname .= 'test';
+}
+
+// $GLOBALS with non-string key, so we don't know what is really overwritten.
+$GLOBALS[ $blogname ] = 'test'; // Ok.
+
+// $GLOBALS with simple obfuscated string key.
+$GLOBALS[ 'p' . 'a' . 'ge' ] = 'test'; // Bad.
+$GLOBALS[ 'p' . $a . 'ge' ] = 'test'; // Probably bad, but not checked for at the moment.
+
+// Issue #300 - Setting default value for a function parameter.
+function local_var_with_default( $param1, $error = true, $post = null ) {} // Ok.
+
+// Issue #300 - Take scope into account.
+function global_vars() {
+	global $pagenow;
+
+	$pagenow           = 'test'; // Bad, global variable in function scope.
+	$GLOBALS['domain'] = 'http://example.com/'; // Bad, global variable in function scope.
+
+	$post = '2016'; // Ok, non-global variable in function scope.
+}
+
+// Test against cross-contamination of global detection.
+// https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/486
+function local_var_only() {
+	$pagenow = 'test'; // Ok, function scope.
+}
+
+add_filter( "comments_open", function( $open, $post_id ) {
+    $post = get_post( $post_id ); // Ok, non-global variable in function scope.
+    return "page" === $page->post_type;
+}, 10, 2 );
+
+add_filter( "comments_open", function( $open, $post_id ) {
+	global $page;
+    $page = get_post( $post_id ); // Bad.
+    return "page" === $page->post_type;
+}, 10, 2 );
+
+$page = 'test'; // Ok, check against cross-contaminiation from within a closure.
+
+// Allow overriding globals in unit tests.
+// https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/300#issuecomment-158778606
+class Test_Class_A extends WP_UnitTestCase {
+
+	public function test_something() {
+		global $tabs;
+		$tabs = 50; // Ok.
+	}
+
+	private function arbitrary_function() {
+		global $post_ID;
+		$post_ID = 50; // Bad - not a test function.
+	}
+}
+
+class Test_Class_B extends PHPUnit_Framework_TestCase {
+
+	public function test_something() {
+		global $cat_id;
+		$cat_id = 50; // Ok.
+	}
+
+	private function arbitrary_function() {
+		global $names;
+		$names = 50; // Bad - not a test function.
+	}
+}
+
+interface Test_Class_C extends NonTestClass {
+
+	public function test_something() {
+		global $cat_id;
+		$cat_id = 50; // Bad - class does not extend either of the two acceptable testcase classes.
+	}
+}
+
+// Ok: overriding class property with same name as global variable.
+trait My_Class {
+	private static $page;
+
+	public function do_something() {
+		global $page;
+		self::$page = 'test'; // Ok, class property, not global variable.
+		$post = 'test'; // Ok, local variable.
+	}
+}

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -31,9 +31,7 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 			35 => 1,
 			36 => 1,
 			54 => 1,
-			71 => 1,
-			84 => 1,
-			92 => 1,
+			95 => 1,
 		);
 
 	}

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -22,8 +22,18 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 	 */
 	public function getErrorList() {
 		return array(
-			3 => 1,
-			6 => 1,
+			3  => 1,
+			6  => 1,
+			16 => 1,
+			17 => 1,
+			18 => 1,
+			25 => 1,
+			35 => 1,
+			36 => 1,
+			54 => 1,
+			71 => 1,
+			84 => 1,
+			92 => 1,
 		);
 
 	}


### PR DESCRIPTION
The `GlobalVariablesSniff` contained a number of bugs which will be fixed by this PR.
* Assignments to global variables using other assignment operators than the `=` (`T_EQUAL`) operator were not detected, so `$post .= 'something';` would skate by.
* If a `T_GLOBAL`, i.e. `global ...;`, was detected, the whole file would be checked for the variables which were made global, not just the code **_after_** the `global` statement.
* If a `T_GLOBAL` was detected, the whole file would be checked for the variables which were made global, **_including_** code contained within a function/closure/class scope where there is no access to the global variable (without it being set explicitly within the function as well).
* If a `T_GLOBAL` was detected within a function call or closure, the whole file would be checked for the variables which were made global, not just the code within the function or closure.
* If a `T_GLOBAL` was detected and an assignment was made to a static class variable using the same name as one of the variables made global, an error would be thrown.
* An override of a protected global via `$GLOBALS` in combination with simple string concatenation obfuscation was not being detected. Generally speaking this shouldn't ever occur anyway and probably never would be an issue, however, with the upcoming theme review ruleset, this is something which should be detected. /cc @grappler 

Additionally, this PR contains an enhancement [as requested](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/300#issuecomment-158778606) by @westonruter :
* Don't throw errors for this sniff if the global variable override is done from within a test method.

For this enhancement a new `is_token_in_test_method()` method has been introduced into the `WordPress_Sniff` class.

PR includes extensive unit tests.
PR includes minor extraneous optimizations for this sniff.

Note: This PR does not cover complex array key obfuscation or complex variables used for obfuscating a global variable override.

Fixes #300 (except for the complex obfuscation)
Fixes #486