### PR TITLE
Improve performance of function restriction sniffs

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -150,24 +150,32 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff implements PHP_CodeSn
 
 			if ( false !== $prev ) {
 				// Skip sniffing if calling a same-named method, or on function definitions.
-				if ( in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true ) ) {
+				$skipped = array(
+					T_FUNCTION        => T_FUNCTION,
+					T_DOUBLE_COLON    => T_DOUBLE_COLON,
+					T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
+				);
+
+				if ( isset( $skipped[ $tokens[ $prev ]['code'] ] ) ) {
 					return;
 				}
 
 				// Skip namespaced functions, ie: \foo\bar() not \bar().
-				$pprev = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $prev - 1 ), null, true );
-				if ( false !== $pprev && T_NS_SEPARATOR === $tokens[ $prev ]['code'] && T_STRING === $tokens[ $pprev ]['code'] ) {
-					return;
+				if ( T_NS_SEPARATOR === $tokens[ $prev ]['code'] ) {
+					$pprev = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $prev - 1 ), null, true );
+					if ( false !== $pprev && T_STRING === $tokens[ $pprev ]['code'] ) {
+						return;
+					}
 				}
 			}
-			unset( $prev, $pprev );
+			unset( $prev, $pprev, $skipped );
 		}
 
-		$exclude = explode( ',', $this->exclude );
+		$exclude = array_flip( explode( ',', $this->exclude ) );
 
 		foreach ( $this->groups as $groupName => $group ) {
 
-			if ( in_array( $groupName, $exclude, true ) ) {
+			if ( isset( $exclude[ $groupName ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
This abstract sniff is extended by quite a few of our sniffs, and so it has a major impact on the performance of the ruleset as a whole.

Here we make two improvements:

1. We use `isset()` instead of `in_array()`.
2. We don't call `findPrevious()` a second time unless we actually need the information. We only need to check if the namespace is top-level if the function is prefixed with `\\`, the namespace separator.

This seems to improve the performance of these sniffs by as much as 25%.

Profiled with Blackfire (free edition, so the links will only be retained for 1 day), by running over a sizable plugin (using a custom ruleset that includes Core, Extra, Docs, and VIP, but with some exclusions):

[Before](https://blackfire.io/profiles/dc4d99a8-59a5-4ccf-9b40-11aae9d30ef6/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=&callname=WordPress_AbstractFunctionRestrictionsSniff%3A%3Aprocess):

![untitled_profile_-_blackfire_-_2017-01-10_10 09 59](https://cloud.githubusercontent.com/assets/4005415/21812374/baa5e034-d720-11e6-8d58-6bb86dd17922.png)

[After](https://blackfire.io/profiles/059efa2c-076d-4fad-a739-99268f53d3aa/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=&callname=WordPress_AbstractFunctionRestrictionsSniff%3A%3Aprocess):

![untitled_profile_-_blackfire_-_2017-01-10_10 27 02](https://cloud.githubusercontent.com/assets/4005415/21812377/bfb3a660-d720-11e6-8c7b-24e0f20f9477.png)

[Comparison](https://blackfire.io/profiles/compare/dc4d99a8-59a5-4ccf-9b40-11aae9d30ef6...059efa2c-076d-4fad-a739-99268f53d3aa/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=&callname=WordPress_AbstractFunctionRestrictionsSniff%3A%3Aprocess):

![comparison_from_untitled_to_untitled_-_blackfire_-_2017-01-10_10 39 36](https://cloud.githubusercontent.com/assets/4005415/21812493/23d63770-d721-11e6-8587-4aa5aac1aa49.png)
