### PR TITLE
Add file_get_contents() & file_get_contents()

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -74,6 +74,8 @@ class WordPress_Sniffs_WP_AlternativeFunctionsSniff extends WordPress_AbstractFu
 					'fclose',
 					'fread',
 					'fwrite',
+					'file_put_contents',
+					'file_get_contents',
 				),
 			),
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -20,3 +20,4 @@ pfsockopen(); // Warning.
 fclose(); // Warning.
 fread(); // Warning.
 fwrite(); // Warning.
+file_put_contents(); // Warning.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -41,7 +41,7 @@ class WordPress_Tests_WP_AlternativeFunctionsUnitTest extends AbstractSniffUnitT
 
 			12 => 1,
 
-			14 => 1,
+			14 => 2,
 
 			16 => 1,
 			17 => 1,
@@ -50,6 +50,7 @@ class WordPress_Tests_WP_AlternativeFunctionsUnitTest extends AbstractSniffUnitT
 			20 => 1,
 			21 => 1,
 			22 => 1,
+			23 => 1,
 		);
 
 	}


### PR DESCRIPTION
As I was looking at https://github.com/WPTRT/WordPress-Coding-Standards/pull/79 I realized I missed two functions.

This is also part of the Theme Check plugin and the VIP Scanner https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes
https://github.com/WordPress/theme-check/blob/master/checks/malware.php#L9
https://github.com/Automattic/vip-scanner/blob/master/vip-scanner/checks/VIPRestrictedCommandsCheck.php#L143

Ref: #633