### PR TITLE
Remove conflict between Long conditional closing comments and commented out code rules

### DIFF
--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -86,6 +86,13 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
 	</rule>
 
+	<!-- Make this sniff less likely to trigger on end comments. -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+	    <properties>
+	        <property name="maxPercentage" value="45" />
+	    </properties>
+	</rule>
+
 	<rule ref="Generic.Commenting">
 		<!-- WP has different alignment of tag values -->
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -33,7 +33,11 @@
 	<rule ref="WordPress.WP.PreparedSQL" />
 
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
-	<rule ref="Squiz.PHP.CommentedOutCode" />
+	<rule ref="Squiz.PHP.CommentedOutCode">
+	    <properties>
+	        <property name="maxPercentage" value="45" />
+	    </properties>
+	</rule>
 
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->
 	<rule ref="Squiz.PHP.Eval"/>


### PR DESCRIPTION
The `Squiz.PHP.CommentedOutCode` sniff triggers on `// End if()` long conditional closing comments which would lead to conflicting messages.

By upping the threshold for the `Squiz.PHP.CommentedOutCode` sniff, this conflict is removed.