### PR TITLE
I18n: Allow setting the allowed text-domains via the command-line.

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -16,7 +16,10 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
- * @since   0.11.0 Now also checks for translators comments.
+ * @since   0.11.0 - Now also checks for translators comments.
+ *                 - Now has the ability to handle text-domain set via the command-line
+ *                   as a comma-delimited list.
+ *                   `phpcs --runtime-set text_domain my-slug,default`
  */
 class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
@@ -77,15 +80,6 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	public $text_domain;
 
 	/**
-	 * Allow unit tests to override the supplied text_domain.
-	 *
-	 * @todo While it doesn't work, ideally this should be able to be done in \WordPress_Tests_WP_I18nUnitTest::setUp()
-	 *
-	 * @var array|string
-	 */
-	public static $text_domain_override;
-
-	/**
 	 * The I18N functions in use in WP.
 	 *
 	 * @var array <string function name> => <string function type>
@@ -143,9 +137,12 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$tokens = $phpcs_file->getTokens();
 		$token  = $tokens[ $stack_ptr ];
 
-		if ( ! empty( self::$text_domain_override ) ) {
-			$this->text_domain = self::$text_domain_override;
+		// Allow overruling the text_domain set in a ruleset via the command line.
+		$cl_text_domain = trim( PHP_CodeSniffer::getConfigData( 'text_domain' ) );
+		if ( ! empty( $cl_text_domain ) ) {
+			$this->text_domain = $cl_text_domain;
 		}
+
 		if ( is_string( $this->text_domain ) ) {
 			$this->text_domain = array_filter( array_map( 'trim', explode( ',', $this->text_domain ) ) );
 		}

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -16,12 +16,11 @@
 class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 
 	/**
-	 * Fill in the $text_domain_override property to test domain check functionality.
+	 * Fill in the $text_domain property to test domain check functionality.
 	 */
 	protected function setUp() {
-		// @todo Should be possible via self::$phpcs->setSniffProperty( 'WordPress_Sniffs_WP_I18nSniff', 'text_domain', 'my-slug' );
-		WordPress_Sniffs_WP_I18nSniff::$text_domain_override = array( 'my-slug', 'default' );
 		parent::setUp();
+		PHP_CodeSniffer::setConfigData( 'text_domain', 'my-slug,default', true );
 	}
 
 	/**


### PR DESCRIPTION
For people who work on a lot of WP projects and want to use a generic custom ruleset, setting the `text_domain` property in the ruleset would mean they would either need to have - yet another - custom ruleset in each project or they would need to manually edit the ruleset each time they would run PHPCS.
Think: theme/plugin reviewers.

With that in mind, adding the ability to set the `$text_domain` property from the command-line as well, seemed a logical next step.

Inspired by a remark made by @grappler.

To use this from the command-line:
`phpcs -p . --standard=WordPress --runtime-set text_domain my-slug,default`

Notes:
* The command line property is to be provided as a comma-delimited list without spaces in it.
* The value passed via the command-line will **overrule** any value already set in a custom ruleset.
* As this feature can also be used for the unit tests, removed the unit test specific static `$text_domain_override` property from the sniff class and changed the unit test code to use the command line property instead.