### PR TITLE
Introduce new `string_to_errorcode()` utility method and implement where applicable.

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -189,7 +189,7 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 						$addWhat,
 						$message,
 						$stackPtr,
-						$groupName,
+						$this->string_to_errorcode( $groupName . '_' . $key ),
 						array( $key, $val )
 					);
 				}

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -254,7 +254,7 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			$addWhat,
 			$this->groups[ $group_name ]['message'],
 			$stackPtr,
-			$group_name,
+			$this->string_to_errorcode( $group_name . '_' . $matched_content ),
 			array( $matched_content )
 		);
 	} // End process_matched_token().

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -17,8 +17,9 @@
  *                 Moved the file and renamed the class from
  *                 `WordPress_Sniffs_Variables_VariableRestrictionsSniff` to
  *                 `WordPress_AbstractVariableRestrictionsSniff`.
+ * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-abstract class WordPress_AbstractVariableRestrictionsSniff implements PHP_CodeSniffer_Sniff {
+abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sniff {
 
 	/**
 	 * Exclude groups.
@@ -175,7 +176,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff implements PHP_CodeSn
 				$addWhat,
 				$group['message'],
 				$stackPtr,
-				$groupName,
+				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
 				array( $var )
 			);
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -544,6 +544,21 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	}
 
 	/**
+	 * Convert an arbitrary string to an alphanumeric string with underscores.
+	 *
+	 * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $base_string Arbitrary string.
+	 *
+	 * @return string
+	 */
+	protected function string_to_errorcode( $base_string ) {
+		return preg_replace( '`[^a-z0-9_]`i', '_', strtolower( $base_string ) );
+	}
+
+	/**
 	 * Get the last pointer in a line.
 	 *
 	 * @since 0.4.0

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1132,11 +1132,12 @@ class WordPress_Sniffs_WP_DeprecatedFunctionsSniff extends WordPress_AbstractFun
 			$message .= ' Use %s instead.';
 			$data[]   = $this->deprecated_functions[ $function_name ]['alt'];
 		}
+		$error_code = $this->string_to_errorcode( $matched_content . 'Found' );
 
 		if ( version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_supported_version, '>=' ) ) {
-			$this->phpcsFile->addWarning( $message, $stackPtr, $matched_content . 'Found', $data );
+			$this->phpcsFile->addWarning( $message, $stackPtr, $error_code, $data );
 		} else {
-			$this->phpcsFile->addError( $message, $stackPtr, $matched_content . 'Found', $data );
+			$this->phpcsFile->addError( $message, $stackPtr, $error_code, $data );
 		}
 
 	} // End process_matched_token().

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -279,7 +279,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$content   = $tokens[0]['content'];
 
 		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
-			$code = 'MissingArg' . ucfirst( $arg_name );
+			$code = $this->string_to_errorcode( 'MissingArg' . ucfirst( $arg_name ) );
 			if ( 'domain' !== $arg_name || ! empty( $this->text_domain ) ) {
 				$phpcs_file->$method( 'Missing $%s arg.', $stack_ptr, $code, array( $arg_name ) );
 			}
@@ -290,7 +290,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			foreach ( $tokens as $token ) {
 				$contents .= $token['content'];
 			}
-			$code = 'NonSingularStringLiteral' . ucfirst( $arg_name );
+			$code = $this->string_to_errorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
 			$phpcs_file->$method( 'The $%s arg must be a single string literal, not "%s".', $stack_ptr, $code, array( $arg_name, $contents ) );
 			return false;
 		}
@@ -309,7 +309,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		if ( T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] ) {
 			$interpolated_variables = $this->get_interpolated_variables( $content );
 			foreach ( $interpolated_variables as $interpolated_variable ) {
-				$code = 'InterpolatedVariable' . ucfirst( $arg_name );
+				$code = $this->string_to_errorcode( 'InterpolatedVariable' . ucfirst( $arg_name ) );
 				$phpcs_file->$method( 'The $%s arg must not contain interpolated variables. Found "$%s".', $stack_ptr, $code, array( $arg_name, $interpolated_variable ) );
 			}
 			if ( ! empty( $interpolated_variables ) ) {
@@ -322,7 +322,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			return true;
 		}
 
-		$code = 'NonSingularStringLiteral' . ucfirst( $arg_name );
+		$code = $this->string_to_errorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
 		$phpcs_file->$method( 'The $%s arg should be single a string literal, not "%s".', $stack_ptr, $code, array( $arg_name, $content ) );
 		return false;
 	}
@@ -384,7 +384,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$all_matches_count       = preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $content, $all_matches );
 
 		if ( $unordered_matches_count > 0 && $unordered_matches_count !== $all_matches_count && $all_matches_count > 1 ) {
-			$code = 'MixedOrderedPlaceholders' . ucfirst( $arg_name );
+			$code = $this->string_to_errorcode( 'MixedOrderedPlaceholders' . ucfirst( $arg_name ) );
 			$phpcs_file->addError(
 				'Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.',
 				$stack_ptr,
@@ -393,7 +393,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			);
 
 		} elseif ( $unordered_matches_count >= 2 ) {
-			$code = 'UnorderedPlaceholders' . ucfirst( $arg_name );
+			$code = $this->string_to_errorcode( 'UnorderedPlaceholders' . ucfirst( $arg_name ) );
 
 			$suggestions     = array();
 			$replace_regexes = array();


### PR DESCRIPTION
Introduce new `string_to_errorcode()` utility method and implement where applicable.

This PR addresses two distinct but closely related issues.

#### 1. Errorcodes should be limited to certain characters for them to be safely usable both in XML ruleset files as well as on the command line.

This PR introduces a new `string_to_errorcode()` method to be used for dynamic errorcodes using arbitrary strings which will convert any non-valid characters to underscores.

This PR also implements the usage of this function for all `addError()`/`addWarning` calls which warrant it.

#### 2. Unique/dynamic sniffcodes

The sniffs which are based on the abstract classes all provide the public `exclude` property to selectively exclude a certain group from the checks the sniff executes.
The sniffcode, however, was also based on the group.
So while there were two different ways to disable the messages about a certain group (`<property name="exclude" ...>`, `<exclude name=... sniffcode>`), there was no possible way to leave a group *en*abled and only disable the message about one individual item (function/variable/etc) within that group.

This PR fixes that.

As groups could already be disabled using the `exclude` property, the errorcode will now refer to the individual item to allow for disabling the messages about one item in a group.

This PR breaks backward-compatibility, though the break will probably only affect a relatively small number of users which use heavily customized custom rulesets.

Also, with the merge of #633, BC was broken anyway for most sniffs this PR affects, so merging this in the same release as in which #633 is contained will ensure that users will only have to update their rulesets once for these changes.

The BC break of #633 is that groups of functions have been moved around to new sniffs, so `<exclude name=...>` and `<property name="exclude" ...>` directives in rulesets would no longer work as expected as they would now need to reference another sniff.

The BC break in this PR affects only the `<exclude name=...>` directives which use errorcodes - in contrast to sniff names - as the errorcodes will change. 

This change affects the errorcodes for the following sniffs:
* `WordPress.DB.RestrictedClasses`
* `WordPress.DB.RestrictedFunctions`
* `WordPress.Functions.DontExtract`
* `WordPress.PHP.DevelopmentFunctions`
* `WordPress.PHP.DiscouragedPHPFunctions`
* `WordPress.PHP.POSIXFunctions`
* `WordPress.PHP.RestrictedFunctions`
* `WordPress.VIP.FileSystemWritesDisallow`
* `WordPress.VIP.OrderByRand`
* `WordPress.VIP.PostsPerPage`
* `WordPress.VIP.RestrictedFunctions`
* `WordPress.VIP.RestrictedVariables`
* `WordPress.VIP.SessionFunctionsUsage`
* `WordPress.VIP.SlowDBQuery`
* `WordPress.VIP.TimezoneChange`
* `WordPress.WP.AlternativeFunctions`
* `WordPress.WP.DiscouragedFunctions`