### PR TITLE
Add a check that associative arrays are multi-line - includes fixer

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -33,13 +33,12 @@
 		<arg name="tab-width" value="4"/>
 		<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 
-		<!-- Rule: For associative arrays, values should start on a new line.
-			 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/638 -->
-
 		<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
 		<rule ref="WordPress.Arrays.ArrayDeclaration">
 			<exclude name="WordPress.Arrays.ArrayDeclaration.SingleLineNotAllowed" />
 		</rule>
+		<!-- Covers rule: For associative arrays, values should start on a new line.
+			 Also covers various single-line array whitespace issues. -->
 		<rule ref="WordPress.Arrays.ArrayDeclarationSpacing">
 			<!-- Exclude the upstream checks which are already thrown by the
 			     WordPress.Arrays.ArrayDeclaration sniff. -->

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -18,9 +18,10 @@ if ( ! class_exists( 'Squiz_Sniffs_Arrays_ArrayDeclarationSniff', true ) ) {
  *
  * @package WPCS\WordPressCodingStandards
  *
- * @since   0.11.0 The WordPress specific additional checks have now been split off
+ * @since   0.11.0 - The WordPress specific additional checks have now been split off
  *                 from the WordPress_Sniffs_Arrays_ArrayDeclaration sniff into
  *                 this sniff.
+ *                 - Added sniffing & fixing for associative arrays.
  *
  * {@internal This sniff only extends the upstream sniff to get the benefit of the
  * process logic which routes the processing to the single-line/multi-line methods.
@@ -97,6 +98,32 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends Squiz_Sniffs_
 				$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), ' ' );
 			}
 		}
+
+		$array_has_keys = $phpcsFile->findNext( T_DOUBLE_ARROW, $arrayStart, $arrayEnd );
+		if ( false !== $array_has_keys ) {
+			$fix = $phpcsFile->addFixableError(
+				'When an array uses associative keys, each value should start on a new line.',
+				$arrayEnd,
+				'AssociativeKeyFound'
+			);
+
+			if ( true === $fix ) {
+				// Only deal with one nesting level per loop to have the best chance of getting the indentation right.
+				static $current_loop = array();
+
+				if ( ! isset( $current_loop[ $phpcsFile->fixer->loops ] ) ) {
+					$current_loop[ $phpcsFile->fixer->loops ] = array_fill( 0, count( $tokens ), false );
+				}
+
+				if ( false === $current_loop[ $phpcsFile->fixer->loops ][ $arrayStart ] ) {
+					for ( $i = $arrayStart; $i <= $arrayEnd; $i++ ) {
+						$current_loop[ $phpcsFile->fixer->loops ][ $i ] = true;
+					}
+
+					$this->fix_associative_array( $phpcsFile, $arrayStart, $arrayEnd );
+				}
+			}
+		}
 	}
 
 	/**
@@ -114,5 +141,108 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends Squiz_Sniffs_
 	public function processMultiLineArray( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd ) {
 		return;
 	} // End processMultiLineArray().
+
+	/**
+	 * Create & apply a changeset for a single line array with associative keys.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile  The file being scanned.
+	 * @param int                  $arrayStart Position of the array opener in the token stack.
+	 * @param int                  $arrayEnd   Position of the array closer in the token stack.
+	 * @return void
+	 */
+	protected function fix_associative_array( PHP_CodeSniffer_File $phpcsFile, $arrayStart, $arrayEnd ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		// Determine the needed indentation.
+		$indentation = '';
+		for ( $i = $arrayStart; $i >= 0; $i-- ) {
+			if ( $tokens[ $i ]['line'] === $tokens[ $arrayStart ]['line'] ) {
+				continue;
+			}
+
+			if ( T_WHITESPACE === $tokens[ ( $i + 1 ) ]['code'] ) {
+				// Something weird going on with tabs vs spaces, but this fixes it.
+				$indentation = str_replace( '    ', "\t", $tokens[ ( $i + 1 ) ]['content'] );
+			}
+			break;
+		}
+		unset( $i );
+
+		$value_indentation = "\t" . $indentation;
+
+		// Which nesting level is the one we are interested in ?
+		$nesting_count = 1;
+		if ( T_OPEN_SHORT_ARRAY === $tokens[ $arrayStart ]['code'] ) {
+			$nesting_count = 0;
+		}
+
+		if ( isset( $tokens[ $arrayStart ]['nested_parenthesis'] ) ) {
+			$nesting_count += count( $tokens[ $arrayStart ]['nested_parenthesis'] );
+		}
+
+		// Record the required changes.
+		$phpcsFile->fixer->beginChangeset();
+
+		$phpcsFile->fixer->addNewline( $arrayStart );
+		if ( T_WHITESPACE === $tokens[ ( $arrayStart + 1 ) ]['code'] ) {
+			$phpcsFile->fixer->replaceToken( ( $arrayStart + 1 ), $value_indentation );
+		} else {
+			$phpcsFile->fixer->addContentBefore( ( $arrayStart + 1 ), $value_indentation );
+		}
+
+		for ( $ptr = ( $arrayStart + 1 ); $ptr < $arrayEnd; $ptr++ ) {
+			$ptr = $phpcsFile->findNext( array( T_COMMA, T_OPEN_SHORT_ARRAY ), $ptr, $arrayEnd );
+
+			if ( false === $ptr ) {
+				break;
+			}
+
+			// Ignore anything within short array definition brackets.
+			// Necessary as the nesting level in that case is still the same.
+			if ( 'T_OPEN_SHORT_ARRAY' === $tokens[ $ptr ]['type']
+				&& ( isset( $tokens[ $ptr ]['bracket_opener'] )
+					&& $tokens[ $ptr ]['bracket_opener'] === $ptr )
+				&& isset( $tokens[ $ptr ]['bracket_closer'] )
+			) {
+				$ptr = $tokens[ $ptr ]['bracket_closer'];
+				continue;
+			}
+
+			// Ignore comma's at a lower nesting level.
+			if ( 'T_COMMA' === $tokens[ $ptr ]['type']
+				&& isset( $tokens[ $ptr ]['nested_parenthesis'] )
+				&& count( $tokens[ $ptr ]['nested_parenthesis'] ) !== $nesting_count
+			) {
+				continue;
+			}
+
+			$phpcsFile->fixer->addNewline( $ptr );
+			if ( isset( $tokens[ ( $ptr + 1 ) ] ) ) {
+				if ( T_WHITESPACE === $tokens[ ( $ptr + 1 ) ]['code'] ) {
+					$phpcsFile->fixer->replaceToken( ( $ptr + 1 ), $value_indentation );
+				} else {
+					$phpcsFile->fixer->addContentBefore( ( $ptr + 1 ), $value_indentation );
+				}
+			}
+		}
+
+		$token_before_end = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $arrayEnd - 1 ), $arrayStart, true, null, true );
+		if ( 'T_COMMA' !== $tokens[ $token_before_end ]['type'] ) {
+			$phpcsFile->fixer->addContent( $token_before_end, ',' );
+
+			if ( T_WHITESPACE === $tokens[ ( $arrayEnd - 1 ) ]['code'] || "\n" === $phpcsFile->fixer->getTokenContent( ( $arrayEnd - 1 ) ) ) {
+				$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), "\n" . $indentation );
+			} else {
+				$phpcsFile->fixer->addContentBefore( $arrayEnd, "\n" . $indentation );
+			}
+		} elseif ( $value_indentation === $phpcsFile->fixer->getTokenContent( ( $arrayEnd - 1 ) ) ) {
+			$phpcsFile->fixer->replaceToken( ( $arrayEnd - 1 ), $indentation );
+		}
+
+		$phpcsFile->fixer->endChangeset();
+	} // End fix_associative_array().
 
 } // End class.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -213,33 +213,90 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 		$argument_assertions = array();
 		if ( 'simple' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'text',    'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'text',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 		} elseif ( 'context' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'text',    'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'context', 'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'text',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 		} elseif ( 'number' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'single',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'plural',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 			array_shift( $arguments_tokens );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 		} elseif ( 'number_context' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'single',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'plural',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 			array_shift( $arguments_tokens );
-			$argument_assertions[] = array( 'arg_name' => 'context', 'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 		} elseif ( 'noopnumber' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'single',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'plural',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens' => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
 		} elseif ( 'noopnumber_context' === $this->i18n_functions[ $translation_function ] ) {
-			$argument_assertions[] = array( 'arg_name' => 'single',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'plural',  'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'context', 'tokens' => array_shift( $arguments_tokens ) );
-			$argument_assertions[] = array( 'arg_name' => 'domain',  'tokens' => array_shift( $arguments_tokens ) );
-		}
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} // End if().
 
 		if ( ! empty( $arguments_tokens ) ) {
 			$phpcs_file->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $translation_function ) );

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.inc
@@ -2,7 +2,23 @@
 
 $good = array( 'value1', 'value2' ); // Ok.
 
-$query_vars = array('post_type' => 'food'); // Bad, no spaces after opening and before closing parenthesis.
+$query_vars = array('food'); // Bad, no spaces after opening and before closing parenthesis.
 
 // Test for fixing of extra whitespace.
 $test = array(   1, 2     );
+
+$bad = array( 'key' => 'value' ); // Bad, each value of an associative array should start on a new line.
+
+// Test for fixing nested associative arrays.
+$bad = array( array( 'key1' => 'value1', 'key2' => ['sub1' => 1, 'sub2' => 2] ), $key3 => 'value3', [ 'value4', 10 => 'value5', ] ); // Bad.
+
+// Test for fixing mixed single & multi-line nested associative arrays.
+$bad = array(
+	array( 'key1' => 'value1', array('sub1' => 1,'sub2' => 2,)),
+	$key3 => 'value3',
+	[ 'value4', 10 => 'value5' ]
+); // Bad.
+
+// Test for fixing associative arrays with multiple values & whitespace in front.
+// This needs to be the last test as the scope indent sniff will otherwise screw things up.
+		$bad = array( 'key1' => 'value1', 'key2' => 'value2', $key3 => 'value3', 'value4', 10 => 'value5' ); // Bad.

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.inc.fixed
@@ -2,7 +2,53 @@
 
 $good = array( 'value1', 'value2' ); // Ok.
 
-$query_vars = array( 'post_type' => 'food' ); // Bad, no spaces after opening and before closing parenthesis.
+$query_vars = array( 'food' ); // Bad, no spaces after opening and before closing parenthesis.
 
 // Test for fixing of extra whitespace.
 $test = array( 1, 2 );
+
+$bad = array(
+	'key' => 'value',
+); // Bad, each value of an associative array should start on a new line.
+
+// Test for fixing nested associative arrays.
+$bad = array(
+	array(
+		'key1' => 'value1',
+		'key2' => [
+			'sub1' => 1,
+			'sub2' => 2,
+		],
+	),
+	$key3 => 'value3',
+	[
+		'value4',
+		10 => 'value5',
+	],
+); // Bad.
+
+// Test for fixing mixed single & multi-line nested associative arrays.
+$bad = array(
+	array(
+		'key1' => 'value1',
+		array(
+			'sub1' => 1,
+			'sub2' => 2,
+		),
+	),
+	$key3 => 'value3',
+	[
+		'value4',
+		10 => 'value5',
+	]
+); // Bad.
+
+// Test for fixing associative arrays with multiple values & whitespace in front.
+// This needs to be the last test as the scope indent sniff will otherwise screw things up.
+		$bad = array(
+			'key1' => 'value1',
+			'key2' => 'value2',
+			$key3 => 'value3',
+			'value4',
+			10 => 'value5',
+		); // Bad.

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -24,6 +24,11 @@ class WordPress_Tests_Arrays_ArrayDeclarationSpacingUnitTest extends AbstractSni
 		return array(
 			5 => 2,
 			8 => 2,
+			10 => 1,
+			13 => 6,
+			17 => 5,
+			19 => 1,
+			24 => 1,
 		);
 	}
 


### PR DESCRIPTION
> For associative arrays, values should start on a new line.
https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation

Detecting this was easy, creating the fixer.... not so much...
I got it working, but would not be surprised if I rewrite the fixer in a few months or so. I've tried to anticipate the most common situations, but the fixer will fail on arrays with very inconsistent spacing.
Think:
```php
array(
	'key' => array( 'key1' => 'value', 'key2' => array(
		'another_value'
	) ),
)
```

Anticipating a comment on line 43 of the `.fixed` file: the fixer will add a trailing comma to arrays which it is triggered on (if needed), but will *not* do so on arrays on which it is not triggered - that is covered by another sniff.

Fixes #638

* Allows for both long as well as short array syntax.
* Includes unit tests.
* Includes fixing the one file in the WPCS code base which did not comply with the rule.