### PR TITLE
Improve ruleset documentation

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -89,7 +89,7 @@
 		<rule ref="WordPress.PHP.POSIXFunctions" />
 
 		<!-- Rule: Never use the /e switch, use preg_replace_callback instead.
-			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/608 -->
+			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/632 -->
 
 		<!-- Rule: It's most convenient to use single-quoted strings for regular expressions.
 			 Already covered by Squiz.Strings.DoubleQuoteUsage -->
@@ -317,6 +317,8 @@
 
 	<!--
 		Not in the coding standard handbook: WP specific sniffs.
+		Ref: https://make.wordpress.org/core/handbook/best-practices/internationalization/ (limited info)
+		Ref: https://developer.wordpress.org/plugins/internationalization/ (more extensive)
 	-->
 		<!-- Check for correct usage of the WP i18n functions. -->
 		<rule ref="WordPress.WP.I18n"/>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -234,6 +234,21 @@
 
 
 	<!--
+		Handbook: PHP - Interpolation for Naming Dynamic Hooks.
+		Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#interpolation-for-naming-dynamic-hooks
+
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/751
+	-->
+		<!-- Rule: Dynamic hooks should be named using interpolation rather than concatenation. -->
+
+		<!-- Rule: Variables used in hook tags should be wrapped in curly braces { and },
+			 with the complete outer tag name wrapped in double quotes. -->
+
+		<!-- Rule: Where possible, dynamic values in tag names should also be as succinct
+			 and to the point as possible. -->
+
+
+	<!--
 		Handbook: PHP - Ternary Operator.
 		Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#ternary-operator
 	-->

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -2,6 +2,11 @@
 <ruleset name="WordPress Docs">
 	<description>WordPress Coding Standards for Inline Documentation and Comments</description>
 
+	<!--
+		Handbook: PHP Documentation Standards
+		Ref: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
+	-->
+
 	<rule ref="Squiz.Commenting">
 		<!-- Excluded to allow /* translators: ... */ comments -->
 		<exclude name="Squiz.Commenting.BlockComment.SingleLine"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -2,9 +2,10 @@
 <ruleset name="WordPress Extra">
 	<description>Best practices beyond core WordPress Coding Standards</description>
 
+	<!-- Generic PHP best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
-	<rule ref="Generic.PHP.BacktickOperator"/>
 	<rule ref="Generic.Functions.CallTimePassByReference"/>
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement" />
@@ -28,16 +29,36 @@
 	<rule ref="WordPress-Core"/>
 
 	<rule ref="WordPress.XSS.EscapeOutput"/>
+
+	<!-- Verify that a nonce check is done before using values in superglobals.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/73 -->
 	<rule ref="WordPress.CSRF.NonceVerification" />
+
 	<rule ref="WordPress.PHP.DiscouragedFunctions"/>
+
+	<!-- Scripts & style should be enqueued.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/35 -->
 	<rule ref="WordPress.WP.EnqueuedResources"/>
+
+	<!-- Warn against overriding WP global variables.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/26 -->
 	<rule ref="WordPress.Variables.GlobalVariables"/>
+
+	<!-- Encourage the use of strict ( === and !== ) comparisons.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/242 -->
 	<rule ref="WordPress.PHP.StrictComparisons" />
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
+	<!-- Check that in_array() and array_search() use strict comparisons.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/399
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/503 -->
 	<rule ref="WordPress.PHP.StrictInArray" />
 
-	<!-- Check for PHP Parse errors. -->
+	<!-- Discourage use of the backtick operator (execution of shell commands).
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/646 -->
+	<rule ref="Generic.PHP.BacktickOperator"/>
+
+	<!-- Check for PHP Parse errors.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/522 -->
 	<rule ref="Generic.PHP.Syntax" />
 
 </ruleset>

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -4,11 +4,32 @@
 
 	<rule ref="WordPress-Core"/>
 
+	<!-- Covers:
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#removing-the-admin-bar
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#direct-database-queries
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#filesystem-writes
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-__file__-for-page-registration
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#uncached-functions
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#flush_rewrite_rules
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#functions-that-use-joins-taxonomy-relation-queries-cat-tax-queries-subselects-or-api-calls
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#querying-on-meta_value
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#manipulating-the-timezone-server-side
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#validation-sanitization-and-escaping
+	-->
 	<rule ref="WordPress.VIP"/>
 
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#validation-sanitization-and-escaping -->
+	<!-- https://vip.wordpress.com/documentation/best-practices/security/validating-sanitizing-escaping/ -->
 	<rule ref="WordPress.XSS.EscapeOutput"/>
 	<rule ref="WordPress.CSRF.NonceVerification" />
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-instead-of -->
 	<rule ref="WordPress.PHP.StrictComparisons" />
+
+	<!-- https://vip.wordpress.com/documentation/best-practices/database-queries/ -->
 	<rule ref="WordPress.WP.PreparedSQL" />
 
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
@@ -16,4 +37,5 @@
 
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
 	<rule ref="WordPress.PHP.StrictInArray" />
+
 </ruleset>


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/717#issuecomment-269217452) from issue #717:

> > If at all, I think links to the PRs/issues which introduced those sniffs into the Extra ruleset should be sufficient as those will give the reasoning of why those sniffs were included.
>
> If someone wants to open an issue/PR for that, feel free.

### Core ruleset:
* Added a section with the "Interpolation for Naming Dynamic Hooks" rules (currently not yet covered) & documentation link.
* Corrected one existing link
* Added links to the handbook pages about internationalization for the `WP.I18n` sniff.

### Docs ruleset:
* Added a generic link to the documentation handbook at the top. Could use more specificity (doc section vs rule), but this should do for now.

### Extra ruleset:
* I've added a short description and links to the underlying issues which were the reason a sniff was added where I could find them.
* Moved the `backtick` rule down as it came from a different issue.

### VIP ruleset:
* Added links for the included rules in so far I could easily find them.
* Incomplete - VIP team is welcome to enhance.


This PR will conflict with PR #633 on the ruleset files. Depending on whichever of these two PRs gets merged first, the other will need to be rebased solving the conflicts. /cc @grappler 