### PR TITLE
Check for deprecated parameters

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -64,6 +64,7 @@
 	</rule>
 	<rule ref="WordPress.WP.DeprecatedFunctions"/>
 	<rule ref="WordPress.WP.DeprecatedClasses"/>
+	<rule ref="WordPress.WP.DeprecatedParameters"/>
 	<rule ref="WordPress.WP.AlternativeFunctions"/>
 	<rule ref="WordPress.WP.DiscouragedFunctions"/>
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Check for usage of deprecated parameters in WP functions and suggest alternative based on the parameter passed.
+ *
+ * This sniff will throw an error when usage of deprecated parameters is
+ * detected if the parameter was deprecated before the minimum supported
+ * WP version; a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_WP_DeprecatedParametersSniff extends WordPress_AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'wp_deprecated_parameters';
+
+	/**
+	 * Minimum WordPress version.
+	 *
+	 * This variable allows changing the minimum supported WP version used by
+	 * this sniff by setting a property in a custom ruleset XML file.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.WP.DeprecatedParameters">
+	 *  <properties>
+	 *   <property name="minimum_supported_version" value="4.5"/>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string WordPress version.
+	 */
+	public $minimum_supported_version = 4.5;
+
+	/**
+	 * Array of function, argument, and default value for deprecated argument.
+	 *
+	 * The functions are ordered alphabetically.
+	 * Last updated for WordPress 4.8.0.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array Multidimensional array with parameter details.
+	 *    $target_functions = array(
+	 *        (string) Function name. => array(
+	 *            (int) Target parameter position, 1-based. => array(
+	 *                'value'   => (mixed) Expected default value for the
+	 *                              deprecated parameter. Currently the default
+	 *                              values: true, false, null, empty arrays and
+	 *                              both empty and non-empty strings can be
+	 *                              handled correctly by the process_parameters()
+	 *                              method. When an additional default value is
+	 *                              added, the relevant code in the
+	 *                              process_parameters() method will need to be
+	 *                              adjusted.
+	 *                'version' => (int) The WordPress version when deprecated.
+	 *            )
+	 *         )
+	 *    );
+	 */
+	protected $target_functions = array(
+
+		'add_option' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.3.0',
+			),
+		),
+		'comments_link' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '0.72',
+			),
+			2 => array(
+				'value'   => '',
+				'version' => '1.3.0',
+			),
+		),
+		'comments_number' => array(
+			4 => array(
+				'value'   => '',
+				'version' => '1.3.0',
+			),
+		),
+		'convert_chars' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '0.71',
+			),
+		),
+		'discover_pingback_server_uri' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.7.0',
+			),
+		),
+		'get_category_parents' => array(
+			5 => array(
+				'value'   => array(),
+				'version' => '4.8.0',
+			),
+		),
+		'get_delete_post_link' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '3.0.0',
+			),
+		),
+		'get_last_updated' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '3.0.0', // Was previously part of MU.
+			),
+		),
+		'get_the_author' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+		),
+		'get_user_option' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.3.0',
+			),
+		),
+		'get_wp_title_rss' => array(
+			1 => array(
+				'value'   => '&#8211;',
+				'version' => '4.4.0',
+			),
+		),
+		'is_email' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '3.0.0',
+			),
+		),
+		'load_plugin_textdomain' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '2.7.0',
+			),
+		),
+		'safecss_filter_attr' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.8.1',
+			),
+		),
+		'the_attachment_link' => array(
+			3 => array(
+				'value'   => false,
+				'version' => '2.5.0',
+			),
+		),
+		'the_author' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+			2 => array(
+				'value'   => true,
+				'version' => '1.5.0',
+			),
+		),
+		'the_author_posts_link' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+		),
+		'trackback_rdf' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.5.0',
+			),
+		),
+		'trackback_url' => array(
+			1 => array(
+				'value'   => true,
+				'version' => '2.5.0',
+			),
+		),
+		'update_blog_option' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.1.0',
+			),
+		),
+		'update_blog_status' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.1.0',
+			),
+		),
+		'update_user_status' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.0.2',
+			),
+		),
+		'unregister_setting' => array(
+			4 => array(
+				'value'   => '',
+				'version' => '4.7.0',
+			),
+		),
+		'wp_get_http_headers' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '2.7.0',
+			),
+		),
+		'wp_get_sidebars_widgets' => array(
+			1 => array(
+				'value'   => true,
+				'version' => '2.8.1',
+			),
+		),
+		'wp_install' => array(
+			5 => array(
+				'value'   => '',
+				'version' => '2.6.0',
+			),
+		),
+		'wp_new_user_notification' => array(
+			2 => array(
+				'value'   => null,
+				'version' => '4.3.1',
+			),
+		),
+		'wp_notify_postauthor' => array(
+			2 => array(
+				'value'   => null,
+				'version' => '3.8.0',
+			),
+		),
+		'wp_title_rss' => array(
+			1 => array(
+				'value'   => '&#8211;',
+				'version' => '4.4.0',
+			),
+		),
+		'wp_upload_bits' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.0.0',
+			),
+		),
+		'xfn_check' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.5.0',
+			),
+		),
+
+	); // End $target_functions.
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$paramCount = count( $parameters );
+		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
+
+			// Check that number of parameters defined is not less than the position to check.
+			if ( $position > $paramCount ) {
+				break;
+			}
+
+			// The list will need to updated if the default value is not supported.
+			switch ( $parameters[ $position ]['raw'] ) {
+				case 'true':
+					$matched_parameter = true;
+					break;
+				case 'false':
+					$matched_parameter = false;
+					break;
+				case 'null':
+					$matched_parameter = null;
+					break;
+				case 'array()':
+				case '[]':
+					$matched_parameter = array();
+					break;
+				default:
+					$matched_parameter = $this->strip_quotes( $parameters[ $position ]['raw'] );
+					break;
+			}
+
+			if ( $parameter_args['value'] === $matched_parameter ) {
+				continue;
+			}
+
+			$message = 'The parameter "%s" at position #%s of %s() has been deprecated since WordPress version %s.';
+			$is_error = version_compare( $parameter_args['version'], $this->minimum_supported_version, '<' );
+			$code = $this->string_to_errorcode( ucfirst( $matched_content ) . 'Param' . $position . 'Found' );
+
+			$data = array(
+				$parameters[ $position ]['raw'],
+				$position,
+				$matched_content,
+				$parameter_args['version'],
+			);
+
+			if ( isset( $parameter_args['value'] ) && $position < $paramCount ) {
+				$message .= ' Use "%s" instead.';
+				$data[]   = (string) $parameter_args['value'];
+			} else {
+				$message .= ' Instead do not pass the parameter.';
+			}
+
+			$this->addMessage( $message, $stackPtr, $is_error, $code, $data, 0 );
+		}
+	}
+
+}

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -1,0 +1,66 @@
+<?php
+
+// All will be OK as the default value is used.
+
+wp_title_rss( '&#8211;' ); // 1st.
+wp_get_sidebars_widgets( true ); // 1st.
+wp_new_user_notification( '', null, '' ); // 2nd.
+the_attachment_link( '', false, false, false ); // 3rd.
+update_blog_option( '', '', '', null ); // 4th.
+wp_install( '', '', '', '', '' ); // 5th.
+get_category_parents( '', '', '', '', array() ); // 5th.
+get_category_parents( '', '', '', '', [] ); // 5th.
+
+// Method names within a class should be fine.
+
+Theme_Object::wp_title_rss( 'home' ); // Ok.
+$this->wp_title_rss( 'siteurl' ); // Ok.
+$theme_object->wp_title_rss( 'text_direction' ); // Ok.
+
+// All will give an Error even though they have a dynamic variable.
+
+wp_new_user_notification( '', $variable );
+wp_new_user_notification( '', function_name() );
+wp_new_user_notification( '', $this->method_name() );
+
+// All will give an ERROR. The functions are ordered alphabetically.
+
+add_option( '', '', [] );
+add_option( '', '', 1.23 );
+add_option( '', '', 10 );
+add_option( '', '', false );
+add_option( '', '', 'deprecated' );
+comments_link( 'deprecated', 'deprecated' );
+comments_number( '', '', '', 'deprecated' );
+convert_chars( '', 'deprecated' );
+discover_pingback_server_uri( '', 'deprecated' );
+get_delete_post_link( '', 'deprecated' );
+get_last_updated( 'deprecated' );
+get_the_author( 'deprecated' );
+get_user_option( '', '', 'deprecated' );
+get_wp_title_rss( 'deprecated' );
+is_email( '', 'deprecated' );
+is_email( '', 'false' ); // False as a string not bool.
+load_plugin_textdomain( '', 'deprecated' );
+safecss_filter_attr( '', 'deprecated' );
+the_attachment_link( '', '', 'deprecated' );
+the_author( 'deprecated', 'deprecated' );
+the_author_posts_link( 'deprecated' );
+trackback_rdf( 'deprecated' );
+trackback_url( 'deprecated' );
+update_blog_option( '', '', '', 'deprecated' );
+update_user_status( '', '', '', 'deprecated' );
+wp_get_http_headers( '', 'deprecated' );
+wp_get_sidebars_widgets( 'deprecated' );
+wp_install( '', '', '', '', 'deprecated' );
+wp_new_user_notification( '', 'deprecated' );
+wp_notify_postauthor( '', 'deprecated' );
+wp_notify_postauthor( '', 'null' ); // Null as a string not null.
+wp_title_rss( 'deprecated' );
+wp_upload_bits( '', 'deprecated' );
+xfn_check( '', '', 'deprecated' );
+
+// All will give an WARNING as they have been deprecated after WP 4.5.
+
+get_category_parents( '', '', '', '', array( 'deprecated') );
+unregister_setting( '', '', '', 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the DeprecatedParameters sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_WP_DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		$errors = array_fill( 28, 34, 1 );
+
+		$errors[22] = 1;
+		$errors[23] = 1;
+		$errors[24] = 1;
+
+		// Override number of errors.
+		$errors[33] = 2;
+		$errors[47] = 2;
+
+		return $errors;
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			65 => 1,
+			66 => 1,
+		);
+	}
+
+} // End class.


### PR DESCRIPTION
Solves part of #576 

I got the list of deprecated parameters by looking where [`_deprecated_argument()`](https://developer.wordpress.org/reference/functions/_deprecated_argument/) was being used.

This is the first of three sniffs. The other two that will follow are
- `WordPress.WP.DeprecatedParameterValues` e.g. `bloginfo( 'url' );` where the value `url` is deprecated
- `WordPress.WP.DeprecatedParameterArgValues` e.g. For `wp_dropdown_categories( $args ) ` `$args['type']` cannot be `links`.

There will be an notice if the parameter value is not what is used by default. The default value is important as in some cases the deprecated parameter maybe in the middle. e.g. `load_plugin_textdomain()`

If a dynamic parameter is used then there will be still an error. The values for the deprecated functions are normally empty strings, bool or null. It is best to write them as is then using a function or variable.

I have again included a property to define the minimum supported WordPress version. Perhaps for future discussion: Would it make more sense to define the minimum supported WordPress version in the `Sniff.php` instead so it would only need to defined once instead for every deprecated sniff.

There maybe a better way to add the ordinal suffix. I have not added support for 11th, 12th or 13th as that many parameters would be an edge case.