### PR TITLE
Abstracts: Fix potential bug - methods should allow for optionally returning a stack pointer

### DIFF
--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -24,6 +24,13 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	protected $regex_pattern = '`^\\\\(?:%s)$`i';
 
 	/**
+	 * Temporary storage for retrieved class name.
+	 *
+	 * @var string
+	 */
+	protected $classname;
+
+	/**
 	 * Groups of classes to restrict.
 	 *
 	 * This method should be overridden in extending classes.
@@ -67,14 +74,30 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	}
 
 	/**
-	 * Verify is the current token relates to one of the targetted classes.
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		// Reset the temporary storage before processing the token.
+		unset( $this->classname );
+
+		return parent::process( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Determine if we have a valid classname for the target token.
 	 *
 	 * @since 0.11.0 This logic was originally contained in the `process()` method.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return int|void Integer stack pointer to skip forward or void to continue
-	 *                  normal file processing.
+	 * @return bool
 	 */
 	public function is_targetted_token( $stackPtr ) {
 
@@ -109,13 +132,31 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 
 		// Stop if we couldn't determine a classname.
 		if ( empty( $classname ) ) {
-			return;
+			return false;
 		}
 
 		// Nothing to do if 'parent', 'self' or 'static'.
 		if ( in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
-			return;
+			return false;
 		}
+
+		$this->classname = $classname;
+		return true;
+
+	} // End is_targetted_token().
+
+	/**
+	 * Verify if the current token is one of the targetted classes.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function check_for_matches( $stackPtr ) {
+		$skip_to = array();
 
 		foreach ( $this->groups as $groupName => $group ) {
 
@@ -123,10 +164,16 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 				continue;
 			}
 
-			if ( preg_match( $group['regex'], $classname ) === 1 ) {
-				return $this->process_matched_token( $stackPtr, $groupName, $classname );
+			if ( preg_match( $group['regex'], $this->classname ) === 1 ) {
+				$skip_to[] = $this->process_matched_token( $stackPtr, $groupName, $this->classname );
 			}
 		}
+
+		if ( empty( $skip_to ) || min( $skip_to ) === 0 ) {
+			return;
+		}
+
+		return min( $skip_to );
 
 	} // End is_targetted_token().
 

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -73,7 +73,8 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function is_targetted_token( $stackPtr ) {
 
@@ -123,7 +124,7 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 			}
 
 			if ( preg_match( $group['regex'], $classname ) === 1 ) {
-				$this->process_matched_token( $stackPtr, $groupName, $classname );
+				return $this->process_matched_token( $stackPtr, $groupName, $classname );
 			}
 		}
 

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -59,16 +59,17 @@ abstract class WordPress_AbstractFunctionParameterSniff extends WordPress_Abstra
 	 * @param array  $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
 		$parameters = $this->get_function_call_parameters( $stackPtr );
 
 		if ( empty( $parameters ) ) {
-			$this->process_no_parameters( $stackPtr, $group_name, $matched_content );
+			return $this->process_no_parameters( $stackPtr, $group_name, $matched_content );
 		} else {
-			$this->process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+			return $this->process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
 		}
 	}
 
@@ -82,21 +83,23 @@ abstract class WordPress_AbstractFunctionParameterSniff extends WordPress_Abstra
 	 * @param string $matched_content The token content (function name) which was matched.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	abstract public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
 
 	/**
 	 * Process the function if no parameters were found.
 	 *
-	 * Default to doing nothing. Can be overloaded in child classes to handle functions
+	 * Defaults to doing nothing. Can be overloaded in child classes to handle functions
 	 * were parameters are expected, but none found.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param array  $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
 		return;

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -154,7 +154,8 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 	 * @param int                  $stackPtr  The position of the current token
 	 *                                        in the stack passed in $tokens.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
 
@@ -168,7 +169,7 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 		// Make phpcsFile and tokens available as properties.
 		$this->init( $phpcsFile );
 
-		$this->is_targetted_token( $stackPtr );
+		return $this->is_targetted_token( $stackPtr );
 
 	} // End process().
 
@@ -179,7 +180,8 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function is_targetted_token( $stackPtr ) {
 
@@ -213,6 +215,8 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			unset( $prev, $pprev, $skipped );
 		}
 
+		$skip_to = null;
+
 		foreach ( $this->groups as $groupName => $group ) {
 
 			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
@@ -224,9 +228,11 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			}
 
 			if ( preg_match( $group['regex'], $token_content ) === 1 ) {
-				$this->process_matched_token( $stackPtr, $groupName, $token_content );
+				$skip_to = $this->process_matched_token( $stackPtr, $groupName, $token_content );
 			}
 		}
+
+		return $skip_to;
 
 	} // End is_targetted_token().
 
@@ -239,7 +245,8 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 	 * @param array  $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
@@ -256,6 +263,8 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			$group_name,
 			array( $matched_content )
 		);
+
+		return;
 	} // End process_matched_token().
 
 	/**


### PR DESCRIPTION
PHPCS allows for the `process()` method to optionally return a stack pointer. If so, it will not call the sniff for the current file again until the returned stack pointer has been reached.

I did not take that into account in the refactor of the AbstractFunctionRestrictionsSniff and the creation of the AbstractFunctionParameterSniff which basically blocks any child classes from using the ability to return a stack pointer.

This has now been fixed.