### PR TITLE
Fix some undefined index notices in the `WordPress.XSS.EscapeOutput` sniff.

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -208,6 +208,11 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 			if ( T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 
+				if ( ! isset( $this->tokens[ $i ]['parenthesis_closer'] ) ) {
+					// Live coding or parse error.
+					break;
+				}
+
 				if ( $in_cast ) {
 
 					// Skip to the end of a function call if it has been casted to a safe value.
@@ -224,7 +229,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
 
 						// We only do it if the ternary isn't within a subset of parentheses.
-						if ( ! $next_paren || $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) {
+						if ( false === $next_paren || ( isset( $this->tokens[ $next_paren ]['parenthesis_closer'] ) && $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) ) {
 							$i = $ternary;
 						}
 					}
@@ -319,7 +324,12 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 						$i     = ( $function_opener + 1 );
 						$watch = true;
 					} else {
-						$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
+						if ( isset( $this->tokens[ $function_opener ]['parenthesis_closer'] ) ) {
+							$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
+						} else {
+							// Live coding or parse error.
+							break;
+						}
 					}
 				}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -180,3 +180,5 @@ echo '<option name="' . esc_attr( $name ) . '"' .
 
 _deprecated_hook( 'some_filter', '1.3.0', esc_html__( 'The $arg is deprecated.' ), 'some_other_filter' ); // Ok.
 _deprecated_hook( "filter_{$context}", '1.3.0', __( 'The $arg is deprecated.' ), sprintf( __( 'Some parsed message %s', $variable ) ) ); // Bad.
+
+echo add_filter( get_the_excerpt( get_the_ID() ) ; // Bad, but ignored as code contains a parse error.


### PR DESCRIPTION
These would be thrown when live coding/running the sniffs on code with parse errors.

Quick fix for https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/248#issuecomment-270635692

/cc @grappler 