### PR TITLE
Fix comment style in testcase files.

### DIFF
--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
@@ -17,7 +17,7 @@ $y = Bar::mysql_info(); // Ok.
 prefix_mysql_info(); // Ok.
 
 
-/**
+/*
  * All the below should give an error.
  */
 
@@ -76,7 +76,7 @@ maxdb_real_query();
 maxdb_stat();
 
 
-/**
+/*
  * And these shouldn't give an error.
  */
 

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -21,7 +21,7 @@ class My_Plugin {
 	public function __invoke() {} // OK.
 }
 
-/**
+/*
  * Verify that CamelCase is not checked for extended classes or interfaces.
  */
 class Test extends WP_UnitTestCase {
@@ -37,7 +37,7 @@ class Foo implements ArrayAccess {
 }
 
 
-/**
+/*
  * Verify all PHP supported magic methods.
  */
 class Its_A_Kind_Of_Magic {
@@ -58,7 +58,7 @@ class Its_A_Kind_Of_Magic {
 	function __debugInfo() {} // Ok.
 }
 
-/**
+/*
  * Verify SoapClient magic methods.
  */
 class My_Soap extends SoapClient {

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -1,5 +1,5 @@
 <?php
-/**
+/*
  * Test sniffing for translator comments.
  */
 

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -108,7 +108,7 @@ function ( $arg ) {} // Ok.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 
-/**
+/*
  * Test for bug where this sniff was triggering a "Blank line found after control structure" error
  * if there is a blank line after the last method in a class.
  *

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -104,7 +104,7 @@ function ( $arg ) {} // Ok.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 
-/**
+/*
  * Test for bug where this sniff was triggering a "Blank line found after control structure" error
  * if there is a blank line after the last method in a class.
  *


### PR DESCRIPTION
Reviewed test case files for (unintended) erroneous comment style. As per comment of @JDGrimes in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/782#discussion_r96122877