### PR TITLE
Add function call parameter related utility functions and abstract class

### DIFF
--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -29,8 +29,9 @@ abstract class WordPress_AbstractFunctionParameterSniff extends WordPress_Abstra
 	 * Functions this sniff is looking for. Should be defined in the child class.
 	 *
 	 * @var array The only requirement for this array is that the top level
-	 * array keys are the names of the functions you're looking for.
-	 * Other than that, the array can have arbitrary content depending on your needs.
+	 *            array keys are the names of the functions you're looking for.
+	 *            Other than that, the array can have arbitrary content
+	 *            depending on your needs.
 	 */
 	protected $target_functions = array();
 

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Advises about parameters used in function calls.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ */
+abstract class WordPress_AbstractFunctionParameterSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * Intended to be overruled in the child class.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'restricted_parameters';
+
+	/**
+	 * Functions this sniff is looking for. Should be defined in the child class.
+	 *
+	 * @var array The only requirement for this array is that the top level
+	 * array keys are the names of the functions you're looking for.
+	 * Other than that, the array can have arbitrary content depending on your needs.
+	 */
+	protected $target_functions = array();
+
+	/**
+	 * Groups of function to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		if ( empty( $this->target_functions ) ) {
+			return array();
+		}
+
+		return array(
+			$this->group_name => array(
+				'functions' => array_keys( $this->target_functions ),
+			),
+		);
+	}
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$parameters = $this->get_function_call_parameters( $stackPtr );
+
+		if ( empty( $parameters ) ) {
+			$this->process_no_parameters( $stackPtr, $group_name, $matched_content );
+		} else {
+			$this->process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+		}
+	}
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * This method has to be made concrete in child classes.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	abstract public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * Default to doing nothing. Can be overloaded in child classes to handle functions
+	 * were parameters are expected, but none found.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+		return;
+	}
+
+} // End class.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1391,10 +1391,6 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * Expects to be passed the T_STRING stack pointer for the function call.
 	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
 	 *
-	 * Will return an multi-dimentional array with the start token pointer, end token
-	 * pointer and raw parameter value for all parameters. Index will be 1-based.
-	 * If no parameters are found, will return an empty array.
-	 *
 	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
 	 * it will tokenize the values / key/value pairs contained in the array call.
 	 *
@@ -1402,7 +1398,14 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @param int $stackPtr The position of the function call token.
 	 *
-	 * @return array
+	 * @return array Multi-dimentional array with parameter details or
+	 *               empty array if no parameter are found.
+	 *
+	 *               @type int $position 1-based index position of the parameter. {
+	 *                   @type int $start Stack pointer for the start of the parameter.
+	 *                   @type int $end   Stack pointer for the end of parameter.
+	 *                   @type int $raw   Trimmed raw parameter content.
+	 *               }
 	 */
 	public function get_function_call_parameters( $stackPtr ) {
 		if ( false === $this->does_function_call_have_parameters( $stackPtr ) ) {

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -18,8 +18,18 @@
  * @since   0.10.0 This sniff not only checks for `in_array()`, but also `array_search()` and `array_keys()`.
  *                 The sniff no longer needlessly extends the WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
  *                 which it didn't use.
+ * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
  */
-class WordPress_Sniffs_PHP_StrictInArraySniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'strict';
 
 	/**
 	 * List of array functions to which a $strict parameter can be passed.
@@ -34,98 +44,61 @@ class WordPress_Sniffs_PHP_StrictInArraySniff implements PHP_CodeSniffer_Sniff {
 	 * @link http://php.net/array-keys
 	 *
 	 * @since 0.10.0
+	 * @since 0.11.0 Renamed from $array_functions to $target_functions.
 	 *
 	 * @var array <string function_name> => <bool always needed ?>
 	 */
-	protected $array_functions = array(
+	protected $target_functions = array(
 		'in_array'     => true,
 		'array_search' => true,
 		'array_keys'   => false,
 	);
 
 	/**
-	 * Returns an array of tokens this test wants to listen for.
+	 * Process the parameters of a matched function.
 	 *
-	 * @return array
-	 */
-	public function register() {
-		return array(
-			T_STRING
-		);
-	}
-
-	/**
-	 * Processes this test, when one of its tokens is encountered.
+	 * @since 0.11.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-		$token  = strtolower( $tokens[ $stackPtr ]['content'] );
-
-		// Bail out if not one of the targetted functions.
-		if ( ! isset( $this->array_functions[ $token ] ) ) {
-			return;
-		}
-
-		if ( ! isset( $tokens[ ( $stackPtr - 1 ) ] ) ) {
-			return;
-		}
-
-		$prev = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
-
-		if ( false !== $prev ) {
-			// Skip sniffing if calling a same-named method, or on function definitions.
-			if ( in_array( $tokens[ $prev ]['code'], array( T_FUNCTION, T_DOUBLE_COLON, T_OBJECT_OPERATOR ), true ) ) {
-				return;
-			}
-
-			// Skip namespaced functions, ie: \foo\bar() not \bar().
-			$pprev = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $prev - 1 ), null, true );
-			if ( false !== $pprev && T_NS_SEPARATOR === $tokens[ $prev ]['code'] && T_STRING === $tokens[ $pprev ]['code'] ) {
-				return;
-			}
-		}
-		unset( $prev, $pprev );
-
-		// Get the closing parenthesis.
-		$openParenthesis = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $stackPtr + 1 ) );
-		if ( false === $openParenthesis ) {
-			return;
-		}
-
-		// Gracefully handle syntax error.
-		if ( ! isset( $tokens[ $openParenthesis ]['parenthesis_closer'] ) ) {
-			return;
-		}
-
-		// Get last token in the function call.
-		$closeParenthesis = $tokens[ $openParenthesis ]['parenthesis_closer'];
-		$lastToken        = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $closeParenthesis - 1 ), ( $openParenthesis + 1 ), true );
-
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		// Check if the strict check is actually needed.
-		if ( false === $this->array_functions[ $token ] ) {
-			$hasComma = $phpcsFile->findPrevious( T_COMMA, ( $closeParenthesis - 1 ), ( $openParenthesis + 1 ) );
-			if ( false === $hasComma || end( $tokens[ $hasComma ]['nested_parenthesis'] ) !== $closeParenthesis ) {
+		if ( false === $this->target_functions[ $matched_content ] ) {
+			if ( count( $parameters ) === 1 ) {
 				return;
 			}
 		}
 
-		$errorData = array( $token );
-
-		if ( false === $lastToken ) {
-			$phpcsFile->addError( 'Missing arguments to %s.', $openParenthesis, 'MissingArguments', $errorData );
+		// We're only interested in the third parameter.
+		if ( false === isset( $parameters[3] ) || 'true' !== $parameters[3]['raw'] ) {
+			$this->phpcsFile->addWarning(
+				'Not using strict comparison for %s; supply true for third argument.',
+				( isset( $parameters[3]['start'] ) ? $parameters[3]['start'] : $parameters[1]['start'] ),
+				'MissingTrueStrict',
+				array( $matched_content )
+			);
 			return;
 		}
+	}
 
-		if ( T_TRUE !== $tokens[ $lastToken ]['code'] ) {
-			$phpcsFile->addWarning( 'Not using strict comparison for %s; supply true for third argument.', $lastToken, 'MissingTrueStrict', $errorData );
-			return;
-		}
-	} // End process().
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+		$this->phpcsFile->addError( 'Missing arguments to %s.', $stackPtr, 'MissingArguments', array( $matched_content ) );
+	}
 
 } // End class.

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -15,74 +15,68 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
  */
-class WordPress_Sniffs_VIP_PluginMenuSlugSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_VIP_PluginMenuSlugSniff extends WordPress_AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'add_menu_functions';
 
 	/**
 	 * Functions which can be used to add pages to the WP Admin menu.
 	 *
-	 * @var array
+	 * @since 0.3.0
+	 * @since 0.11.0 Renamed from $add_menu_functions to $target_functions
+	 *               and changed visibility to protected.
+	 *
+	 * @var array <string function name> => <array target parameter positions>
 	 */
-	public $add_menu_functions = array(
-		'add_menu_page',
-		'add_object_page',
-		'add_utility_page',
-		'add_submenu_page',
-		'add_dashboard_page',
-		'add_posts_page',
-		'add_media_page',
-		'add_links_page',
-		'add_pages_page',
-		'add_comments_page',
-		'add_theme_page',
-		'add_plugins_page',
-		'add_users_page',
-		'add_management_page',
-		'add_options_page',
+	protected $target_functions = array(
+		'add_menu_page'       => array( 4 ),
+		'add_object_page'     => array( 4 ),
+		'add_utility_page'    => array( 4 ),
+		'add_submenu_page'    => array( 1, 5 ),
+		'add_dashboard_page'  => array( 4 ),
+		'add_posts_page'      => array( 4 ),
+		'add_media_page'      => array( 4 ),
+		'add_links_page'      => array( 4 ),
+		'add_pages_page'      => array( 4 ),
+		'add_comments_page'   => array( 4 ),
+		'add_theme_page'      => array( 4 ),
+		'add_plugins_page'    => array( 4 ),
+		'add_users_page'      => array( 4 ),
+		'add_management_page' => array( 4 ),
+		'add_options_page'    => array( 4 ),
 	);
 
 	/**
-	 * Returns an array of tokens this test wants to listen for.
+	 * Process the parameters of a matched function.
 	 *
-	 * @return array
-	 */
-	public function register() {
-		return array(
-			T_STRING,
-		);
-
-	}
-
-	/**
-	 * Processes this test, when one of its tokens is encountered.
+	 * @since 0.11.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		foreach ( $this->target_functions[ $matched_content ] as $position ) {
+			if ( isset( $parameters[ $position ] ) ) {
+				$file_constant = $this->phpcsFile->findNext( T_FILE, $parameters[ $position ]['start'], ( $parameters[ $position ]['end'] + 1 ) );
 
-		if ( ! in_array( $token['content'], $this->add_menu_functions, true ) ) {
-			return;
+				if ( false !== $file_constant ) {
+					$this->phpcsFile->addError( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
+				}
+			}
 		}
-
-		$opening = $phpcsFile->findNext( T_OPEN_PARENTHESIS, $stackPtr );
-		if ( false === $opening ) {
-			return;
-		}
-
-		$closing = $tokens[ $opening ]['parenthesis_closer'];
-
-		$string = $phpcsFile->findNext( T_FILE, $opening, $closing, false, '__FILE__', true );
-
-		if ( false !== $string ) {
-			$phpcsFile->addError( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
-		}
-
 	}
 
 } // End class.

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.inc
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.inc
@@ -5,3 +5,10 @@ add_menu_page( $page_title, $menu_title, $capability, __FILE__, $function, $icon
 add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Bad.
 
 add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, 'awesome-submenu-page', $function ); // Ok.
+
+add_submenu_page( __FILE__ . 'parent', $page_title, $menu_title, $capability, __FILE__, $function ); // Bad x 2.
+
+// These are all ok: not calling the WP core function.
+$my_class->add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.
+Some_Class::add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.
+\My_Namespace\add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -22,8 +22,10 @@ class WordPress_Tests_VIP_PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			3 => 1,
-			5 => 1,
+			3  => 1,
+			5  => 1,
+			9  => 2,
+			14 => ( PHP_VERSION_ID < 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize T_NS_SEPARATOR.
 		);
 
 	}


### PR DESCRIPTION
Now #795 has been merged, it was possible to create an abstract function parameter class which builds upon the logic for determining function calls already contained in `WordPress_AbstractFunctionRestrictionsSniff`.

This PR introduces the abstract and a number of related utility functions.

### Utility functions

I initially introduced these utility functions in the [PHPCompatibility](https://github.com/wimg/PHPCompatibility) standard were they are also [individually unit tested](https://github.com/wimg/PHPCompatibility/tree/master/Tests/BaseClass).
They have been in use there for a number of months and proven useful & accurate.

The functions are:
* `does_function_call_have_parameters( $stackPtr )` - returns bool
* `get_function_call_parameter_count( $stackPtr )` - returns int
* `get_function_call_parameters( $stackPtr )`  - returns array, key: 1-indexed parameter position, value: array with `start` - int stack pointer of param start position, `end` - int stack pointer of param end position and `raw` - trimmed raw content for the passed parameter
* `get_function_call_parameter( $stackPtr, $param_offset )` - returns array or false if no parameter was found at the specified offset

The functions expect to be passed a `T_STRING` stack pointer to a function call.

And while the function name might not indicate this, each of these functions can also be used with array stack pointers (`T_ARRAY`, `T_OPEN_SHORT_ARRAY`). This is a feature which was introduced after the initial naming & merge of the functions and the function documentation reflects this.

It is my intention to introduce these functions upstream in PHPCS itself at some point in the future.

### New `WordPress_AbstractFunctionParameterSniff` class

The new `WordPress_AbstractFunctionParameterSniff` extends the `WordPress_AbstractFunctionRestrictionsSniff` class for the yes/no function call determination, retrieves the parameters used by the targetted function call using the new utility functions and then passes processing on to the child class.

The child class is expected to implement a `process_parameters()` method to handle the actual testing of parameters.

Optionally a `process_no_parameters()` method can be added to the child class to handle cases where parameters are expected, but not found.

The abstract expects a `$target_functions` array, but is without opinion about how that array should look, except for the requirement that the top level array keys are the function names.
Further requirements of the array are not needed as the processing of the parameters is done in the child class, allowing for great flexibility in potential use of this class.

### Start using the abstract

As a last step - and to prove that the same functionality is maintained, and in some cases improved by the new abstract - I've refactored three existing sniffs which were prime candidates (duplicate logic and such) to start using the new `WordPress_AbstractFunctionParameterSniff`.

Fixes #745