### PR TITLE
Ruleset tweaks: Make the scope indent sniff slightly less annoying

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -24,8 +24,10 @@
 		<!-- Covers rule: Your indentation should always reflect logical structure. -->
 		<rule ref="Generic.WhiteSpace.ScopeIndent">
 			<properties>
+				<property name="exact" value="false" />
 				<property name="indent" value="4"/>
 				<property name="tabIndent" value="true"/>
+				<property name="ignoreIndentationTokens" type="array" value="T_HEREDOC,T_NOWDOC,T_INLINE_HTML" />
 			</properties>
 		</rule>
 


### PR DESCRIPTION
* The `exact` property defaults to `false`, but if the WP ruleset is combined with other ruleset, we want to make sure it stays that way.
* The scope indent is often justifiably different for inline HTML, heredocs and nowdocs. The added `ignoreIndentationTokens` property should make the sniff ignore indent issues when those tokens are encountered.