### PR TITLE
Fix unit tests failing on PHP nightly for the `WordPress.WP.I18n` sniff.

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -230,7 +230,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$method    = empty( $context['warning'] ) ? 'addError' : 'addWarning';
 		$content   = $tokens[0]['content'];
 
-		if ( 0 === count( $tokens ) ) {
+		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
 			$code = 'MissingArg' . ucfirst( $arg_name );
 			if ( 'domain' !== $arg_name || ! empty( $this->text_domain ) ) {
 				$phpcs_file->$method( 'Missing $%s arg.', $stack_ptr, $code, array( $arg_name ) );


### PR DESCRIPTION
This solves the following error:
`An error occurred during processing; checking has been aborted. The error message was: "count(): Parameter must be an array or an object that implements Countable" at /home/travis/build/WordPress-Coding-Standards/WordPress-Coding-Standards/WordPress/Sniffs/WP/I18nSniff.php:233`

[`array_shift()`](http://php.net/manual/en/function.array-shift.php) returns null if the array is empty or not an array which may have happened when less arguments where passed to the i18n function than expected.
In that case `$tokens` will be null and start throwing the `countable` error for PHP nightly.