### PR TITLE
Utility: Add `strip_quotes()` utility function & implement use

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -132,16 +132,16 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 
 			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
 			if ( ! is_numeric( $tokens[ $keyIdx ]['content'] ) ) {
-				$key            = trim( $tokens[ $keyIdx ]['content'], '\'"' );
+				$key            = $this->strip_quotes( $tokens[ $keyIdx ]['content'] );
 				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
 				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
-				$val            = trim( $val, '\'"' );
+				$val            = $this->strip_quotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
 		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
 			// $foo = 'bar=taz&other=thing';
-			if ( preg_match_all( '#[\'"&]([a-z_]+)=([^\'"&]*)#i', $token['content'], $matches ) <= 0 ) {
+			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', $this->strip_quotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.
 			}
 			foreach ( $matches[1] as $i => $_k ) {

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -530,6 +530,20 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	}
 
 	/**
+	 * Strip quotes surrounding an arbitrary string.
+	 *
+	 * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $string The raw string.
+	 * @return string String without quotes around it.
+	 */
+	public function strip_quotes( $string ) {
+		return preg_replace( '`^([\'"])(.*)\1$`Ds', '$2', $string );
+	}
+
+	/**
 	 * Get the last pointer in a line.
 	 *
 	 * @since 0.4.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -980,7 +980,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 			// If we're able to resolve the function name, do so.
 			if ( false !== $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
-				$functionName = trim( $this->tokens[ $mapped_function ]['content'], '\'' );
+				$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
 			}
 		}
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -20,8 +20,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
+ * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_NamingConventions_ValidHookNameSniff extends WordPress_Sniff {
 
 	/**
 	 * Additional word separators.
@@ -135,17 +136,17 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff implements PHP_CodeS
 			$expected[ $i ] = $tokens[ $i ]['content'];
 
 			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				$string = $this->strip_quotes( $tokens[ $i ]['content'] );
+
 				/*
 				   Here be dragons - a double quoted string can contain extrapolated variables
 				   which don't have to comply with these rules.
 				 */
 				if ( T_DOUBLE_QUOTED_STRING === $tokens[ $i ]['code'] ) {
-					$string          = trim( $tokens[ $i ]['content'], '"' );
 					$transform       = $this->transform_complex_string( $string, $regex );
 					$case_transform  = $this->transform_complex_string( $string, $regex, 'case' );
 					$punct_transform = $this->transform_complex_string( $string, $regex, 'punctuation' );
 				} else {
-					$string          = trim( $tokens[ $i ]['content'], '\'"' );
 					$transform       = $this->transform( $string, $regex );
 					$case_transform  = $this->transform( $string, $regex, 'case' );
 					$punct_transform = $this->transform( $string, $regex, 'punctuation' );

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -15,8 +15,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -44,7 +45,7 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff implements PHP_CodeSniffer_Sniff
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
-		if ( in_array( trim( $tokens[ $stackPtr ]['content'], '"\'' ), array( 'show_admin_bar' ), true ) ) {
+		if ( in_array( $this->strip_quotes( $tokens[ $stackPtr ]['content'] ), array( 'show_admin_bar' ), true ) ) {
 			$phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
 		}
 	} // End process().

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -15,8 +15,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -44,7 +45,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
-		if ( 'cron_schedules' !== trim( $token['content'], '"\'' ) ) {
+		if ( 'cron_schedules' !== $this->strip_quotes( $token['content'] ) ) {
 			return;
 		}
 
@@ -76,7 +77,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
 
 		// Search for the function in tokens.
 		if ( in_array( $tokens[ $callbackPtr ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
-			$functionName = trim( $tokens[ $callbackPtr ]['content'], '"\'' );
+			$functionName = $this->strip_quotes( $tokens[ $callbackPtr ]['content'] );
 
 			foreach ( $tokens as $ptr => $_token ) {
 				if ( T_STRING === $_token['code'] && $_token['content'] === $functionName ) {
@@ -101,7 +102,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff implements PHP_CodeSniffer_Sniff {
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
 			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
-				if ( 'interval' === trim( $tokens[ $i ]['content'], '\'"' ) ) {
+				if ( 'interval' === $this->strip_quotes( $tokens[ $i ]['content'] ) ) {
 					$operator = $phpcsFile->findNext( T_DOUBLE_ARROW, $i, null, false, null, true );
 					if ( empty( $operator ) ) {
 						$this->confused( $phpcsFile, $stackPtr );

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -308,7 +308,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			$start    = ( $bracketPtr + 1 );
 			for ( $ptr = $start; $ptr < $this->tokens[ $bracketPtr ]['bracket_closer']; $ptr++ ) {
 				if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $ptr ]['code'] ) {
-					$var_name .= trim( $this->tokens[ $ptr ]['content'], '\'"' );
+					$var_name .= $this->strip_quotes( $this->tokens[ $ptr ]['content'] );
 				}
 			}
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -303,7 +303,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( $this->strip_quotes( $content ), $this->text_domain, true ) ) {
 				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( implode( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
@@ -318,7 +318,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			if ( ! empty( $interpolated_variables ) ) {
 				return false;
 			}
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( trim( $content, '\'""' ), $this->text_domain, true ) ) {
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) && ! in_array( $this->strip_quotes( $content ), $this->text_domain, true ) ) {
 				$phpcs_file->$method( 'Mismatch text domain. Expected \'%s\' but got %s.', $stack_ptr, 'TextDomainMismatch', array( implode( "' or '", $this->text_domain ), $content ) );
 				return false;
 			}
@@ -435,7 +435,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		 *
 		 * Strip placeholders and surrounding quotes.
 		 */
-		$non_placeholder_content = trim( $content, "'" );
+		$non_placeholder_content = $this->strip_quotes( $content );
 		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $non_placeholder_content );
 
 		if ( empty( $non_placeholder_content ) ) {

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -312,7 +312,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 						// If we're able to resolve the function name, do so.
 						if ( $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
-							$functionName = trim( $this->tokens[ $mapped_function ]['content'], '\'' );
+							$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
 							$ptr = $mapped_function;
 						}
 					}


### PR DESCRIPTION
 Add `strip_quotes()` utility method to consistently and correctly strip quotes from `T_CONSTANT_ENCAPSED_STRING` / `T_DOUBLE_QUOTED_STRING` strings.

Until now, most often `trim( $var, '\'"' )` was used which might incorrectly strip too much.
Example: `"'my' string"` would become `my' string` (note the extra `'` which was removed) instead of `'my' string`.

This utility function will strip the quotes off correctly.

The second commit implements use of the `strip_quotes()` method where appropriate in the current codebase.