### PR TITLE
Fix bug in WordPress_Sniffs_NamingConventions_ValidVariableNameSniff

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -238,6 +238,11 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 					continue;
 				}
 
+				// Likewise if it is a mixed-case var used by WordPress core.
+				if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
+					return;
+				}
+
 				if ( false === self::isSnakeCase( $var_name ) ) {
 					$error = 'Variable "%s" is not in valid snake_case format';
 					$data  = array( $var_name );

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -122,3 +122,6 @@ if ( is_category() ) {
 }
 
 $EZSQL_ERROR = array(); // OK
+
+echo "This is a $comment_ID"; // Bad
+echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -63,6 +63,7 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 			104  => 1,
 			105  => 1,
 			121  => 1,
+			126  => 1,
 		);
 
 		return $errors;


### PR DESCRIPTION
* Allow for usage of whitelisted mixed case WP vars in double quoted strings and heredocs.