### PR TITLE
Improve cron schedule sniff

### DIFF
--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -147,7 +147,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 			}
 		}
 
-		if ( isset( $interval ) && $interval < ( 15 * 60 ) ) {
+		if ( isset( $interval ) && $interval < 900 ) {
 			$phpcsFile->addError( 'Scheduling crons at %s sec ( less than 15 min ) is prohibited.', $stackPtr, 'CronSchedulesInterval', array( $interval ) );
 			return;
 		}

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -15,9 +15,24 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.11.0 Extends the WordPress_Sniff class.
+ * @since   0.11.0 - Extends the WordPress_Sniff class.
+ *                 - Now deals correctly with WP time constants.
  */
 class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
+
+	/**
+	 * Known WP Time constant names and their value.
+	 *
+	 * @var array
+	 */
+	protected $wp_time_constants = array(
+		'MINUTE_IN_SECONDS' => 60,
+		'HOUR_IN_SECONDS'   => 3600,
+		'DAY_IN_SECONDS'    => 86400,
+		'WEEK_IN_SECONDS'   => 604800,
+		'MONTH_IN_SECONDS'  => 2592000,
+		'YEAR_IN_SECONDS'   => 31536000,
+	);
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -116,6 +131,9 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 						$interval = $value;
 						break;
 					}
+
+					// Deal correctly with WP time constants.
+					$value = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $value );
 
 					// If all digits and operators, eval!
 					if ( preg_match( '#^[\s\d\+\*\-\/]+$#', $value ) > 0 ) {

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -121,7 +121,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 			}
 		}
 
-		if ( is_null( $functionPtr ) ) {
+		if ( ! isset( $functionPtr ) ) {
 			$this->confused( $stackPtr );
 			return;
 		}
@@ -137,8 +137,9 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
 				if ( 'interval' === $this->strip_quotes( $this->tokens[ $i ]['content'] ) ) {
 					$operator = $phpcsFile->findNext( T_DOUBLE_ARROW, $i, null, false, null, true );
-					if ( empty( $operator ) ) {
+					if ( false === $operator ) {
 						$this->confused( $stackPtr );
+						return;
 					}
 
 					$valueStart = $phpcsFile->findNext( T_WHITESPACE, ( $operator + 1 ), null, true, null, true );

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -155,7 +155,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 					$value = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $value );
 
 					// If all digits and operators, eval!
-					if ( preg_match( '#^[\s\d\+\*\-\/]+$#', $value ) > 0 ) {
+					if ( preg_match( '#^[\s\d+*/-]+$#', $value ) > 0 ) {
 						$interval = eval( "return ( $value );" ); // @codingStandardsIgnoreLine - No harm here.
 						break;
 					}

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -109,12 +109,12 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 			return;
 		}
 
-		$opening = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, $functionPtr );
-		if ( false === $opening ) {
+		if ( ! isset( $this->tokens[ $functionPtr ]['scope_opener'], $this->tokens[ $functionPtr ]['scope_closer'] ) ) {
 			return;
 		}
 
-		$closing = $this->tokens[ $opening ]['bracket_closer'];
+		$opening = $this->tokens[ $functionPtr ]['scope_opener'];
+		$closing = $this->tokens[ $functionPtr ]['scope_closer'];
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
 			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.inc
@@ -1,5 +1,7 @@
 <?php
 
+Foo::my_add_quicklier( $schedules ); // The old logic would get confused by this.
+
 function my_add_weekly( $schedules ) {
 	$schedules['every_6_mins'] = array(
 		'interval' => 360,
@@ -7,12 +9,12 @@ function my_add_weekly( $schedules ) {
 	);
 	return $schedules;
 }
-add_filter( 'cron_schedules', 'my_add_weekly');
+add_filter( 'cron_schedules', 'my_add_weekly'); // Error: 6 min.
 
 
 class Foo {
 	function __construct() {
-		add_filter( 'cron_schedules', array( $this, 'my_add_quickly' ) );
+		add_filter( 'cron_schedules', array( $this, 'my_add_quickly' ) ); // Error: 10 min.
 	}
 
 	function my_add_quickly( $schedules ) {
@@ -32,9 +34,11 @@ class Foo {
 	}
 }
 
-add_filter( 'cron_schedules', array( 'Foo', 'my_add_quicklier' ) );
+add_filter( 'cron_schedules', array( 'Foo', 'my_add_quicklier' ) ); // Error: 5 min.
 
-add_filter( 'cron_schedules', array( $some_other_place, 'some_other_method' ) );
+add_filter( 'cron_schedules', array( $some_other_place, 'some_other_method' ) ); // Warning: time undetermined.
+
+add_filter( 'cron_schedules', array( $some_other_place, $some_other_method ) ); // Warning: time undetermined.
 
 add_filter( 'cron_schedules', function ( $schedules ) {
 	$schedules['every_9_mins'] = array(
@@ -42,4 +46,37 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 		'display' => __( 'Once every 9 minutes' )
 	);
 	return $schedules;
-} );
+} ); // Error: 9 min.
+
+add_filter( 'cron_schedules' ); // Ignore, no callback parameter.
+
+add_filter( 'cron_schedules', [ 'Foo', 'my_add_quicklier' ] ); // Error: 5 min.
+
+// Ignore, not our function. Currently gives false positive, will be fixed later when function call detection utility functions are added.
+My_Custom::add_filter( 'cron_schedules', [ 'Foo', 'my_add_quicklier' ] );
+
+// Deal correctly with the WP time constants.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_2_days_and_a_bit'] = [
+		'interval' => 2 * DAY_IN_SECONDS + 2 * HOUR_IN_SECONDS,
+		'display' => __( 'Once every 2 days and a bit' )
+	];
+	return $schedules;
+} ); // Ok: > 15 min.
+
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_8_minutes'] = [
+		'interval' => 8 * MINUTE_IN_SECONDS,
+		'display' => __( 'Once every 8 minutes' )
+	];
+	return $schedules;
+} ); // Error: 8 min.
+
+// Deal correctly with the function calls for interval.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_2_days_and_a_bit'] = [
+		'interval' => get_my_interval( 1, 5, 20 ),
+		'display' => __( 'Once every 2 days and a bit' )
+	];
+	return $schedules;
+} ); // Warning: time undetermined.

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -22,10 +22,13 @@ class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			10 => 1,
-			15 => 1,
-			35 => 1,
-			39 => 1,
+			12 => 1,
+			17 => 1,
+			37 => 1,
+			43 => 1,
+			53 => 1,
+			56 => 1, // False positive.
+			67 => 1,
 		);
 
 	}
@@ -37,7 +40,9 @@ class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			37 => 1,
+			39 => 1,
+			41 => 1,
+			76 => 1,
 		);
 
 	}


### PR DESCRIPTION
* Deal correctly with WP time constants leading to more accurate error/warning messages.
* Takes advantage of the new function parameter utility functions for greater accuracy.
* Allow for short array syntax in callback for `add_filter`.
* Make the finding of the referenced function declaration more accurate and efficient by only looking at `T_FUNCTION` tokens, skipping past the rest of the function and breaking out if the right function is found. (Still could get confused over two classes in the same file with a same name method, but better than it was before)
* Minor other efficiency tweaks

Includes additional unit tests.