### PR TITLE
Implement ternary related extra rules

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -274,6 +274,7 @@
 			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
 		<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
 		<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+		<rule ref="Squiz.PHP.DisallowInlineIf"/>
 
 
 	<!--

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -24,6 +24,7 @@
 	<rule ref="Squiz.Operators.IncrementDecrementUsage"/>
 	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
 	<rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
+	<rule ref="Squiz.PHP.DisallowComparisonAssignment"/>
 
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -144,7 +144,10 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 				continue;
 			}
 
-			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
+			$callback = array( $this, 'callback' );
+			if ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) {
+				$callback = $group['callback'];
+			}
 
 			foreach ( $inst as $key => $assignments ) {
 				foreach ( $assignments as $occurance ) {

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -139,7 +139,11 @@ abstract class WordPress_AbstractVariableRestrictionsSniff implements PHP_CodeSn
 
 			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
 			$pattern  = implode( '|', $patterns );
-			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) ? '\b' : '';
+
+			$delim = '';
+			if ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) {
+				$delim = '\b';
+			}
 
 			if ( T_DOUBLE_QUOTED_STRING === $token['code'] ) {
 				$var = $token['content'];

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -754,7 +754,10 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// If this is inside an isset(), check after it as well, all the way to the
 		// end of the scope.
 		if ( $in_isset ) {
-			$end = ( 0 === $start ) ? count( $tokens ) : $tokens[ $start ]['scope_closer'];
+			$end = $tokens[ $start ]['scope_closer'];
+			if ( 0 === $start ) {
+				$end = count( $tokens );
+			}
 		}
 
 		// Check if we've looked here before.

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -56,8 +56,15 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 			true
 		);
 
-		$spaced1 = ( T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code'] );
-		$spaced2 = ( T_WHITESPACE === $tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
+		$spaced1 = false;
+		if ( T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+			$spaced1 = true;
+		}
+
+		$spaced2 = false;
+		if ( T_WHITESPACE === $tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] ) {
+			$spaced2 = true;
+		}
 
 		// It should have spaces only if it only has strings or numbers as the key.
 		if ( false !== $need_spaces && ! ( $spaced1 && $spaced2 ) ) {

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -119,7 +119,10 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 		}
 
 		// If we're still here, no nonce-verification function was found.
-		$severity = ( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ) ? 0 : 'warning';
+		$severity = 'warning';
+		if ( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ) {
+			$severity = 0;
+		}
 
 		$phpcsFile->addError(
 			'Processing form data without nonce verification.'

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -242,8 +242,12 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$stack_ptr = $context['stack_ptr'];
 		$tokens    = $context['tokens'];
 		$arg_name  = $context['arg_name'];
-		$method    = empty( $context['warning'] ) ? 'addError' : 'addWarning';
 		$content   = $tokens[0]['content'];
+
+		$method    = 'addWarning';
+		if ( empty( $context['warning'] ) ) {
+			$method = 'addError';
+		}
 
 		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
 			$code = 'MissingArg' . ucfirst( $arg_name );
@@ -343,7 +347,11 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$stack_ptr      = $context['stack_ptr'];
 		$arg_name       = $context['arg_name'];
 		$content        = $context['tokens'][0]['content'];
-		$fixable_method = empty( $context['warning'] ) ? 'addFixableError' : 'addFixableWarning';
+
+		$fixable_method = 'addFixableWarning';
+		if ( empty( $context['warning'] ) ) {
+			$fixable_method = 'addFixableError';
+		}
 
 		// UnorderedPlaceholders: Check for multiple unordered placeholders.
 		$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
@@ -366,8 +374,13 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$replace_regexes = array();
 			$replacements    = array();
 			for ( $i = 0; $i < $unordered_matches_count; $i++ ) {
-				$to_insert         = ( $i + 1 );
-				$to_insert        .= ( '"' !== $content[0] ) ? '$' : '\$';
+				$to_insert = ( $i + 1 );
+				if ( '"' !== $content[0] ) {
+					$to_insert .= '$';
+				} else {
+					$to_insert .= '\$';
+				}
+
 				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], $to_insert, 1, 0 );
 
 				// Prepare the strings for use a regex.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -24,7 +24,7 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 		return array(
 			3  => 1,
 			17 => 1,
-			30 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1,
+			30 => (int) ( PHP_VERSION_ID < 50300 ),
 			32 => 1,
 			34 => 1,
 			36 => 1,


### PR DESCRIPTION
> Clever Code
>
> In general, readability is more important than cleverness or brevity.
> ```php
> isset( $var ) || $var = some_function();
> ```
> Although the above line is clever, it takes a while to grok if you’re not familiar with it. So, just write it like this:
> ```php
> if ( ! isset( $var ) ) {
>     $var = some_function();
> }

See: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#clever-code

This part is so far not really covered in WPCS. Existing sniffs which come close - but still don't cover this completely - relate to inline if statements and comparison assignments.

This PR is intended to have a discussion on whether or not to add these sniffs to the rulesets.