### PR TITLE
Enhancement: check controlstructure for superfluous whitespace

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -126,7 +126,7 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 		 */
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
-			if ( T_CLOSE_SQUARE_BRACKET === $token['code']  ) {
+			if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
 				$operator = $phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
 			}
 

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -154,7 +154,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 			} elseif ( 1 !== strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] ) && 1 !== $tokens[ ( $stackPtr - 1 ) ]['column'] ) {
 				// Don't throw an error for assignments, because other standards allow
 				// multiple spaces there to align multiple assignments.
-				if ( false === in_array( $tokens[ $stackPtr ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true )  ) {
+				if ( false === in_array( $tokens[ $stackPtr ]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens, true ) ) {
 					$found = strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] );
 					$error = 'Expected 1 space before "%s"; %s found';
 					$data  = array(

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -174,3 +174,40 @@ if ( $foo ) {
 
 }
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+
+// Check for too many spaces as long as the next non-blank token is on the same line.
+function test( $blah   ) {} // Bad.
+function(   $bar   ) {}  // Bad.
+
+if (    'abc' === $test ) { // Bad.
+	echo 'hi';
+} elseif ( false === $foo    ) { // Bad.
+	echo 'bye';
+}
+
+do {
+	echo 'hi';
+} while (   $blah ); // Bad.
+
+while ( $blah   ) { // Bad.
+	echo 'bye bye';
+}
+
+for (   $i = 0; $i < 1; $++    ) { // Bad.
+	echo 'hi';
+}
+
+foreach (   $foo as $bar   ) { // Bad.
+	echo 'hi';
+}
+
+if (
+	'abc' === $test
+) { // Ok.
+	echo 'hi';
+} elseif (
+	false === $foo
+	&& true === $bar
+) { // Ok.
+	echo 'bye';
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -169,3 +169,40 @@ if ( $foo ) {
 
 }
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+
+// Check for too many spaces as long as the next non-blank token is on the same line.
+function test( $blah ) {} // Bad.
+function(   $bar ) {}  // Bad.
+
+if ( 'abc' === $test ) { // Bad.
+	echo 'hi';
+} elseif ( false === $foo ) { // Bad.
+	echo 'bye';
+}
+
+do {
+	echo 'hi';
+} while ( $blah ); // Bad.
+
+while ( $blah ) { // Bad.
+	echo 'bye bye';
+}
+
+for ( $i = 0; $i < 1; $++ ) { // Bad.
+	echo 'hi';
+}
+
+foreach ( $foo as $bar ) { // Bad.
+	echo 'hi';
+}
+
+if (
+	'abc' === $test
+) { // Ok.
+	echo 'hi';
+} elseif (
+	false === $foo
+	&& true === $bar
+) { // Ok.
+	echo 'bye';
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -59,6 +59,14 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			137 => 5,
 			144 => 1,
 			152 => 2,
+			179 => 1,
+			180 => 1,
+			182 => 1,
+			184 => 1,
+			190 => 1,
+			192 => 1,
+			196 => 2,
+			200 => 2,
 		);
 
 		/*


### PR DESCRIPTION
While working on #789, I noticed that the control structure whitespace check did check for *no* space after the open parenthesis / before the closing parenthesis, but did **not** check whether this was exactly one space.

This PR fixes that.

Includes unit tests.
Includes fixer.
Includes fixes to the WPCS codebase for issue detected by this check.

Notes:
* For multi-line conditions, the superfluous space check will not be executed. See the last unit test as an example.
* For the space after the open parenthesis, it disregards function declarations as those are already being checked for superfluous spacing after the open parenthesis by the `Squiz.Functions.FunctionDeclarationArgumentSpacing` sniff which is included in the WP Core ruleset.
* For the space before the closing parenthesis, it does not disregards those, as it appears that the `Squiz.Functions.FunctionDeclarationArgumentSpacing` sniff does not check that (might be an upstream bug, but that would need further investigation, in the mean time it will be checked for correctly within WPCS).