### PR TITLE
Don't error for syntax errors in StrictInArray sniff

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -100,7 +100,6 @@ class WordPress_Sniffs_PHP_StrictInArraySniff implements PHP_CodeSniffer_Sniff {
 
 		// Gracefully handle syntax error.
 		if ( ! isset( $tokens[ $openParenthesis ]['parenthesis_closer'] ) ) {
-			$phpcsFile->addError( 'Missing closing parenthesis for in_array().', $openParenthesis, 'MissingClosingParenthesis' );
 			return;
 		}
 

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
@@ -3,9 +3,6 @@
 in_array( 1, array( '1', 1, true ), true ); // Ok.
 
 in_array( 1, array( '1', 1, true ) ); // Warning.
-
-in_array( 1, array( '1', 1, true ); // Error.
-
 in_array( 1, array( '1', 1, true ), false ); // Warning.
 IN_ARRAY( 1, array( '1', 1, true ), false ); // Warning.
 

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -22,8 +22,7 @@ class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			7 => 1,
-			20 => 1,
+			17 => 1,
 		);
 	}
 
@@ -35,16 +34,16 @@ class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array(
 			5 => 1,
-			9 => 1,
-			10 => 1,
+			6 => 1,
+			7 => 1,
+			23 => 1,
+			24 => 1,
+			25 => 1,
 			26 => 1,
-			27 => 1,
-			28 => 1,
-			29 => 1,
+			34 => 1,
+			35 => 1,
+			36 => 1,
 			37 => 1,
-			38 => 1,
-			39 => 1,
-			40 => 1,
 		);
 	}
 


### PR DESCRIPTION
This should be left up to the `Generic.PHP.Syntax` sniff.

See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/770#discussion_r94809371