### PR TITLE
 	Improve custom property handling in WordPress_Sniffs_NamingConventions_ValidVariableNameSniff

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -276,11 +276,39 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			return;
 		}
 
+		if ( ! empty( $this->customPropertiesWhitelist ) ) {
+			if ( ! is_array( $this->customPropertiesWhitelist ) ) {
+				// Incorrectly set property.
+				$phpcs_file->addWarning(
+					'The customVariablesWhitelist property should be provided with type="array".',
+					0,
+					'WrongFormatCustomVariablesWhitelist'
+				);
+			}
+
+			// Potentially correct incorrect format.
+			if ( is_string( $this->customPropertiesWhitelist ) ) {
+				$this->customPropertiesWhitelist = array_map( 'trim', explode( ',', $this->customPropertiesWhitelist ) );
+			} else {
+				// Otherwise, disregard the value.
+				$this->customPropertiesWhitelist = array();
+			}
+		}
+
 		if ( ! empty( $this->customVariablesWhitelist ) ) {
-			$this->customPropertiesWhitelist = array_merge(
-				$this->customPropertiesWhitelist,
-				$this->customVariablesWhitelist
-			);
+			if ( ! is_array( $this->customVariablesWhitelist ) ) {
+				// Incorrectly set property, disregard it.
+				$phpcs_file->addWarning(
+					'The customVariablesWhitelist property should be provided with type="array".',
+					0,
+					'WrongFormatCustomVariablesWhitelist'
+				);
+			} else {
+				$this->customPropertiesWhitelist = array_merge(
+					$this->customPropertiesWhitelist,
+					$this->customVariablesWhitelist
+				);
+			}
 
 			$phpcs_file->addWarning(
 				'The customVariablesWhitelist property is deprecated in favor of customPropertiesWhitelist.',

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -125,3 +125,11 @@ $EZSQL_ERROR = array(); // OK
 
 echo "This is a $comment_ID"; // Bad
 echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.
+
+/*
+ * Unit test whitelisting.
+ */
+// @codingStandardsChangeSetting WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist varName
+echo MyClass::$varName; // Ok, whitelisted.
+echo $this->varName; // Ok, whitelisted.
+echo $object->varName;  // Ok, whitelisted.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -76,7 +76,9 @@ class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends Abstra
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			1 => 1, // Warning about property setting.
+		);
 
 	}
 


### PR DESCRIPTION
Allow for incorrectly set custom properties.

The `customPropertiesWhitelist` and (deprecated) `customVariablesWhitelist` properties should be provided with `type="array"`, but it's an easy mistake to miss that and provide a comma-delimited list instead as the value of the property would be the same.

Along the same lines, setting the property inline for unit testing the property handling will fail as there is no way to pass the `type="array"` part via an inline setting change.

Without the fix in this commit, this would lead to errors that `array_merge()` expects the parameters to be in array format.

* For the `$customPropertiesWhitelist`, a warning will be thrown that the format of the custom property should be corrected.
* If the received value is a string, the format will be corrected. Otherwise the value will be disregarded.
* In the case of the deprecated `$customVariablesWhitelist` property, a warning will be thrown when an incorrect format is encountered and the contents of the property will be disregarded regardless of what was received.

Includes unit tests for the custom property.