### PR TITLE
Extra: Add Squiz.PHP.DisallowSizeFunctionsInLoops sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -24,6 +24,10 @@
 	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
 	<rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
 
+	<!-- And even more generic PHP best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/809 -->
+	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops" />
+
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
 	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->


### PR DESCRIPTION
This sniff will forbid the use of size functions in loops as it's highly inefficient.

So code like the below would be flagged:
```php
for( $i = 0; $i < count( $something ); $i++ ) {}
```

And this code would be fine:
```php
$max = count( $something );
for( $i = 0; $i < $max; $i++ ) {}
```