### PR TITLE
Improve efficiency of the abstract sniffs.

### DIFF
--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -85,6 +85,14 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	 * @return void
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		$this->excluded_groups = array_flip( explode( ',', $this->exclude ) );
+		if ( array_diff_key( $this->groups, $this->excluded_groups ) === array() ) {
+			// All groups have been excluded.
+			// Don't remove the listener as the exclude property can be changed inline.
+			return;
+		}
+
 		$tokens    = $phpcsFile->getTokens();
 		$token     = $tokens[ $stackPtr ];
 		$classname = '';
@@ -125,11 +133,9 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 			return;
 		}
 
-		$exclude   = explode( ',', $this->exclude );
-
 		foreach ( $this->groups as $groupName => $group ) {
 
-			if ( in_array( $groupName, $exclude, true ) ) {
+			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
#779 applied a performance fix to the function restrictions abstract.

This PR builds onto that for all the abstract classes:
* Bow out early if all the groups have been excluded.
* `array_flip()` the excluded groups and use `isset()` instead of `in_array()`, i.e. applying the fix from #779 to the other abstracts

I've chosen to add a new `$excluded_groups` property to the abstracts which holds the exploded & flipped array of excluded groups. This allows for that array to be accessed by child classes and other methods within the class without having to reprocess the original property. This is done with an eye on a refactor of the function restrictions sniff in anticipation of introducing a function parameter abstract sniff.

While for the other abstracts, the property is - at this moment - not necessary, I've applied the fix in the same manner - including the adding of the new property - for consistency.