### PR TITLE
Accuracy: always pass the delimiter to `preg_quote()` if not using `/`.

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -623,7 +623,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// Now let's see if the comment contains the whitelist remark we're looking for.
-		return ( preg_match( '#' . preg_quote( $comment ) . '#i', $last['content'] ) === 1 );
+		return ( preg_match( '#' . preg_quote( $comment, '#' ) . '#i', $last['content'] ) === 1 );
 	}
 
 	/**


### PR DESCRIPTION
Reviewed usage of the `preg_quote()` function which should always be passed the delimiter if not using `/` to make sure the correct characters are being escaped.