### PR TITLE
Bug fix: `is_sanitized()` did not consistently take all sanitization functions into account for final result

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -229,22 +229,24 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * Functions that sanitize values.
 	 *
+	 * This list is complementary to the `$unslashingSanitizingFunctions`
+	 * list.
+	 * Sanitizing functions should be added to this list if they do *not*
+	 * implicitely unslash data and to the `$unslashingsanitizingFunctions`
+	 * list if they do.
+	 *
 	 * @since 0.5.0
 	 *
 	 * @var array
 	 */
 	public static $sanitizingFunctions = array(
 		'_wp_handle_upload'          => true,
-		'absint'                     => true,
 		'array_key_exists'           => true,
 		'esc_url_raw'                => true,
 		'filter_input'               => true,
 		'filter_var'                 => true,
-		'floatval'                   => true,
 		'hash_equals'                => true,
 		'in_array'                   => true,
-		'intval'                     => true,
-		'is_array'                   => true,
 		'is_email'                   => true,
 		'number_format'              => true,
 		'sanitize_bookmark_field'    => true,
@@ -254,7 +256,6 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'sanitize_hex_color_no_hash' => true,
 		'sanitize_hex_color'	     => true,
 		'sanitize_html_class'        => true,
-		'sanitize_key'               => true,
 		'sanitize_meta'              => true,
 		'sanitize_mime_type'         => true,
 		'sanitize_option'            => true,
@@ -282,6 +283,11 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * Sanitizing functions that implicitly unslash the data passed to them.
+	 *
+	 * This list is complementary to the `$sanitizingFunctions` list.
+	 * Sanitizing functions should be added to this list if they also
+	 * implicitely unslash data and to the `$sanitizingFunctions` list
+	 * if they don't.
 	 *
 	 * @since 0.5.0
 	 *
@@ -995,7 +1001,11 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// Check if this is a sanitizing function.
-		return isset( self::$sanitizingFunctions[ $functionName ] );
+		if ( isset( self::$sanitizingFunctions[ $functionName ] ) || isset( self::$unslashingSanitizingFunctions[ $functionName ] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
The `$sanitizingFunctions` and `$unslashingSanitizingFunctions` are two distinct lists and custom sanitizing / unslashsanitizing functions are only merged with one or the other.

The `$sanitizingFunctions` list currently contained an (incomplete) overlap with the `$unslashingSanitizingFunctions` which would become even more incomplete if/when custom functions would be merged in.

The `$unslashingSanitizingFunctions` was only considered to determine whether or not unslashing was needed.
Functions contained in that list which were not *also* contained in the `$sanitizingFunctions` list were not taken into account for the final result of the `is_sanitized()` function.

This has now been fixed.

* Removed overlap between the functions listed in the two properties
* `is_sanitized()` now also takes the `$unslashingSanitizingFunctions` into account when doing the final determination of whether something is sanitized or not.