### PR TITLE
New utility function: addMessage()

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -109,12 +109,11 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 		// Make phpcsFile and tokens available as properties.
 		$this->init( $phpcsFile );
 
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
+		$token = $this->tokens[ $stackPtr ];
 
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ), true ) ) {
 			$equal = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			if ( T_EQUAL !== $tokens[ $equal ]['code'] ) {
+			if ( T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
 				return; // This is not an assignment!
 			}
 		}
@@ -134,8 +133,8 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 			}
 
 			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
-			if ( ! is_numeric( $tokens[ $keyIdx ]['content'] ) ) {
-				$key            = $this->strip_quotes( $tokens[ $keyIdx ]['content'] );
+			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
+				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
 				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -106,6 +106,9 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 			return;
 		}
 
+		// Make phpcsFile and tokens available as properties.
+		$this->init( $phpcsFile );
+
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
@@ -179,16 +182,10 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 						$message = $output;
 					}
 
-					if ( 'warning' === $group['type'] ) {
-						$addWhat = array( $phpcsFile, 'addWarning' );
-					} else {
-						$addWhat = array( $phpcsFile, 'addError' );
-					}
-
-					call_user_func(
-						$addWhat,
+					$this->addMessage(
 						$message,
 						$stackPtr,
+						( 'error' === $group['type'] ),
 						$this->string_to_errorcode( $groupName . '_' . $key ),
 						array( $key, $val )
 					);

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -269,16 +269,10 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		if ( 'warning' === $this->groups[ $group_name ]['type'] ) {
-			$addWhat = array( $this->phpcsFile, 'addWarning' );
-		} else {
-			$addWhat = array( $this->phpcsFile, 'addError' );
-		}
-
-		call_user_func(
-			$addWhat,
+		$this->addMessage(
 			$this->groups[ $group_name ]['message'],
 			$stackPtr,
+			( 'error' === $this->groups[ $group_name ]['type'] ),
 			$this->string_to_errorcode( $group_name . '_' . $matched_content ),
 			array( $matched_content )
 		);

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -98,8 +98,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 		// Make phpcsFile and tokens available as properties.
 		$this->init( $phpcsFile );
 
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
+		$token  = $this->tokens[ $stackPtr ];
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
@@ -118,7 +117,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
 			$method               = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
-			if ( T_OPEN_PARENTHESIS === $tokens[ $possible_parenthesis ]['code'] ) {
+			if ( T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
 				return; // So .. it is a function after all !
 			}
 		}
@@ -142,7 +141,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 				$owner = $phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
 				$child = $phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
-				$var   = implode( '', array( $tokens[ $owner ]['content'], $token['content'], $tokens[ $child ]['content'] ) );
+				$var   = implode( '', array( $this->tokens[ $owner ]['content'], $token['content'], $this->tokens[ $child ]['content'] ) );
 
 			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
@@ -150,7 +149,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 				$owner  = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
 				$inside = $phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
-				$var    = implode( '', array( $tokens[ $owner ]['content'], $inside ) );
+				$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
 			} else {
 				continue;
 			}

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -94,6 +94,10 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	 *                  normal file processing.
 	 */
 	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+
+		// Make phpcsFile and tokens available as properties.
+		$this->init( $phpcsFile );
+
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 		$groups = $this->getGroups();
@@ -167,16 +171,10 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 				continue;
 			}
 
-			if ( 'warning' === $group['type'] ) {
-				$addWhat = array( $phpcsFile, 'addWarning' );
-			} else {
-				$addWhat = array( $phpcsFile, 'addError' );
-			}
-
-			call_user_func(
-				$addWhat,
+			$this->addMessage(
 				$group['message'],
 				$stackPtr,
+				( 'error' === $group['type'] ),
 				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
 				array( $var )
 			);

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -550,6 +550,76 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	}
 
 	/**
+	 * Add a PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @return bool
+	 */
+	protected function addMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0 ) {
+		return $this->throwMessage( $message, $stackPtr, $is_error, $code, $data, $severity, false );
+	}
+
+	/**
+	 * Add a fixable PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @return bool
+	 */
+	protected function addFixableMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0 ) {
+		return $this->throwMessage( $message, $stackPtr, $is_error, $code, $data, $severity, true );
+	}
+
+	/**
+	 * Add a PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @param bool   $fixable   Optional. Whether this is a fixable error. Defaults to false.
+	 * @return bool
+	 */
+	private function throwMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0, $fixable = false ) {
+
+		$method = 'add';
+		if ( true === $fixable ) {
+			$method .= 'Fixable';
+		}
+
+		if ( true === $is_error ) {
+			$method .= 'Error';
+		} else {
+			$method .= 'Warning';
+		}
+
+		return call_user_func( array( $this->phpcsFile, $method ), $message, $stackPtr, $code, $data, $severity );
+	}
+
+	/**
 	 * Convert an arbitrary string to an alphanumeric string with underscores.
 	 *
 	 * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -119,14 +119,11 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 		}
 
 		// If we're still here, no nonce-verification function was found.
-		$severity = ( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ) ? 0 : 'warning';
-
-		$phpcsFile->addError(
-			'Processing form data without nonce verification.'
-			, $stackPtr
-			, 'NoNonceVerification'
-			, array()
-			, $severity
+		$this->addMessage(
+			'Processing form data without nonce verification.',
+			$stackPtr,
+			( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ),
+			'NoNonceVerification'
 		);
 
 	} // End process().

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1132,13 +1132,14 @@ class WordPress_Sniffs_WP_DeprecatedFunctionsSniff extends WordPress_AbstractFun
 			$message .= ' Use %s instead.';
 			$data[]   = $this->deprecated_functions[ $function_name ]['alt'];
 		}
-		$error_code = $this->string_to_errorcode( $matched_content . 'Found' );
 
-		if ( version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_supported_version, '>=' ) ) {
-			$this->phpcsFile->addWarning( $message, $stackPtr, $error_code, $data );
-		} else {
-			$this->phpcsFile->addError( $message, $stackPtr, $error_code, $data );
-		}
+		$this->addMessage(
+			$message,
+			$stackPtr,
+			( version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_supported_version, '<' ) ),
+			$this->string_to_errorcode( $matched_content . 'Found' ),
+			$data
+		);
 
 	} // End process_matched_token().
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -140,8 +140,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		// Make phpcsFile and tokens available as properties.
 		$this->init( $phpcs_file );
 
-		$tokens = $phpcs_file->getTokens();
-		$token  = $tokens[ $stack_ptr ];
+		$token  = $this->tokens[ $stack_ptr ];
 
 		// Allow overruling the text_domain set in a ruleset via the command line.
 		$cl_text_domain = trim( PHP_CodeSniffer::getConfigData( 'text_domain' ) );
@@ -167,16 +166,17 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		$func_open_paren_token = $phpcs_file->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
-		if ( false === $func_open_paren_token || T_OPEN_PARENTHESIS !== $tokens[ $func_open_paren_token ]['code'] ) {
+		if ( false === $func_open_paren_token || T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code'] ) {
 			 return;
 		}
 
 		$arguments_tokens = array();
 		$argument_tokens  = array();
+		$tokens           = $this->tokens;
 
 		// Look at arguments.
-		for ( $i = ( $func_open_paren_token + 1 ); $i < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $i++ ) {
-			$this_token                = $tokens[ $i ];
+		for ( $i = ( $func_open_paren_token + 1 ); $i < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $i++ ) {
+			$this_token                = $this->tokens[ $i ];
 			$this_token['token_index'] = $i;
 			if ( in_array( $this_token['code'], PHP_CodeSniffer_Tokens::$emptyTokens, true ) ) {
 				continue;
@@ -189,9 +189,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 			// Merge consecutive single or double quoted strings (when they span multiple lines).
 			if ( T_CONSTANT_ENCAPSED_STRING === $this_token['code'] || 'T_DOUBLE_QUOTED_STRING' === $this_token['type'] ) {
-				for ( $j = ( $i + 1 ); $j < $tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
-					if ( $this_token['code'] === $tokens[ $j ]['code'] ) {
-						$this_token['content'] .= $tokens[ $j ]['content'];
+				for ( $j = ( $i + 1 ); $j < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
+					if ( $this_token['code'] === $this->tokens[ $j ]['code'] ) {
+						$this_token['content'] .= $this->tokens[ $j ]['content'];
 						$i                      = $j;
 					} else {
 						break;
@@ -254,7 +254,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			} else {
 				$argument_assertion_context['stack_ptr'] = $argument_assertion_context['tokens'][0]['token_index'];
 			}
-			$this->check_argument_tokens( $phpcs_file, $argument_assertion_context );
+			$this->check_argument_tokens( $argument_assertion_context );
 		}
 
 		// For _n*() calls, compare the singular and plural strings.
@@ -262,22 +262,21 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$single_context = $argument_assertions[0];
 			$plural_context = $argument_assertions[1];
 
-			$this->compare_single_and_plural_arguments( $phpcs_file, $stack_ptr, $single_context, $plural_context );
+			$this->compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context );
 		}
 
 		if ( true === $this->check_translator_comments ) {
-			$this->check_for_translator_comment( $phpcs_file, $stack_ptr, $argument_assertions );
+			$this->check_for_translator_comment( $stack_ptr, $argument_assertions );
 		}
 	}
 
 	/**
 	 * Check if supplied tokens represent a translation text string literal.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param array                $context    Context (@todo needs better description).
+	 * @param array $context Context (@todo needs better description).
 	 * @return bool
 	 */
-	protected function check_argument_tokens( PHP_CodeSniffer_File $phpcs_file, $context ) {
+	protected function check_argument_tokens( $context ) {
 		$stack_ptr = $context['stack_ptr'];
 		$tokens    = $context['tokens'];
 		$arg_name  = $context['arg_name'];
@@ -302,7 +301,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
-			$this->check_text( $phpcs_file, $context );
+			$this->check_text( $context );
 		}
 
 		if ( T_CONSTANT_ENCAPSED_STRING === $tokens[0]['code'] ) {
@@ -336,14 +335,12 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	/**
 	 * Check for inconsistencies between single and plural arguments.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file     The file being scanned.
-	 * @param int                  $stack_ptr      The position of the current token
-	 *                                             in the stack.
-	 * @param array                $single_context Single context (@todo needs better description).
-	 * @param array                $plural_context Plural context (@todo needs better description).
+	 * @param int   $stack_ptr      The position of the current token in the stack.
+	 * @param array $single_context Single context (@todo needs better description).
+	 * @param array $plural_context Plural context (@todo needs better description).
 	 * @return void
 	 */
-	protected function compare_single_and_plural_arguments( PHP_CodeSniffer_File $phpcs_file, $stack_ptr, $single_context, $plural_context ) {
+	protected function compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context ) {
 		$single_content = $single_context['tokens'][0]['content'];
 		$plural_content = $plural_context['tokens'][0]['content'];
 
@@ -359,7 +356,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			$error_string = 'Missing singular placeholder, needed for some languages. See https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals';
 			$single_index = $single_context['tokens'][0]['token_index'];
 
-			$phpcs_file->addError( $error_string, $single_index, 'MissingSingularPlaceholder' );
+			$this->phpcsFile->addError( $error_string, $single_index, 'MissingSingularPlaceholder' );
 		}
 
 		// Reordering is fine, but mismatched placeholders is probably wrong.
@@ -367,18 +364,17 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		sort( $plural_placeholders );
 
 		if ( $single_placeholders !== $plural_placeholders ) {
-			$phpcs_file->addWarning( 'Mismatched placeholders is probably an error', $stack_ptr, 'MismatchedPlaceholders' );
+			$this->phpcsFile->addWarning( 'Mismatched placeholders is probably an error', $stack_ptr, 'MismatchedPlaceholders' );
 		}
 	}
 
 	/**
 	 * Check the string itself for problems.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param array                $context    Context (@todo needs better description).
+	 * @param array $context Context (@todo needs better description).
 	 * @return void
 	 */
-	protected function check_text( PHP_CodeSniffer_File $phpcs_file, $context ) {
+	protected function check_text( $context ) {
 		$stack_ptr = $context['stack_ptr'];
 		$arg_name  = $context['arg_name'];
 		$content   = $context['tokens'][0]['content'];
@@ -391,7 +387,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 
 		if ( $unordered_matches_count > 0 && $unordered_matches_count !== $all_matches_count && $all_matches_count > 1 ) {
 			$code = $this->string_to_errorcode( 'MixedOrderedPlaceholders' . ucfirst( $arg_name ) );
-			$phpcs_file->addError(
+			$this->phpcsFile->addError(
 				'Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.',
 				$stack_ptr,
 				$code,
@@ -428,9 +424,9 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			if ( true === $fix ) {
 				$fixed_str = preg_replace( $replace_regexes, $replacements, $content, 1 );
 
-				$phpcs_file->fixer->beginChangeset();
-				$phpcs_file->fixer->replaceToken( $stack_ptr, $fixed_str );
-				$phpcs_file->fixer->endChangeset();
+				$this->phpcsFile->fixer->beginChangeset();
+				$this->phpcsFile->fixer->replaceToken( $stack_ptr, $fixed_str );
+				$this->phpcsFile->fixer->endChangeset();
 			}
 		} // End if().
 
@@ -443,24 +439,18 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $non_placeholder_content );
 
 		if ( empty( $non_placeholder_content ) ) {
-			$phpcs_file->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
+			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
 		}
 	} // End check_text().
 
 	/**
 	 * Check for the presence of a translators comment if one of the text strings contains a placeholder.
 	 *
-	 * @since 0.11.0
-	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param int                  $stack_ptr  The position of the gettext call token
-	 *                                         in the stack.
-	 * @param array                $args       The function arguments.
+	 * @param int   $stack_ptr  The position of the gettext call token in the stack.
+	 * @param array $args       The function arguments.
 	 * @return void
 	 */
-	protected function check_for_translator_comment( PHP_CodeSniffer_File $phpcs_file, $stack_ptr, $args ) {
-		$tokens = $phpcs_file->getTokens();
-
+	protected function check_for_translator_comment( $stack_ptr, $args ) {
 		foreach ( $args as $arg ) {
 			if ( false === in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
 				continue;
@@ -476,7 +466,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 					continue;
 				}
 
-				$previous_comment = $phpcs_file->findPrevious( PHP_CodeSniffer_Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+				$previous_comment = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$commentTokens, ( $stack_ptr - 1 ) );
 
 				if ( false !== $previous_comment ) {
 					/*
@@ -485,11 +475,11 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 					 */
 					$correctly_placed = false;
 
-					if ( ( $tokens[ $previous_comment ]['line'] + 1 ) === $tokens[ $stack_ptr ]['line'] ) {
+					if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) === $this->tokens[ $stack_ptr ]['line'] ) {
 						$correctly_placed = true;
 					} else {
-						$next_non_whitespace = $phpcs_file->findNext( T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
-						if ( false === $next_non_whitespace || $tokens[ $next_non_whitespace ]['line'] === $tokens[ $stack_ptr ]['line'] ) {
+						$next_non_whitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
+						if ( false === $next_non_whitespace || $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $stack_ptr ]['line'] ) {
 							// No non-whitespace found or next non-whitespace is on same line as gettext call.
 							$correctly_placed = true;
 						}
@@ -501,17 +491,17 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 					 */
 					if ( true === $correctly_placed ) {
 
-						if ( T_COMMENT === $tokens[ $previous_comment ]['code'] ) {
-							$comment_text = trim( $tokens[ $previous_comment ]['content'] );
+						if ( T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
+							$comment_text = trim( $this->tokens[ $previous_comment ]['content'] );
 
 			  		   		// If it's multi-line /* */ comment, collect all the parts.
 			  		   		if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
 								for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
-									if ( T_COMMENT !== $tokens[ $i ]['code'] ) {
+									if ( T_COMMENT !== $this->tokens[ $i ]['code'] ) {
 										break;
 									}
 
-									$comment_text = trim( $tokens[ $i ]['content'] ) . $comment_text;
+									$comment_text = trim( $this->tokens[ $i ]['content'] ) . $comment_text;
 								}
 							}
 
@@ -519,13 +509,13 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 								// Comment is ok.
 								return;
 							}
-						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $tokens[ $previous_comment ]['code'] ) {
+						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
 							// If it's docblock comment (wrong style) make sure that it's a translators comment.
-							$db_start      = $phpcs_file->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
-							$db_first_text = $phpcs_file->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ),  $previous_comment );
+							$db_start      = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
+							$db_first_text = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ),  $previous_comment );
 
-							if ( true === $this->is_translators_comment( $tokens[ $db_first_text ]['content'] ) ) {
-								$phpcs_file->addWarning(
+							if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
+								$this->phpcsFile->addWarning(
 									'A "translators:" comment must be a "/* */" style comment. Docblock comments will not be picked up by the tools to generate a ".pot" file.',
 									$stack_ptr,
 									'TranslatorsCommentWrongStyle'
@@ -537,7 +527,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				} // End if().
 
 				// Found placeholders but no translators comment.
-				$phpcs_file->addWarning(
+				$this->phpcsFile->addWarning(
 					'A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.',
 					$stack_ptr,
 					'MissingTranslatorsComment'


### PR DESCRIPTION
This PR addresses duplicate code related to toggling between throwing errors and warnings.
Related to https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/795#discussion_r96204333

It adds two helper functions `addMessage()` and `addFixableMessage()` (and one private grunt function).
Both functions take the same arguments as the PHPCS native `addError()`/`addWarning()` methods with one difference: an extra boolean `$is_error` parameter between the `$stackPtr` and the `$errorcode`.

The PR, of course, also implements the use of the helper functions removing duplicate code.

To use these functions, sniffs have to extend the `WordPress_Sniff`. Three of the sniffs involved did not yet do so. They now do & I've leveraged the fact that they do by letting them defer to using the `$phpcsFile` and `$tokens` properties instead of setting these within each function and/or passing these between functions.
