### PR TITLE
Add checking for translators comments to the I18n sniff.

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -61,4 +61,12 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/522 -->
 	<rule ref="Generic.PHP.Syntax" />
 
+	<!-- Make the translators comment check which is included in core stricter. -->
+	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
+		<type>error</type>
+	</rule>
+	<rule ref="WordPress.WP.I18n.TranslatorsCommentWrongStyle">
+		<type>error</type>
+	</rule>
+
 </ruleset>

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -515,7 +515,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	 * @return bool
 	 */
 	private function is_translators_comment( $content ) {
-		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`', $content, $matches ) === 1 ) {
+		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content, $matches ) === 1 ) {
 			return true;
 		}
 		return false;

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -16,6 +16,7 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
+ * @since   0.11.0 Now also checks for translators comments.
  */
 class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
@@ -71,6 +72,16 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		'_n_noop'                        => 'noopnumber',
 		'_nx_noop'                       => 'noopnumber_context',
 	);
+
+	/**
+	 * Toggle whether or not to check for translators comments for text string containing placeholders.
+	 *
+	 * Intended to make this part of the sniff unit testable, but can be used by end-users too,
+	 * though they can just as easily disable this via the sniff code.
+	 *
+	 * @var bool
+	 */
+	public $check_translator_comments = true;
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -213,6 +224,10 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$plural_context = $argument_assertions[1];
 
 			$this->compare_single_and_plural_arguments( $phpcs_file, $stack_ptr, $single_context, $plural_context );
+		}
+
+		if ( true === $this->check_translator_comments ) {
+			$this->check_for_translator_comment( $phpcs_file, $stack_ptr, $argument_assertions );
 		}
 	}
 
@@ -391,5 +406,119 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$phpcs_file->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
 		}
 	} // End check_text().
+
+	/**
+	 * Check for the presence of a translators comment if one of the text strings contains a placeholder.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 * @param int                  $stack_ptr  The position of the gettext call token
+	 *                                         in the stack.
+	 * @param array                $args       The function arguments.
+	 * @return void
+	 */
+	protected function check_for_translator_comment( PHP_CodeSniffer_File $phpcs_file, $stack_ptr, $args ) {
+		$tokens = $phpcs_file->getTokens();
+
+		foreach ( $args as $arg ) {
+			if ( false === in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
+				continue;
+			}
+
+			foreach ( $arg['tokens'] as $token ) {
+				if ( empty( $token['content'] ) ) {
+					continue;
+				}
+
+				if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $token['content'], $placeholders ) < 1 ) {
+					// No placeholders found.
+					continue;
+				}
+
+				$previous_comment = $phpcs_file->findPrevious( PHP_CodeSniffer_Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+
+				if ( false !== $previous_comment ) {
+					/*
+					 * Check that the comment is either on the line before the gettext call or
+					 * if it's not, that there is only whitespace between.
+					 */
+					$correctly_placed = false;
+
+					if ( ( $tokens[ $previous_comment ]['line'] + 1 ) === $tokens[ $stack_ptr ]['line'] ) {
+						$correctly_placed = true;
+					} else {
+						$next_non_whitespace = $phpcs_file->findNext( T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
+						if ( false === $next_non_whitespace || $tokens[ $next_non_whitespace ]['line'] === $tokens[ $stack_ptr ]['line'] ) {
+							// No non-whitespace found or next non-whitespace is on same line as gettext call.
+							$correctly_placed = true;
+						}
+						unset( $next_non_whitespace );
+					}
+
+					/*
+					 * Check that the comment starts with 'translators:'.
+					 */
+					if ( true === $correctly_placed ) {
+
+						if ( T_COMMENT === $tokens[ $previous_comment ]['code'] ) {
+							$comment_text = trim( $tokens[ $previous_comment ]['content'] );
+
+			  		   		// If it's multi-line /* */ comment, collect all the parts.
+			  		   		if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
+								for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
+									if ( T_COMMENT !== $tokens[ $i ]['code'] ) {
+										break;
+									}
+
+									$comment_text = trim( $tokens[ $i ]['content'] ) . $comment_text;
+								}
+							}
+
+			  		   		if ( true === $this->is_translators_comment( $comment_text ) ) {
+								// Comment is ok.
+								return;
+							}
+						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $tokens[ $previous_comment ]['code'] ) {
+							// If it's docblock comment (wrong style) make sure that it's a translators comment.
+							$db_start      = $phpcs_file->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
+							$db_first_text = $phpcs_file->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ),  $previous_comment );
+
+							if ( true === $this->is_translators_comment( $tokens[ $db_first_text ]['content'] ) ) {
+								$phpcs_file->addWarning(
+									'A "translators:" comment must be a "/* */" style comment. Docblock comments will not be picked up by the tools to generate a ".pot" file.',
+									$stack_ptr,
+									'TranslatorsCommentWrongStyle'
+								);
+								return;
+							}
+						}
+					} // End if().
+
+				} // End if().
+
+				// Found placeholders but no translators comment.
+				$phpcs_file->addWarning(
+					'A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.',
+					$stack_ptr,
+					'MissingTranslatorsComment'
+				);
+				return;
+			} // End foreach().
+
+		} // End foreach().
+
+	} // End check_for_translator_comment().
+
+	/**
+	 * Check if a (collated) comment string starts with 'translators:'.
+	 *
+	 * @param string $content Comment string content.
+	 * @return bool
+	 */
+	private function is_translators_comment( $content ) {
+		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`', $content, $matches ) === 1 ) {
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Test sniffing for translator comments.
+ */
+
+/* Basic test ****************************************************************/
+__( 'No placeholders here.', 'my-slug' ); // Ok, no placeholders, so no translators comment needed.
+__( 'There are %1$d monkeys in the %2$s', 'my-slug' ); // Bad - no translators comment.
+
+
+/* Testing different comment styles ******************************************/
+
+/* translators: %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - single line /* */ style.
+
+		/* translators: %d: number of cats. */
+		_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - single line /* */ style, indented code.
+
+// translators: %d: number of cats.
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - single line // style.
+
+/* translators:
+   - number of monkeys,
+   - location. */
+esc_html__( 'There are %1$d monkeys in the %2$s', 'my-slug' ), // OK - multi-line /* */ style.
+
+/*
+ * translators: %d: number of cats.
+ */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - multi-line /* */ style.
+
+/*
+ * translators: %d: number of cats.
+ * This is a multiline comment,
+ * But it also has * at the start
+ of some lines ;-)
+*/
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - inconsistent multi-line /* */ style.
+
+/**
+ * translators: %d: number of cats.
+ */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // Bad - docblock style.
+
+
+/* Testing comment content ****************************************************/
+
+/* %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // Bad - doesn't start with 'translators: '.
+
+/* this is for translators: %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // Bad - doesn't *start* with 'translators:'
+
+
+/* Testing comment placement ***************************************************/
+
+/* translators: %d: number of cats. */
+
+
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - only whitespace between.
+
+/* Some other comment. */
+/* translators: %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK.
+
+// translators: 1: number; 2: string.
+// Some other comment.
+esc_attr_e( 'Text to translate to %1$d languages. Another %2$s placeholder', 'my-slug' ); // Bad - translators comment has to be the first comment before the function call.
+
+printf(
+	/* translators: number of monkeys, location. */
+	__( 'There are %1$d monkeys in the %2$s', 'my-slug' ),
+	(int) $number,
+	esc_html( $string )
+); // Ok.
+
+/* translators: number of monkeys, location. */
+printf(
+	__( 'There are %1$d monkeys in the %2$s', 'my-slug' ),
+	(int) $number,
+	esc_html( $string )
+); // Bad - comment not directly before line containing the gettext call.
+
+/* translators: number of monkeys, location. */
+printf( __( 'There are %1$d monkeys in the %2$s', 'my-slug' ), intval( $number ), esc_html( $string ) ); // Ok - comment is directly before line containing the gettext call.

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -51,6 +51,12 @@ _n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // Bad - doesn't star
 /* this is for translators: %d: number of cats. */
 _n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // Bad - doesn't *start* with 'translators:'
 
+/* Translators: %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - Capitalized translators.
+
+/* TRANSLATORS: %d: number of cats. */
+_n_noop( 'I have %d cat.', "I have %d cats.", 'my-slug' ); // OK - All caps translators.
+
 
 /* Testing comment placement ***************************************************/
 
@@ -83,3 +89,10 @@ printf(
 
 /* translators: number of monkeys, location. */
 printf( __( 'There are %1$d monkeys in the %2$s', 'my-slug' ), intval( $number ), esc_html( $string ) ); // Ok - comment is directly before line containing the gettext call.
+
+/* translators: number of monkeys, location. */
+printf( __(
+	'There are %1$d monkeys in the %2$s', 'my-slug' ),
+	intval( $number ),
+	esc_html( $string )
+); // Ok - comment is directly before line containing the gettext call.

--- a/WordPress/Tests/WP/I18nUnitTest.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.inc
@@ -1,5 +1,5 @@
 <?php
-
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments false
 __( "hell$varo", 'my-slug' ); // Bad, shouldn't use a string with variables.
 
 __( "hell\$varo", 'my-slug' ); // OK, Variable is not interpolated.
@@ -127,3 +127,6 @@ __( "%04d for %'.9d item", 'my-slug' ); // Bad - Placeholder with other specifie
 // Related to issue #698 - mixed ordered and non-ordered placeholders.
 __( '%1$d for %d item', 'my-slug' ); // Bad.
 __( '%1$d for %d and %d item', 'my-slug' ); // Bad.
+
+
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.inc.fixed
@@ -1,5 +1,5 @@
 <?php
-
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments false
 __( "hell$varo", 'my-slug' ); // Bad, shouldn't use a string with variables.
 
 __( "hell\$varo", 'my-slug' ); // OK, Variable is not interpolated.
@@ -127,3 +127,6 @@ __( "%1\$04d for %2\$'.9d item", 'my-slug' ); // Bad - Placeholder with other sp
 // Related to issue #698 - mixed ordered and non-ordered placeholders.
 __( '%1$d for %d item', 'my-slug' ); // Bad.
 __( '%1$d for %d and %d item', 'my-slug' ); // Bad.
+
+
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -27,84 +27,113 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
-		return array(
-			3 => 1,
-			6 => 1,
-			9 => 1,
-			11 => 1,
-			13 => 1,
-			15 => 1,
-			17 => 1,
-			19 => 1,
-			21 => 1,
-			23 => 1,
-			25 => 1,
-			27 => 1,
-			33 => 1,
-			35 => 1,
-			37 => 1,
-			39 => 1,
-			41 => 1,
-			43 => 1,
-			45 => 1,
-			47 => 1,
-			48 => 1,
-			50 => 1,
-			52 => 1,
-			53 => 1,
-			55 => 1,
-			56 => 2,
-			58 => 1,
-			59 => 1,
-			60 => 1,
-			62 => 1,
-			63 => 2,
-			65 => 1,
-			66 => 1,
-			67 => 1,
-			72 => 1,
-			74 => 1,
-			75 => 1,
-			76 => 1,
-			77 => 1,
-			78 => 1,
-			93 => 1,
-			95 => 2,
-			100 => 1,
-			101 => 1,
-			102 => 1,
-			103 => 1,
-			105 => 1,
-			106 => 1,
-			107 => 1,
-			120 => 1,
-			121 => 1,
-			122 => 1,
-			123 => 1,
-			124 => 1,
-			125 => 1,
-			128 => 1,
-			129 => 1,
-		);
+	public function getErrorList( $testFile = 'I18nUnitTest.inc' ) {
+
+		switch ( $testFile ) {
+			case 'I18nUnitTest.inc':
+				return array(
+					3 => 1,
+					6 => 1,
+					9 => 1,
+					11 => 1,
+					13 => 1,
+					15 => 1,
+					17 => 1,
+					19 => 1,
+					21 => 1,
+					23 => 1,
+					25 => 1,
+					27 => 1,
+					33 => 1,
+					35 => 1,
+					37 => 1,
+					39 => 1,
+					41 => 1,
+					43 => 1,
+					45 => 1,
+					47 => 1,
+					48 => 1,
+					50 => 1,
+					52 => 1,
+					53 => 1,
+					55 => 1,
+					56 => 2,
+					58 => 1,
+					59 => 1,
+					60 => 1,
+					62 => 1,
+					63 => 2,
+					65 => 1,
+					66 => 1,
+					67 => 1,
+					72 => 1,
+					74 => 1,
+					75 => 1,
+					76 => 1,
+					77 => 1,
+					78 => 1,
+					93 => 1,
+					95 => 2,
+					100 => 1,
+					101 => 1,
+					102 => 1,
+					103 => 1,
+					105 => 1,
+					106 => 1,
+					107 => 1,
+					120 => 1,
+					121 => 1,
+					122 => 1,
+					123 => 1,
+					124 => 1,
+					125 => 1,
+					128 => 1,
+					129 => 1,
+				);
+
+			case 'I18nUnitTest.1.inc':
+			default:
+				return array();
+
+		} // End switch().
+
 	} // end getErrorList()
 
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
-		return array(
-			69 => 1,
-			70 => 1,
-			100 => 1,
-			101 => 1,
-			102 => 1,
-			103 => 1,
-		);
+	public function getWarningList( $testFile = 'I18nUnitTest.inc' ) {
+		switch ( $testFile ) {
+			case 'I18nUnitTest.inc':
+				return array(
+					69 => 1,
+					70 => 1,
+					100 => 1,
+					101 => 1,
+					102 => 1,
+					103 => 1,
+				);
+
+			case 'I18nUnitTest.1.inc':
+				return array(
+					8 => 1,
+					43 => 1,
+					49 => 1,
+					52 => 1,
+					68 => 1,
+					79 => 1,
+				);
+
+			default:
+				return array();
+
+		}
 	}
 
 } // End class.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -126,8 +126,8 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 					43 => 1,
 					49 => 1,
 					52 => 1,
-					68 => 1,
-					79 => 1,
+					74 => 1,
+					85 => 1,
 				);
 
 			default:


### PR DESCRIPTION
Implemented based on the following specs:
* Only one error should be thrown per gettext call.
* A translators comment is only required when (one of) the text string(s) contains placeholders.
* It's ok for there to be a translators comment if the text string(s) does not contain placeholders.
* The translators comment must be directly above the gettext call.
* If the comment is not on the *line* directly above the gettext call, there should only be whitespace lines between the comment and the line containing the gettext call.
* The translators comment must be in `//` or `/* */` format, docblocks are not allowed.
* A translators comment must start with `translators:`
* The check defaults to throwing a warning. If the `extra` ruleset is enabled, the error level will change to `error`.

Fixes #423 

I've added a sniff property `$check_translator_comments` to enable us to unit test the other checks within the I18n sniff without getting bogged down by errors thrown by the translators comment check.
This is a public property, but is only intended to be used in combination with the unit tests.
It *could* be used in custom rulesets too, but this shouldn't be needed as the translator comment checks can be excluded via their error codes.

#### Regarding the travis run failure:
The unit tests against PHPCS 2.7.0 are failing because the ruleset is erroneously taken into account when running the unit tests, which leads to PHPCS throwing an `error` instead of the expected `warning`.

This was fixed in PHPCS 2.7.1.
This *only* affects the unit tests however, not the functioning of the sniff itself.

Related: #733, #696 and https://github.com/squizlabs/PHP_CodeSniffer/issues/1177