### PR TITLE
AdminBarRemoval: More thorough checking for admin bar removal and hiding

### DIFF
--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -17,6 +17,7 @@
  * @since   0.3.0
  * @since   0.11.0 - Extends the WordPress_AbstractFunctionParameterSniff class.
  *                 - Added the $remove_only property.
+ *                 - Now also sniffs for manipulation of the admin bar visibility through CSS.
  */
 class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFunctionParameterSniff {
 
@@ -45,6 +46,80 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 		'show_admin_bar' => true,
 		'add_filter'     => true,
 	);
+
+	/**
+	 * CSS properties this sniff is looking for.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $target_css_properties = array(
+		'visibility' => array(
+			'type'  => '!=',
+			'value' => 'hidden',
+		),
+		'display' => array(
+			'type'  => '!=',
+			'value' => 'none',
+		),
+		'opacity' => array(
+			'type'  => '>',
+			'value' => 0.3,
+		),
+	);
+
+	/**
+	 * CSS selectors this sniff is looking for.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $target_css_selectors = array(
+		'.show-admin-bar',
+		'#wpadminbar',
+	);
+
+	/**
+	 * String tokens within PHP files we want to deal with.
+	 *
+	 * Set from the register() method.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $string_tokens = array();
+
+	/**
+	 * Regex template for use with the CSS selectors in combination with PHP text strings.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	private $target_css_selectors_regex = '`(?:%s).*?\{(.*)$`';
+
+	/**
+	 * Property to keep track of whether a <style> open tag has been encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $in_style;
+
+	/**
+	 * Property to keep track of whether a one of the target selectors has been encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $in_target_selector;
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -52,6 +127,15 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 	public function register() {
 		// Set up all string targets.
 		$targets                  = PHP_CodeSniffer_Tokens::$stringTokens;
+		$targets[ T_INLINE_HTML ] = T_INLINE_HTML;
+		$targets[ T_HEREDOC ]     = T_HEREDOC;
+		$targets[ T_NOWDOC ]      = T_NOWDOC;
+
+		$this->string_tokens = $targets;
+
+		// Set the target selectors regex only once.
+		$selectors = array_map( 'preg_quote', $this->target_css_selectors, array_fill( 0, count( $this->target_css_selectors ), '`' ) );
+		$this->target_css_selectors_regex = sprintf( $this->target_css_selectors_regex, implode( '|', $selectors ) );
 
 		// Add function call targets.
 		$parent = parent::register();
@@ -62,6 +146,38 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 		return $targets;
 	}
 
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$this->init( $phpcsFile );
+
+		$file_name      = $phpcsFile->getFileName();
+		if ( isset( $this->string_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+			/*
+			 * Set $in_style && $in_target_selector to false if it is the first time
+			 * this sniff is run on a file.
+			 */
+			if ( ! isset( $this->in_style[ $file_name ] ) ) {
+				$this->in_style[ $file_name ] = false;
+			}
+			if ( ! isset( $this->in_target_selector[ $file_name ] ) ) {
+				$this->in_target_selector[ $file_name ] = false;
+			}
+
+			$this->process_text_for_style( $stackPtr, $file_name );
+
+		} else {
+			parent::process( $phpcsFile, $stackPtr );
+		}
+
+	} // End process().
 
 	/**
 	 * Process the parameters of a matched function.
@@ -110,4 +226,129 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 			$this->phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
 		}
 	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr  The position of the current token in the stack.
+	 * @param string $file_name The file name of the current file being processed.
+	 *
+	 * @return void
+	 */
+	public function process_text_for_style( $stackPtr, $file_name ) {
+		$content = trim( $this->tokens[ $stackPtr ]['content'] );
+
+		// No need to check an empty string.
+		if ( '' === $content ) {
+			return;
+		}
+
+		// Are we in a <style> tag ?
+		if ( true === $this->in_style[ $file_name ] ) {
+			if ( false !== strpos( $content, '</style>' ) ) {
+				// Make sure we check any content on this line before the closing style tag.
+				$this->in_style[ $file_name ] = false;
+				$content                      = trim( substr( $content, 0, strpos( $content, '</style>' ) ) );
+			}
+		} elseif ( true === $this->has_html_open_tag( 'style', $stackPtr, $content ) ) {
+			// Ok, found a <style> open tag.
+			if ( false === strpos( $content, '</style>' ) ) {
+				// Make sure we check any content on this line after the opening style tag.
+				$this->in_style[ $file_name ] = true;
+				$content                      = trim( substr( $content, ( strpos( $content, '<style' ) + 6 ) ) );
+			} else {
+				// Ok, we have open and close style tag on the same line with possibly content within.
+				$start   = ( strpos( $content, '<style' ) + 6 );
+				$end     = strpos( $content, '</style>' );
+				$content = trim( substr( $content, $start, ( $end - $start ) ) );
+				unset( $start, $end );
+			}
+		} else {
+			return;
+		}
+
+		// Are we in one of the target selectors ?
+		if ( true === $this->in_target_selector[ $file_name ] ) {
+			if ( false !== strpos( $content, '}' ) ) {
+				// Make sure we check any content on this line before the selector closing brace.
+				$this->in_target_selector[ $file_name ] = false;
+				$content                                = trim( substr( $content, 0, strpos( $content, '}' ) ) );
+			}
+		} elseif ( preg_match( $this->target_css_selectors_regex, $content, $matches ) > 0 ) {
+			// Ok, found a new target selector.
+			$content = '';
+
+			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
+				if ( false === strpos( $matches[1], '}' ) ) {
+					// Make sure we check any content on this line before the closing brace.
+					$this->in_target_selector[ $file_name ] = true;
+					$content                                = trim( $matches[1] );
+				} else {
+					// Ok, we have the selector open and close brace on the same line.
+					$content = trim( substr( $matches[1], 0, strpos( $matches[1], '}' ) ) );
+				}
+			} else {
+				$this->in_target_selector[ $file_name ] = true;
+			}
+		} else {
+			return;
+		}
+		unset( $matches );
+
+		// Now let's do the check for the CSS properties.
+		if ( ! empty( $content ) ) {
+			foreach ( $this->target_css_properties as $property => $requirements ) {
+				if ( false !== strpos( $content, $property ) ) {
+					$error = true;
+
+					if ( true === $this->remove_only ) {
+						// Check the value of the CSS property.
+						if ( preg_match( '`' . preg_quote( $property, '`' ) . '\s*:\s*(.+?)\s*(?:!important)?;`', $content, $matches ) > 0 ) {
+							$value = trim( $matches[1] );
+							$valid = $this->validate_css_property_value( $value, $requirements['type'], $requirements['value'] );
+							if ( true === $valid ) {
+								$error = false;
+							}
+						}
+					}
+
+					if ( true === $error ) {
+						$this->phpcsFile->addError( 'Hiding of the admin bar is not allowed.', $stackPtr, 'HidingDetected' );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Verify if a CSS property value complies with an expected value.
+	 *
+	 * {@internal This is a method stub, doing only what is needed for this sniff.
+	 * If at some point in the future other sniff would need similar functionality,
+	 * this method should be moved to the WordPress_Sniff class and expanded to cover
+	 * all types of comparisons.}}
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param mixed  $value         The value of CSS property.
+	 * @param string $compare_type  The type of comparison to use for the validation.
+	 * @param string $compare_value The value to compare against.
+	 *
+	 * @return bool True if the property value complies, false otherwise.
+	 */
+	protected function validate_css_property_value( $value, $compare_type, $compare_value ) {
+		switch ( $compare_type ) {
+			case '!=':
+				return $value !== $compare_value;
+
+			case '>':
+				return $value > $compare_value;
+
+			default:
+				return false;
+		}
+	}
+
 } // End class.

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.css
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.css
@@ -1,0 +1,55 @@
+#wpadminbar {
+	display: block; /* OK. */
+	visibility: visible; /* OK. */
+	opacity: 1; /* OK. */
+	color: red; /* OK. */
+}
+
+#not-wpadminbar {
+	display: none; /* OK. */
+	visibility: hidden; /* OK. */
+	opacity: 0; /* OK. */
+}
+
+#wpadminbar {
+	display: none; /* Bad. */
+	visibility: hidden; /* Bad. */
+	opacity: 0; /* Bad. */
+}
+
+/* With !important. */
+#wpadminbar {
+	display: none !important; /* Bad. */
+	visibility: hidden !important; /* Bad. */
+	opacity: 0.0 !important; /* Bad. */
+}
+
+/* Indented. */
+	.show-admin-bar {
+		visibility: hidden; /* Bad. */
+		display: none !important; /* Bad. */
+		opacity: 0; /* Bad. */
+	}
+	
+/* Multi-line selector. */
+.something-else,
+.show-admin-bar,
+#identifier {
+	visibility: hidden; /* Bad. */
+	display: none !important; /* Bad. */
+	opacity: 0; /* Bad. */
+}
+
+
+/* @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only false */
+#wpadminbar {
+	display: block; /* Bad. */
+	visibility: visible; /* Bad. */
+	opacity: 1; /* Bad. */
+}
+#not-wpadminbar {
+	display: none; /* OK. */
+	visibility: hidden; /* OK. */
+	opacity: 0; /* OK. */
+}
+/* @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only true */

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.inc
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.inc
@@ -1,5 +1,108 @@
 <?php
 
-add_filter( 'show_admin_bar', '__return_false' );
+add_filter( 'show_admin_bar', '__return_false' ); // Bad.
+add_filter( 'show_admin_bar', '__return_true' ); // Ok.
 
-show_admin_bar( false );
+show_admin_bar( false ); // Bad.
+show_admin_bar( true ); // Ok.
+
+add_filter( 'show_admin_bar', 'my_own_return_false' ); // Bad.
+
+// @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only false
+add_filter( 'show_admin_bar', '__return_true' ); // Bad.
+show_admin_bar( true ); // Bad.
+// @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only true
+
+// Testing T_CONSTANT_ENCAPSED_STRING.
+echo '<style type="text/css">
+#wpadminbar {
+	visibility: hidden; /* Bad. */
+	display: none; /* Bad. */
+	opacity: 0; /* Bad. */
+}
+</style>';
+
+// Various text before/after combinations.
+echo '<style type="text/css">.show-admin-bar { visibility: hidden; }</style>'; // Bad.
+
+echo 'Some text about .show-admin-bar before a style tag <style type="text/css">.nothing-here { display: ' . 'none' . '; }</style>'; // Ok.
+echo '<style type="text/css">.nothing-here { display: ' . 'none' . '; }</style>Some text about .show-admin-bar after a style tag'; // Ok.
+
+echo '<style type="text/css">';
+echo '.show-admin-bar { visibility: hidden; }'; // Bad.
+echo '</style>';
+
+// Testing T_DOUBLE_QUOTED_STRING.
+echo "
+<style type=\"text/css\">
+	.show-admin-bar {
+		visibility: $hidden; /* Ok, value not 'hidden'. */
+	}
+</style>";
+
+// Testing T_HEREDOC.
+$style = <<<EOT
+<style type="text/css">
+	.show-admin-bar {
+		visibility: $hidden; /* Ok, value not 'hidden'. */
+	}
+</style>
+EOT;
+
+// Testing T_NOWDOC.
+$style = <<<'EOT'
+<style type="text/css">
+	.show-admin-bar {
+		visibility: hidden; /* Bad. */
+		display: none; /* Bad. */
+		opacity: 0; /* Bad. */
+	}
+</style>
+EOT;
+
+// Testing T_INLINE_HTML
+?>
+
+<style type="text/css">
+#wpadminbar {
+	visibility: hidden; /* Bad. */
+	display: none; /* Bad. */
+	opacity: 0; /* Bad. */
+}
+#not-wpadminbar {
+	visibility: hidden; /* OK. */
+	display: none; /* OK. */
+	opacity: 0; /* OK. */
+}
+</style>
+
+<style type="text/css">
+	.show-admin-bar {
+		visibility: hidden; /* Bad. */
+		display: none; /* Bad. */
+		opacity: 0; /* Bad. */
+	}
+</style>
+
+<?php
+// @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only false
+$style = <<<EOT
+<style type="text/css">
+	.show-admin-bar {
+		visibility: $hidden; /* Bad. */
+	}
+	.my-admin-bar {
+		visibility: $hidden; /* OK. */
+	}
+</style>
+EOT;
+?>
+
+<style type="text/css">
+	.show-admin-bar {
+		visibility: visible; /* Bad. */
+		display: block; /* Bad. */
+		opacity: 1; /* Bad. */
+	}
+</style>
+/* @codingStandardsChangeSetting WordPress.VIP.AdminBarRemoval remove_only true */

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -18,14 +18,63 @@ class WordPress_Tests_VIP_AdminBarRemovalUnitTest extends AbstractSniffUnitTest 
 	/**
 	 * Returns the lines where errors should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array <int line number> => <int number of errors>
 	 */
-	public function getErrorList() {
-		return array(
-			3 => 1,
-			5 => 1,
-		);
+	public function getErrorList( $testFile = '' ) {
 
+		switch ( $testFile ) {
+			case 'AdminBarRemovalUnitTest.inc':
+				return array(
+					3   => 1,
+					6   => 1,
+					9   => 1,
+					12  => 1,
+					13  => 1,
+					19  => 1,
+					20  => 1,
+					21  => 1,
+					26  => 1,
+					32  => 1,
+					56  => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize T_NOWDOC.
+					57  => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize T_NOWDOC.
+					58  => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize T_NOWDOC.
+					68  => 1,
+					69  => 1,
+					70  => 1,
+					81  => 1,
+					82  => 1,
+					83  => 1,
+					92  => 1,
+					103 => 1,
+					104 => 1,
+					105 => 1,
+				);
+
+			case 'AdminBarRemovalUnitTest.css':
+				return array(
+					15  => 1,
+					16 => 1,
+					17 => 1,
+					22 => 1,
+					23 => 1,
+					24 => 1,
+					29 => 1,
+					30 => 1,
+					31 => 1,
+					38 => 1,
+					39 => 1,
+					40 => 1,
+					46 => 1,
+					47 => 1,
+					48 => 1,
+				);
+
+			default:
+				return array();
+
+		} // End switch().
 	}
 
 	/**


### PR DESCRIPTION
This sniff has been completely overhauled with the additional wish-list of the Theme Review Team in mind.

Originally the sniff only checked for `show_admin_bar( ... )` and `add_filter( 'show_admin_bar', ... )`.
* It didn't contain a further check for the actual value passed to these functions.
* It didn't check for usage of CSS to hide the admin bar

This PR fixes that.
Includes extensive additional unit tests.

Notes:
* The sniff now checks both PHP as well as CSS files.
* The class now extends the `WordPress_AbstractFunctionParameterSniff` for the PHP function parameter checks.
* It overloads the `register()` method to register additional tokens.
* It overloads the `process()` method of that class to only use the functions in the abstract class when passed a `T_STRING` token. For the other token types, the processing is handled within the sniff.
* The sniff now contains a public property `$remove_only` which defaults to `true`, to toggle whether to just check that the admin bar is being manipulated or to do a more in-depth check and only throw errors when removing or hiding of the admin bar is detected.
* The sniff also contains a new utility function to work around a bug in the PHP 5.2 tokenizer regarding text strings containing `<s`, like `<style>`.

Who should I ping from the VIP team to have a look as well ?