### PR TITLE
Efficiency: Defer to the PHPCS native `$numTokens` property for the token count

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -866,7 +866,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		// If this is inside an isset(), check after it as well, all the way to the
 		// end of the scope.
 		if ( $in_isset ) {
-			$end = ( 0 === $start ) ? count( $tokens ) : $tokens[ $start ]['scope_closer'];
+			$end = ( 0 === $start ) ? $this->phpcsFile->numTokens : $tokens[ $start ]['scope_closer'];
 		}
 
 		// Check if we've looked here before.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -112,7 +112,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends Squiz_Sniffs_
 				static $current_loop = array();
 
 				if ( ! isset( $current_loop[ $phpcsFile->fixer->loops ] ) ) {
-					$current_loop[ $phpcsFile->fixer->loops ] = array_fill( 0, count( $tokens ), false );
+					$current_loop[ $phpcsFile->fixer->loops ] = array_fill( 0, $phpcsFile->numTokens, false );
 				}
 
 				if ( false === $current_loop[ $phpcsFile->fixer->loops ][ $arrayStart ] ) {

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -161,8 +161,7 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff implements PHP_CodeSniffer_S
 
 		$endOfStatement   = $phpcsFile->findNext( array( T_SEMICOLON ), ( $stackPtr + 1 ), null, false, null, true );
 		$endOfLineComment = '';
-		$tokenCount       = count( $tokens );
-		for ( $i = ( $endOfStatement + 1 ); $i < $tokenCount; $i++ ) {
+		for ( $i = ( $endOfStatement + 1 ); $i < $phpcsFile->numTokens; $i++ ) {
 
 			if ( $tokens[ $i ]['line'] !== $tokens[ $endOfStatement ]['line'] ) {
 				break;

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -350,7 +350,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 
 			// Only search from the end of the "global ...;" statement onwards.
 			$start        = ( $phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
-			$end          = count( $this->tokens );
+			$end          = $phpcsFile->numTokens;
 			$global_scope = true;
 
 			// Is the global statement within a function call or closure ?


### PR DESCRIPTION
Saves on the overhead of calling `count( $tokens )` numerous times.