### PR TITLE
Don't throw error for syntax errors

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1083,13 +1083,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			$condition    = $this->tokens[ $conditionPtr ];
 
 			if ( ! isset( $condition['parenthesis_opener'] ) ) {
-
-				$this->phpcsFile->addError(
-					'Possible parse error, condition missing open parenthesis.',
-					$conditionPtr,
-					'IsValidatedMissingConditionOpener'
-				);
-
+				// Live coding or parse error.
 				return false;
 			}
 


### PR DESCRIPTION
@JDGrimes Found another one ;-)

This should be left up to the Generic.PHP.Syntax sniff.

See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/770#discussion_r94809371