### PR TITLE
TimezoneChange: Use the WPCS abstract function call sniff.

### DIFF
--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -7,10 +7,6 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
-	throw new PHP_CodeSniffer_Exception( 'Class Generic_Sniffs_PHP_ForbiddenFunctionsSniff not found' );
-}
-
 /**
  * Disallow the changing of timezone.
  *
@@ -19,38 +15,34 @@ if ( ! class_exists( 'Generic_Sniffs_PHP_ForbiddenFunctionsSniff', true ) ) {
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
+ *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
  */
-class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff {
+class WordPress_Sniffs_VIP_TimezoneChangeSniff extends WordPress_AbstractFunctionRestrictionsSniff {
 
 	/**
-	 * A list of forbidden functions with their alternatives.
+	 * Groups of functions to restrict.
 	 *
-	 * The value is NULL if no alternative exists. IE, the
-	 * function should just not be used.
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
 	 *
-	 * @var array(string => string|null)
+	 * @return array
 	 */
-	public $forbiddenFunctions = array(
-		'date_default_timezone_set' => null,
-	);
-
-	/**
-	 * Generates the error or warning for this sniff.
-	 *
-	 * Overloads parent addError method.
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the forbidden function
-	 *                                        in the token array.
-	 * @param string               $function  The name of the forbidden function.
-	 * @param string               $pattern   The pattern used for the match.
-	 *
-	 * @return void
-	 */
-	protected function addError( $phpcsFile, $stackPtr, $function, $pattern = null ) {
-		$error = 'Using date_default_timezone_set() and similar isn\'t allowed, instead use WP internal timezone support.';
-		$phpcsFile->addError( $error, $stackPtr, $function );
-
-	}
+	public function getGroups() {
+		return array(
+			'timezone_change' => array(
+				'type'      => 'error',
+				'message'   => 'Using %s() and similar isn\'t allowed, instead use WP internal timezone support.',
+				'functions' => array(
+					'date_default_timezone_set',
+				),
+			),
+		);
+	} // End getGroups().
 
 } // End class.


### PR DESCRIPTION
There were three sniffs which still extended the upstream `Generic_Sniffs_PHP_ForbiddenFunctionsSniff` class.
Extending the `WordPress_AbstractFunctionRestrictionsSniff` instead has the following advantages:
* Functions can be provided in groups and the `exclude` property to selectively exclude groups becomes available.
* The sniffs no longer have a `public $forbiddenFunctions` property which could be overruled via the ruleset.
* Once callback checks have been added to the `WordPress_AbstractFunctionRestrictionsSniff`, the sniffs will benefit from the additional detection. (#611)
* If needed at some point, the functions within the `WordPress_Sniff` class are available for use.

This PR addresses the above for the `VIP.TimezoneChange` sniff.

This PR contains no functional changes. The sniff effectively still does the same.

Related to #614