### PR TITLE
Sync in upstream fixes to controlstructure whitespace sniff

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -528,7 +528,6 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 							}
 						}
 					} // End if().
-
 				} // End if().
 
 				// Found placeholders but no translators comment.
@@ -539,7 +538,6 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				);
 				return;
 			} // End foreach().
-
 		} // End foreach().
 
 	} // End check_for_translator_comment().

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -102,13 +102,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
 			&& ! ( T_ELSE === $this->tokens[ $stackPtr ]['code'] && T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
-			&& ! (
-				T_CLOSURE === $this->tokens[ $stackPtr ]['code']
-				&& (
-					0 === (int) $this->spaces_before_closure_open_paren
-					|| -1 === (int) $this->spaces_before_closure_open_paren
-				)
-			)
+			&& ! ( T_CLOSURE === $this->tokens[ $stackPtr ]['code']
+				&& 0 >= (int) $this->spaces_before_closure_open_paren )
 		) {
 			$error = 'Space after opening control structure is required';
 			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -79,6 +79,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			T_FUNCTION,
 			T_CLOSURE,
 			T_USE,
+			T_TRY,
+			T_CATCH,
 		);
 
 	}

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -111,15 +111,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			)
 		) {
 			$error = 'Space after opening control structure is required';
-			if ( isset( $phpcsFile->fixer ) ) {
-				$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
-				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->addContent( $stackPtr, ' ' );
-					$phpcsFile->fixer->endChangeset();
-				}
-			} else {
-				$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+
+			if ( true === $fix ) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+				$phpcsFile->fixer->endChangeset();
 			}
 		}
 
@@ -143,34 +140,24 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				if ( T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Space between opening control structure and T_COLON is required';
+					$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
 
-					if ( isset( $phpcsFile->fixer ) ) {
-						$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
-
-						if ( true === $fix ) {
-							$phpcsFile->fixer->beginChangeset();
-							$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
-							$phpcsFile->fixer->endChangeset();
-						}
-					} else {
-						$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBetweenStructureColon' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+						$phpcsFile->fixer->endChangeset();
 					}
 				}
 			} elseif ( 'forbidden' === $this->space_before_colon ) {
 
 				if ( T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Extra space between opening control structure and T_COLON found';
+					$fix   = $phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
 
-					if ( isset( $phpcsFile->fixer ) ) {
-						$fix = $phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
-
-						if ( true === $fix ) {
-							$phpcsFile->fixer->beginChangeset();
-							$phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
-							$phpcsFile->fixer->endChangeset();
-						}
-					} else {
-						$phpcsFile->addError( $error, $stackPtr, 'SpaceBetweenStructureColon' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
+						$phpcsFile->fixer->endChangeset();
 					}
 				}
 			}
@@ -258,6 +245,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					// Checking this: function[*](...) {}.
 					$error = 'Space before closure opening parenthesis is prohibited';
 					$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
+
 					if ( true === $fix ) {
 						$phpcsFile->fixer->beginChangeset();
 						$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
@@ -274,15 +262,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				// Checking this: if[*](...) {}.
 				$error = 'No space before opening parenthesis is prohibited';
-				if ( isset( $phpcsFile->fixer ) ) {
-					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
-					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->addContent( $stackPtr, ' ' );
-						$phpcsFile->fixer->endChangeset();
-					}
-				} else {
-					$phpcsFile->addError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+				$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+					$phpcsFile->fixer->endChangeset();
 				}
 			}
 		} // End if().
@@ -293,7 +278,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		) {
 			// Checking this: if [*](...) {}.
 			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
-			$fix = $phpcsFile->addFixableError(
+			$fix   = $phpcsFile->addFixableError(
 				$error,
 				$stackPtr,
 				'ExtraSpaceBeforeOpenParenthesis',
@@ -312,15 +297,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		) {
 			// Checking this: $value = my_function([*]...).
 			$error = 'No space after opening parenthesis is prohibited';
-			if ( isset( $phpcsFile->fixer ) ) {
-				$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
-				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
-					$phpcsFile->fixer->endChangeset();
-				}
-			} else {
-				$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+
+			if ( true === $fix ) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
+				$phpcsFile->fixer->endChangeset();
 			}
 		}
 
@@ -332,15 +314,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
 					$error = 'No space before closing parenthesis is prohibited';
-					if ( isset( $phpcsFile->fixer ) ) {
-						$fix = $phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
-						if ( true === $fix ) {
-							$phpcsFile->fixer->beginChangeset();
-							$phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
-							$phpcsFile->fixer->endChangeset();
-						}
-					} else {
-						$phpcsFile->addError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+					$fix   = $phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
+						$phpcsFile->fixer->endChangeset();
 					}
 				}
 
@@ -349,17 +328,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					&& ( isset( $scopeOpener ) && T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
 				) {
 					$error = 'Space between opening control structure and closing parenthesis is required';
+					$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
 
-					if ( isset( $phpcsFile->fixer ) ) {
-						$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
-
-						if ( true === $fix ) {
-							$phpcsFile->fixer->beginChangeset();
-							$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
-							$phpcsFile->fixer->endChangeset();
-						}
-					} else {
-						$phpcsFile->addError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+					if ( true === $fix ) {
+						$phpcsFile->fixer->beginChangeset();
+						$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+						$phpcsFile->fixer->endChangeset();
 					}
 				}
 			}
@@ -369,20 +343,17 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
 			) {
 				$error = 'Opening brace should be on the same line as the declaration';
-				if ( isset( $phpcsFile->fixer ) ) {
-					$fix = $phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
-					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
+				$fix   = $phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
 
-						for ( $i = ( $parenthesisCloser + 1 ); $i < $scopeOpener; $i++ ) {
-							$phpcsFile->fixer->replaceToken( $i, '' );
-						}
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
 
-						$phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
-						$phpcsFile->fixer->endChangeset();
+					for ( $i = ( $parenthesisCloser + 1 ); $i < $scopeOpener; $i++ ) {
+						$phpcsFile->fixer->replaceToken( $i, '' );
 					}
-				} else {
-					$phpcsFile->addError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
+
+					$phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
+					$phpcsFile->fixer->endChangeset();
 				}
 				return;
 
@@ -393,7 +364,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				// Checking this: if (...) [*]{}.
 				$error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
-				$fix = $phpcsFile->addFixableError(
+				$fix   = $phpcsFile->addFixableError(
 					$error,
 					$stackPtr,
 					'ExtraSpaceAfterCloseParenthesis',
@@ -414,20 +385,17 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				&& false === in_array( $this->tokens[ $firstContent ]['code'], array( T_CLOSE_TAG, T_COMMENT ), true )
 			) {
 				$error = 'Blank line found at start of control structure';
-				if ( isset( $phpcsFile->fixer ) ) {
-					$fix = $phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
-					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
+				$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
 
-						for ( $i = ( $scopeOpener + 1 ); $i < $firstContent; $i++ ) {
-							$phpcsFile->fixer->replaceToken( $i, '' );
-						}
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
 
-						$phpcsFile->fixer->addNewline( $scopeOpener );
-						$phpcsFile->fixer->endChangeset();
+					for ( $i = ( $scopeOpener + 1 ); $i < $firstContent; $i++ ) {
+						$phpcsFile->fixer->replaceToken( $i, '' );
 					}
-				} else {
-					$phpcsFile->addError( $error, $scopeOpener, 'BlankLineAfterStart' );
+
+					$phpcsFile->fixer->addNewline( $scopeOpener );
+					$phpcsFile->fixer->endChangeset();
 				}
 			}
 
@@ -440,20 +408,17 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 						) {
 							// TODO: Reporting error at empty line won't highlight it in IDE.
 							$error = 'Blank line found at end of control structure';
-							if ( isset( $phpcsFile->fixer ) ) {
-								$fix = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
-								if ( true === $fix ) {
-									$phpcsFile->fixer->beginChangeset();
-	
-									for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
-										$phpcsFile->fixer->replaceToken( $j, '' );
-									}
-	
-									$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
-									$phpcsFile->fixer->endChangeset();
+							$fix   = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
+
+							if ( true === $fix ) {
+								$phpcsFile->fixer->beginChangeset();
+
+								for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
+									$phpcsFile->fixer->replaceToken( $j, '' );
 								}
-							} else {
-								$phpcsFile->addError( $error, $i, 'BlankLineBeforeEnd' );
+
+								$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
+								$phpcsFile->fixer->endChangeset();
 							}
 							break;
 						} // End if().
@@ -506,21 +471,18 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			if ( ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line'] ) {
 				// TODO: Won't cover following case: "} echo 'OK';".
 				$error = 'Blank line found after control structure';
-				if ( isset( $phpcsFile->fixer ) ) {
-					$fix = $phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
-					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
+				$fix   = $phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
 
-						for ( $i = ( $scopeCloser + 1 ); $i < $trailingContent; $i++ ) {
-							$phpcsFile->fixer->replaceToken( $i, '' );
-						}
+				if ( true === $fix ) {
+					$phpcsFile->fixer->beginChangeset();
 
-						// TODO: Instead a separate error should be triggered when content comes right after closing brace.
-						$phpcsFile->fixer->addNewlineBefore( $trailingContent );
-						$phpcsFile->fixer->endChangeset();
+					for ( $i = ( $scopeCloser + 1 ); $i < $trailingContent; $i++ ) {
+						$phpcsFile->fixer->replaceToken( $i, '' );
 					}
-				} else {
-					$phpcsFile->addError( $error, $scopeCloser, 'BlankLineAfterEnd' );
+
+					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
+					$phpcsFile->fixer->addNewlineBefore( $trailingContent );
+					$phpcsFile->fixer->endChangeset();
 				}
 			}
 		} // End if().

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -430,32 +430,34 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 			}
 
-			$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
-			if ( ( $this->tokens[ $scopeCloser ]['line'] - 1 ) !== $this->tokens[ $lastContent ]['line'] ) {
-				for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
-					if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
-						&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
-					) {
-						// TODO: Reporting error at empty line won't highlight it in IDE.
-						$error = 'Blank line found at end of control structure';
-						if ( isset( $phpcsFile->fixer ) ) {
-							$fix = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
-							if ( true === $fix ) {
-								$phpcsFile->fixer->beginChangeset();
-
-								for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
-									$phpcsFile->fixer->replaceToken( $j, '' );
+			if ( $firstContent !== $scopeCloser ) {
+				$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
+				if ( ( $this->tokens[ $scopeCloser ]['line'] - 1 ) !== $this->tokens[ $lastContent ]['line'] ) {
+					for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
+						if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
+							&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
+						) {
+							// TODO: Reporting error at empty line won't highlight it in IDE.
+							$error = 'Blank line found at end of control structure';
+							if ( isset( $phpcsFile->fixer ) ) {
+								$fix = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
+								if ( true === $fix ) {
+									$phpcsFile->fixer->beginChangeset();
+	
+									for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
+										$phpcsFile->fixer->replaceToken( $j, '' );
+									}
+	
+									$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
+									$phpcsFile->fixer->endChangeset();
 								}
-
-								$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
-								$phpcsFile->fixer->endChangeset();
+							} else {
+								$phpcsFile->addError( $error, $i, 'BlankLineBeforeEnd' );
 							}
-						} else {
-							$phpcsFile->addError( $error, $i, 'BlankLineBeforeEnd' );
-						}
-						break;
-					} // End if().
-				} // End for().
+							break;
+						} // End if().
+					} // End for().
+				} // End if().
 			} // End if().
 		} // End if().
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -459,24 +459,14 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			} // End if().
 		} // End if().
 
-		$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
-		if ( false !== $trailingContent && T_ELSE === $this->tokens[ $trailingContent ]['code'] ) {
-			if ( T_IF === $this->tokens[ $stackPtr ]['code'] ) {
-				// IF with ELSE.
-				return;
-			}
+		$trailingContent = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {
 			return;
 		}
 
-		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
-			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
-				if ( '//end' === substr( $this->tokens[ $trailingContent ]['content'], 0, 5 ) ) {
-					// There is an end comment, so we have to get the next piece
-					// of content.
-					$trailingContent = $phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1), null, true );
-				}
-			}
+		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] && T_IF === $this->tokens[ $stackPtr ]['code'] ) {
+			// IF with ELSE.
+			return;
 		}
 
 		if ( T_BREAK === $this->tokens[ $trailingContent ]['code'] ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -128,7 +128,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			if ( T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
 				$scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
 				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
-			} else {
+			} elseif ( T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {
 				return;
 			}
 		} else {
@@ -137,7 +137,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		}
 
 		// Alternative syntax.
-		if ( T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
+		if ( isset( $scopeOpener ) && T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
 
 			if ( 'required' === $this->space_before_colon ) {
 
@@ -346,7 +346,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				if (
 					T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
-					&& T_COLON !== $this->tokens[ $scopeOpener ]['code']
+					&& ( isset( $scopeOpener ) && T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
 				) {
 					$error = 'Space between opening control structure and closing parenthesis is required';
 
@@ -365,7 +365,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 
 			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
-				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line']
+				&& ( isset( $scopeOpener )
+				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
 			) {
 				$error = 'Opening brace should be on the same line as the declaration';
 				if ( isset( $phpcsFile->fixer ) ) {
@@ -407,7 +408,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			} // End if().
 		} // End if().
 
-		if ( true === $this->blank_line_check ) {
+		if ( true === $this->blank_line_check && isset( $scopeOpener ) ) {
 			$firstContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
 			if ( $this->tokens[ $firstContent ]['line'] > ( $this->tokens[ $scopeOpener ]['line'] + 1 )
 				&& false === in_array( $this->tokens[ $firstContent ]['code'], array( T_CLOSE_TAG, T_COMMENT ), true )
@@ -460,6 +461,10 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				} // End if().
 			} // End if().
 		} // End if().
+
+		if ( ! isset( $scopeCloser ) ) {
+			return;
+		}
 
 		$trailingContent = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -465,6 +465,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				// IF with ELSE.
 				return;
 			}
+		if ( false === $trailingContent ) {
+			return;
 		}
 
 		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -401,7 +401,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 			if ( $firstContent !== $scopeCloser ) {
 				$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
-				if ( ( $this->tokens[ $scopeCloser ]['line'] - 1 ) !== $this->tokens[ $lastContent ]['line'] ) {
+				if ( $this->tokens[ $lastContent ]['line'] <= ( $this->tokens[ $scopeCloser ]['line'] - 2 ) ) {
 					for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
 						if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
 							&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -461,7 +461,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			// Another control structure's closing brace.
 			if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] ) ) {
 				$owner = $this->tokens[ $trailingContent ]['scope_condition'];
-				if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+				if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
 					// The next content is the closing brace of a function, class, interface or trait
 					// so normal function/class rules apply and we can ignore it.
 					return;

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -17,7 +17,9 @@
  * @since   0.3.0      This sniff now has the ability to fix most errors it flags.
  * @since   0.7.0      This class now extends WordPress_Sniff.
  *
- * Last synced with base class ?[unknown date]? at commit ?[unknown commit]?.
+ * Last synced with base class 2017-01-15 at commit b024ad84656c37ef5733c6998ebc1e60957b2277.
+ * Note: This class has diverged quite far from the original. All the same, checking occassionally
+ * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
 class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress_Sniff {
@@ -408,7 +410,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 			if ( $firstContent !== $scopeCloser ) {
 				$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
-				
+
 				$lastNonEmptyContent = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ($scopeCloser - 1), null, true );
 
 				$checkToken = $lastContent;

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -462,7 +462,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			} // End if().
 		} // End if().
 
-		if ( ! isset( $scopeCloser ) ) {
+		if ( ! isset( $scopeCloser ) || false === $this->blank_line_after_check ) {
 			return;
 		}
 
@@ -503,9 +503,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				}
 			}
 
-			if ( true === $this->blank_line_after_check
-				&& ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line']
-			) {
+			if ( ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line'] ) {
 				// TODO: Won't cover following case: "} echo 'OK';".
 				$error = 'Blank line found after control structure';
 				if ( isset( $phpcsFile->fixer ) ) {

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -149,3 +149,27 @@ if ( $one ) {
 do {
 	echo 'hi';
 } while ($blah);
+
+// Upstream bug GH #782
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+if ( $foo ) {
+
+
+    /**
+     * Comment
+     */
+    function foo() {
+        // Code here
+    }
+
+
+    /**
+     * Comment
+     */
+    class bar() {
+
+    }//end class
+
+
+}
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -144,3 +144,8 @@ if ( $one ) {
 
 }
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+
+// Upstream bug PEAR #20247.
+do {
+	echo 'hi';
+} while ($blah);

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -137,3 +137,10 @@ try{ // Bad.
 } catch(Exception $e){ // Bad.
 	// Something
 }
+
+// Upstream bug PEAR #20248.
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+if ( $one ) {
+
+}
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -140,6 +140,7 @@ try{ // Bad.
 
 // Upstream bug PEAR #20248.
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// Bad.
 if ( $one ) {
 
 }
@@ -148,7 +149,7 @@ if ( $one ) {
 // Upstream bug PEAR #20247.
 do {
 	echo 'hi';
-} while ($blah);
+} while ($blah); // Bad.
 
 // Upstream bug GH #782
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -130,3 +130,10 @@ class Foo_Bar {
 	}
 
 }
+
+// Handle try/catch statements as well.
+try{ // Bad.
+	// Something
+} catch(Exception $e){ // Bad.
+	// Something
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -136,6 +136,7 @@ try { // Bad.
 
 // Upstream bug PEAR #20248.
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// Bad.
 if ( $one ) {
 }
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
@@ -143,7 +144,7 @@ if ( $one ) {
 // Upstream bug PEAR #20247.
 do {
 	echo 'hi';
-} while ( $blah );
+} while ( $blah ); // Bad.
 
 // Upstream bug GH #782
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -139,3 +139,8 @@ try { // Bad.
 if ( $one ) {
 }
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+
+// Upstream bug PEAR #20247.
+do {
+	echo 'hi';
+} while ( $blah );

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -144,3 +144,27 @@ if ( $one ) {
 do {
 	echo 'hi';
 } while ( $blah );
+
+// Upstream bug GH #782
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+if ( $foo ) {
+
+
+    /**
+     * Comment
+     */
+    function foo() {
+        // Code here
+    }
+
+
+    /**
+     * Comment
+     */
+    class bar() {
+
+    }//end class
+
+
+}
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -133,3 +133,9 @@ try { // Bad.
 } catch ( Exception $e ) { // Bad.
 	// Something
 }
+
+// Upstream bug PEAR #20248.
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+if ( $one ) {
+}
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -126,3 +126,10 @@ class Foo_Bar {
 	}
 
 }
+
+// Handle try/catch statements as well.
+try { // Bad.
+	// Something
+} catch ( Exception $e ) { // Bad.
+	// Something
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -55,6 +55,8 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			95 => 1,
 			97 => 1,
 			98 => 1,
+			135 => 2,
+			137 => 5,
 		);
 
 		/*

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -57,8 +57,8 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			98 => 1,
 			135 => 2,
 			137 => 5,
-			143 => 1,
-			151 => 2,
+			144 => 1,
+			152 => 2,
 		);
 
 		/*

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -57,6 +57,7 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			98 => 1,
 			135 => 2,
 			137 => 5,
+			143 => 1,
 		);
 
 		/*

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -58,6 +58,7 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			135 => 2,
 			137 => 5,
 			143 => 1,
+			151 => 2,
 		);
 
 		/*


### PR DESCRIPTION
The `WordPress.WhiteSpace.ControlStructureSpacing` sniff is based upon the upstream `Squiz.WhiteSpace.ControlStructureSpacing` sniff, but has since diverged a lot to be more specifically relevant to WordPress.

Even so, I've gone through all commits to the upstream sniff to see if there were any bugfixes which we should implement in the WPCS version of the sniff.

As expected, there were a few and while implementing these, I came across a few other optimizations which could be made and have implemented these as well.

I've kept each change in a separate commit for easier review and easier reference to the related upstream issues.

Commit summary:
* Enhancement: Handle try/catch statements as well.
* Efficiency: Bail early if no trailing content found (otherwise we'll get lots of undefined index notices)
* Optimal use of PHPCS: No need to check separately for comments.
* Bugfix: Don't confuse the fixer with a single empty line in a control structure. (also: don't throw two errors for the same line)
    Upstream PEAR bug 20248.
* Bugfix: Fix sniff not working with do-while constructs.
    Upstream PEAR bug 20247.
* Efficiency: bow out early if blank line after end if not being checked.
* Efficiency: Remove unnecessary checks for `$phpcsFile->fixer`. That's what the `$fix` return value is all about already.
* Minor miscellaneous fix
* Enhancement: Add T_CLOSURE to closing brace of other entity check for the blank line after end check.
* Bugfix: Prevent infinite loop in fixer
    Conditional function declarations cause fixing conflicts when this sniff is combined with the `Squiz.ControlStructures.ControlSignature` sniff as it is in the WP-Core ruleset.
    Upstream issue GH 782
* Efficiency: Minor miscellaneous code simplification
* Document & tidy up

Includes minor code style fix in I18n sniff for something which previously was missed by the ControlStructureSpacing sniff.

Related to #614