### PR TITLE
Core: also check closure braces for being on the same line as the function opener

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -134,7 +134,11 @@
 		<rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
 
 		<!-- Covers rule: Define a function like so: function my_function( $param1 = 'foo', $param2 = 'bar' ) { -->
-		<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
+		<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+			<properties>
+				<property name="checkClosures" value="true" />
+			</properties>
+		</rule>
 		<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
 			<properties>
 				<property name="equalsSpacing" value="1" />


### PR DESCRIPTION
Related to #764