### PR TITLE
Remove duplicate rule

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -5,7 +5,6 @@
 	<!-- Generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
-	<rule ref="WordPress.WP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Generic.Functions.CallTimePassByReference"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement" />


### PR DESCRIPTION
the other is in [line 49](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/develop...grappler:fix/duplicate-rule?expand=1#diff-9dbd3b63f5d2589b5eb1701e92893803R49)