### PR TITLE
Add screenshot image of unit testing in terminal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,7 @@ vendor/bin/phpunit --filter WordPress tests/AllTests.php
 
 Expected output:
 
-~~~sh
-PHPUnit 4.8.26 by Sebastian Bergmann and contributors.
-
-....................................
-
-Tests generated 90 unique error codes; 28 were fixable (31.11%)
-
-Time: 3.08 second, Memory: 24.00MB
-
-OK (36 tests, 0 assertions)
-~~~
+[![asciicast](https://asciinema.org/a/98078.png)](https://asciinema.org/a/98078)
 
 You can ignore any skipped tests as these are for `PHP_CodeSniffer` external tools.
 
@@ -49,7 +39,7 @@ the `WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php` sniff has unit test clas
 `WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php` that check `WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc`
 file. See the file naming convention? Lets take a look what inside `ArrayDeclarationUnitTest.php`:
 
-~~~php
+```php
 ...
 class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitTest
 {
@@ -66,13 +56,13 @@ class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitT
     }//end getErrorList()
 }
 ...
-~~~
+```
 
 Also note the class name convention. The method `getErrorList` MUST return an array of line numbers
 indicating errors (when running `phpcs`) found in `WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc`.
 If you run:
 
-~~~sh
+```sh
 $ cd /path-to-cloned/phpcs
 $ ./scripts/phpcs --standard=Wordpress -s CodeSniffer/Standards/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc
 ...
@@ -101,7 +91,7 @@ FOUND 8 ERROR(S) AND 2 WARNING(S) AFFECTING 6 LINE(S)
     |         | (WordPress.WhiteSpace.OperatorSpacing)
 --------------------------------------------------------------------------------
 ....
-~~~
+```
 
 You'll see the line number and number of ERRORs we need to return in `getErrorList` method.
 In line #31 there are two ERRORs belong to `WordPress.WhiteSpace.OperatorSpacing` sniff and


### PR DESCRIPTION
This links through to https://asciinema.org/a/98078 which is a replay of the unit tests being run.

If we ended up with a docs/ site on GitHub, we could embed the asciinema player :-)