### PR TITLE
Add `process()` method to WordPress_Sniff …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,16 +23,15 @@ Example usage:
 ```php
 class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$this->init( $phpcsFile );
-		
+	public function process_token( $stackPtr ) {
+
 		// Check something.
 		
 		if ( $this->has_whitelist_comment( 'CSRF', $stackPtr ) ) {
 			return;
 		}
 		
-		$phpcsFile->addError( ... );
+		$this->phpcsFile->addError( ... );
 	}
 }
 ```

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -84,18 +84,16 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			$phpcsFile->removeTokenListener( $this, $this->register() );
+			$this->phpcsFile->removeTokenListener( $this, $this->register() );
 			return;
 		}
 
@@ -106,13 +104,10 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 			return;
 		}
 
-		// Make phpcsFile and tokens available as properties.
-		$this->init( $phpcsFile );
-
 		$token = $this->tokens[ $stackPtr ];
 
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET ), true ) ) {
-			$equal = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$equal = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 			if ( T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
 				return; // This is not an assignment!
 			}
@@ -129,15 +124,15 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
 			if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-				$operator = $phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
+				$operator = $this->phpcsFile->findNext( array( T_EQUAL ), ( $stackPtr + 1 ) );
 			}
 
-			$keyIdx = $phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			$keyIdx = $this->phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
 			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
 				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
-				$valStart       = $phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
-				$valEnd         = $phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
-				$val            = $phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
+				$valStart       = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valEnd         = $this->phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
 				$val            = $this->strip_quotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -76,18 +76,16 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 		// Reset the temporary storage before processing the token.
 		unset( $this->classname );
 
-		return parent::process( $phpcsFile, $stackPtr );
+		return parent::process_token( $stackPtr );
 	}
 
 	/**

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -150,14 +150,12 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 
 		$this->excluded_groups = array_flip( explode( ',', $this->exclude ) );
 		if ( array_diff_key( $this->groups, $this->excluded_groups ) === array() ) {
@@ -165,9 +163,6 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			// Don't remove the listener as the exclude property can be changed inline.
 			return;
 		}
-
-		// Make phpcsFile and tokens available as properties.
-		$this->init( $phpcsFile );
 
 		if ( true === $this->is_targetted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -86,23 +86,18 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-
-		// Make phpcsFile and tokens available as properties.
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 
 		$token  = $this->tokens[ $stackPtr ];
 		$groups = $this->getGroups();
 
 		if ( empty( $groups ) ) {
-			$phpcsFile->removeTokenListener( $this, $this->register() );
+			$this->phpcsFile->removeTokenListener( $this, $this->register() );
 			return;
 		}
 
@@ -115,8 +110,8 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 		// Check if it is a function not a variable.
 		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
-			$method               = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			$possible_parenthesis = $phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
+			$method               = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$possible_parenthesis = $this->phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
 			if ( T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
 				return; // So .. it is a function after all !
 			}
@@ -139,16 +134,16 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
-				$owner = $phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
-				$child = $phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
+				$owner = $this->phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
+				$child = $this->phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
 				$var   = implode( '', array( $this->tokens[ $owner ]['content'], $token['content'], $this->tokens[ $child ]['content'] ) );
 
 			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 
-				$owner  = $phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
-				$inside = $phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+				$owner  = $this->phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
+				$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
 				$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
 			} else {
 				continue;

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -521,6 +521,35 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	);
 
 	/**
+	 * Set sniff properties and hand off to child class for processing of the token.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$this->init( $phpcsFile );
+		return $this->process_token( $stackPtr );
+	}
+
+	/**
+	 * Processes a sniff when one of its tokens is encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	abstract public function process_token( $stackPtr );
+
+	/**
 	 * Initialize the class for the current process.
 	 *
 	 * This method must be called by child classes before using many of the methods

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -71,13 +71,11 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
@@ -88,8 +86,6 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
 			self::$addedCustomFunctions = true;
 		}
-
-		$this->init( $phpcsFile );
 
 		$instance = $this->tokens[ $stackPtr ];
 

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -37,18 +37,15 @@ class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 
 		if ( ! $this->has_whitelist_comment( 'loose comparison', $stackPtr ) ) {
 			$error  = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
-			$phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
+			$this->phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
 		}
 
 	}

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -161,21 +161,19 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 
-		$file_name      = $phpcsFile->getFileName();
+		$file_name      = $this->phpcsFile->getFileName();
 		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
 
 		if ( 'css' === $file_extension ) {
 			if ( T_STYLE === $this->tokens[ $stackPtr ]['code'] ) {
-				$this->process_css_style( $stackPtr );
+				return $this->process_css_style( $stackPtr );
 			}
 		} elseif ( isset( $this->string_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
 			/*
@@ -189,10 +187,10 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 				$this->in_target_selector[ $file_name ] = false;
 			}
 
-			$this->process_text_for_style( $stackPtr, $file_name );
+			return $this->process_text_for_style( $stackPtr, $file_name );
 
 		} else {
-			parent::process( $phpcsFile, $stackPtr );
+			return parent::process_token( $stackPtr );
 		}
 
 	} // End process().

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -54,21 +54,18 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 *
 	 * @since 0.10.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 
 		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
 			return;
 		}
 
-		parent::process( $phpcsFile, $stackPtr );
+		return parent::process_token( $stackPtr );
 	}
 
 	/**

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -34,15 +34,11 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$this->init( $phpcsFile );
-
+	public function process_token( $stackPtr ) {
 		// Check for global input variable.
 		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], self::$input_superglobals, true ) ) {
 			return;
@@ -57,7 +53,7 @@ class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
 
 		// Check for whitelisting comment.
 		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
-			$phpcsFile->addWarning( 'Detected access of super global var %s, probably needs manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
+			$this->phpcsFile->addWarning( 'Detected access of super global var %s, probably needs manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
 
 	}

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -69,13 +69,11 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
@@ -93,7 +91,6 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			self::$addedCustomFunctions = true;
 		}
 
-		$this->init( $phpcsFile );
 		$superglobals = self::$input_superglobals;
 
 		// Handling string interpolation.
@@ -103,7 +100,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 				$this->get_interpolated_variables( $this->tokens[ $stackPtr ]['content'] )
 			);
 			foreach ( array_intersect( $interpolated_variables, $superglobals ) as $bad_variable ) {
-				$phpcsFile->addError( 'Detected usage of a non-sanitized, non-validated input variable %s: %s', $stackPtr, 'InputNotValidatedNotSanitized', array( $bad_variable, $this->tokens[ $stackPtr ]['content'] ) );
+				$this->phpcsFile->addError( 'Detected usage of a non-sanitized, non-validated input variable %s: %s', $stackPtr, 'InputNotValidatedNotSanitized', array( $bad_variable, $this->tokens[ $stackPtr ]['content'] ) );
 			}
 
 			return;
@@ -134,7 +131,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 
 		// Check for validation first.
 		if ( ! $this->is_validated( $stackPtr, $array_key, $this->check_validation_in_scope_only ) ) {
-			$phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );
+			$this->phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );
 			// return; // Should we just return and not look for sanitizing functions ?
 		}
 
@@ -149,7 +146,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 
 		// Now look for sanitizing functions.
 		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
-			$phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
+			$this->phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
 		}
 
 	} // End process().

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -280,25 +280,22 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 		$token = $this->tokens[ $stackPtr ];
 
 		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
-			$bracketPtr = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			$bracketPtr = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 			if ( false === $bracketPtr || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] || ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
 				return;
 			}
 
 			// Bow out if the array key contains a variable.
-			$has_variable = $phpcsFile->findNext( T_VARIABLE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'] );
+			$has_variable = $this->phpcsFile->findNext( T_VARIABLE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'] );
 			if ( false !== $has_variable ) {
 				return;
 			}
@@ -349,15 +346,15 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			}
 
 			// Only search from the end of the "global ...;" statement onwards.
-			$start        = ( $phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
-			$end          = $phpcsFile->numTokens;
+			$start        = ( $this->phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
+			$end          = $this->phpcsFile->numTokens;
 			$global_scope = true;
 
 			// Is the global statement within a function call or closure ?
 			// If so, limit the token walking to the function scope.
-			$function_token = $phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			$function_token = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
 			if ( false === $function_token ) {
-				$function_token = $phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+				$function_token = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
 			}
 
 			if ( false !== $function_token ) {
@@ -388,7 +385,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 					&& in_array( $this->tokens[ $ptr ]['content'], $search, true )
 				) {
 					// Don't throw false positives for static class properties.
-					$previous = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
+					$previous = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
 					if ( false !== $previous && T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {
 						continue;
 					}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -72,7 +72,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	/**
 	 * Text domain.
 	 *
-	 * @todo Eventually this should be able to be auto-supplied via looking at $phpcs_file->getFilename()
+	 * @todo Eventually this should be able to be auto-supplied via looking at $this->phpcsFile->getFilename()
 	 * @link https://youtrack.jetbrains.com/issue/WI-17740
 	 *
 	 * @var array
@@ -129,18 +129,12 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param int                  $stack_ptr  The position of the current token
-	 *                                         in the stack.
+	 * @param int $stack_ptr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
-
-		// Make phpcsFile and tokens available as properties.
-		$this->init( $phpcs_file );
-
-		$token  = $this->tokens[ $stack_ptr ];
+	public function process_token( $stack_ptr ) {
+		$token = $this->tokens[ $stack_ptr ];
 
 		// Allow overruling the text_domain set in a ruleset via the command line.
 		$cl_text_domain = trim( PHP_CodeSniffer::getConfigData( 'text_domain' ) );
@@ -153,7 +147,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		}
 
 		if ( '_' === $token['content'] ) {
-			$phpcs_file->addError( 'Found single-underscore "_()" function when double-underscore expected.', $stack_ptr, 'SingleUnderscoreGetTextFunction' );
+			$this->phpcsFile->addError( 'Found single-underscore "_()" function when double-underscore expected.', $stack_ptr, 'SingleUnderscoreGetTextFunction' );
 		}
 
 		if ( ! isset( $this->i18n_functions[ $token['content'] ] ) ) {
@@ -162,10 +156,10 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		$translation_function = $token['content'];
 
 		if ( in_array( $translation_function, array( 'translate', 'translate_with_gettext_context' ), true ) ) {
-			$phpcs_file->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $translation_function ) );
+			$this->phpcsFile->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $translation_function ) );
 		}
 
-		$func_open_paren_token = $phpcs_file->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
+		$func_open_paren_token = $this->phpcsFile->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
 		if ( false === $func_open_paren_token || T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code'] ) {
 			 return;
 		}
@@ -302,7 +296,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 		} // End if().
 
 		if ( ! empty( $arguments_tokens ) ) {
-			$phpcs_file->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $translation_function ) );
+			$this->phpcsFile->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $translation_function ) );
 		}
 
 		foreach ( $argument_assertions as $argument_assertion_context ) {

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -94,17 +94,14 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
-	 *
 	 * @since 0.8.0
 	 *
-	 * @return int|void
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-
-		$this->init( $phpcsFile );
+	public function process_token( $stackPtr ) {
 
 		// Check for $wpdb variable.
 		if ( '$wpdb' !== $this->tokens[ $stackPtr ]['content'] ) {
@@ -133,7 +130,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				);
 
 				foreach ( $bad_variables as $bad_variable ) {
-					$phpcsFile->addError(
+					$this->phpcsFile->addError(
 						'Use placeholders and $wpdb->prepare(); found interpolated variable $%s at %s',
 						$this->i,
 						'NotPrepared',
@@ -177,7 +174,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				}
 			}
 
-			$phpcsFile->addError(
+			$this->phpcsFile->addError(
 				'Use placeholders and $wpdb->prepare(); found %s',
 				$this->i,
 				'NotPrepared',

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -108,17 +108,13 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 		$this->blank_line_check 	  = (bool) $this->blank_line_check;
 		$this->blank_line_after_check = (bool) $this->blank_line_after_check;
-
-		$this->init( $phpcsFile );
 
 		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
 			&& ! ( T_ELSE === $this->tokens[ $stackPtr ]['code'] && T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
@@ -126,19 +122,19 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				&& 0 >= (int) $this->spaces_before_closure_open_paren )
 		) {
 			$error = 'Space after opening control structure is required';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
 
 			if ( true === $fix ) {
-				$phpcsFile->fixer->beginChangeset();
-				$phpcsFile->fixer->addContent( $stackPtr, ' ' );
-				$phpcsFile->fixer->endChangeset();
+				$this->phpcsFile->fixer->beginChangeset();
+				$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+				$this->phpcsFile->fixer->endChangeset();
 			}
 		}
 
 		if ( ! isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 
 			if ( T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
-				$scopeOpener = $phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
+				$scopeOpener = $this->phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
 				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
 			} elseif ( T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {
 				return;
@@ -155,30 +151,30 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				if ( T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Space between opening control structure and T_COLON is required';
-					$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
+					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			} elseif ( 'forbidden' === $this->space_before_colon ) {
 
 				if ( T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Extra space between opening control structure and T_COLON found';
-					$fix   = $phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
+					$fix   = $this->phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			}
 		} // End if().
 
-		$parenthesisOpener = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$parenthesisOpener = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If this is a function declaration.
 		if ( T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
@@ -190,7 +186,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			} elseif ( T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
 				// This function returns by reference (function &function_name() {}).
-				$parenthesisOpener = $phpcsFile->findNext(
+				$parenthesisOpener = $this->phpcsFile->findNext(
 					PHP_CodeSniffer_Tokens::$emptyTokens,
 					( $parenthesisOpener + 1 ),
 					null,
@@ -200,7 +196,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 
 			if ( isset( $function_name_ptr ) ) {
-				$parenthesisOpener = $phpcsFile->findNext(
+				$parenthesisOpener = $this->phpcsFile->findNext(
 					PHP_CodeSniffer_Tokens::$emptyTokens,
 					( $parenthesisOpener + 1 ),
 					null,
@@ -211,7 +207,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				if ( ( $function_name_ptr + 1 ) !== $parenthesisOpener ) {
 
 					$error = 'Space between function name and opening parenthesis is prohibited.';
-					$fix   = $phpcsFile->addFixableError(
+					$fix   = $this->phpcsFile->addFixableError(
 						$error,
 						$stackPtr,
 						'SpaceBeforeFunctionOpenParenthesis',
@@ -219,9 +215,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					);
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->replaceToken( ( $function_name_ptr + 1 ), '' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( ( $function_name_ptr + 1 ), '' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			}
@@ -230,7 +226,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			// Check if there is a use () statement.
 			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
 
-				$usePtr = $phpcsFile->findNext(
+				$usePtr = $this->phpcsFile->findNext(
 					PHP_CodeSniffer_Tokens::$emptyTokens,
 					( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
 					null,
@@ -259,12 +255,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				if ( ( $stackPtr + 1 ) !== $parenthesisOpener ) {
 					// Checking this: function[*](...) {}.
 					$error = 'Space before closure opening parenthesis is prohibited';
-					$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
+					$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			} elseif (
@@ -277,12 +273,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				// Checking this: if[*](...) {}.
 				$error = 'No space before opening parenthesis is prohibited';
-				$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->addContent( $stackPtr, ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
 		} // End if().
@@ -293,7 +289,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		) {
 			// Checking this: if [*](...) {}.
 			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
-			$fix   = $phpcsFile->addFixableError(
+			$fix   = $this->phpcsFile->addFixableError(
 				$error,
 				$stackPtr,
 				'ExtraSpaceBeforeOpenParenthesis',
@@ -301,9 +297,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			);
 
 			if ( true === $fix ) {
-				$phpcsFile->fixer->beginChangeset();
-				$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
-				$phpcsFile->fixer->endChangeset();
+				$this->phpcsFile->fixer->beginChangeset();
+				$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
+				$this->phpcsFile->fixer->endChangeset();
 			}
 		}
 
@@ -311,12 +307,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 				// Checking this: $value = my_function([*]...).
 				$error = 'No space after opening parenthesis is prohibited';
-				$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			} elseif ( ( ' ' !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content']
 				&& "\n" !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content']
@@ -325,7 +321,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			) {
 				// Checking this: if ([*]...) {}.
 				$error = 'Expected exactly one space after opening parenthesis; "%s" found.';
-				$fix   = $phpcsFile->addFixableError(
+				$fix   = $this->phpcsFile->addFixableError(
 					$error,
 					$stackPtr,
 					'ExtraSpaceAfterOpenParenthesis',
@@ -333,9 +329,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				);
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->replaceToken( ( $parenthesisOpener + 1 ), ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->replaceToken( ( $parenthesisOpener + 1 ), ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
 		}
@@ -349,18 +345,18 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				// Checking this: if (...[*]) {}.
 				if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
 					$error = 'No space before closing parenthesis is prohibited';
-					$fix   = $phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+					$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				} elseif ( ' ' !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['content'] ) {
-					$prevNonEmpty = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $parenthesisCloser - 1 ), null, true );
+					$prevNonEmpty = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $parenthesisCloser - 1 ), null, true );
 					if ( $this->tokens[ ( $parenthesisCloser ) ]['line'] === $this->tokens[ ( $prevNonEmpty + 1 ) ]['line'] ) {
 						$error = 'Expected exactly one space before closing parenthesis; "%s" found.';
-						$fix   = $phpcsFile->addFixableError(
+						$fix   = $this->phpcsFile->addFixableError(
 							$error,
 							$stackPtr,
 							'ExtraSpaceBeforeCloseParenthesis',
@@ -368,9 +364,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 						);
 
 						if ( true === $fix ) {
-							$phpcsFile->fixer->beginChangeset();
-							$phpcsFile->fixer->replaceToken( ( $parenthesisCloser - 1 ), ' ' );
-							$phpcsFile->fixer->endChangeset();
+							$this->phpcsFile->fixer->beginChangeset();
+							$this->phpcsFile->fixer->replaceToken( ( $parenthesisCloser - 1 ), ' ' );
+							$this->phpcsFile->fixer->endChangeset();
 						}
 					}
 				}
@@ -380,12 +376,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					&& ( isset( $scopeOpener ) && T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
 				) {
 					$error = 'Space between opening control structure and closing parenthesis is required';
-					$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
+					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
 
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			} // End if().
@@ -395,17 +391,17 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
 			) {
 				$error = 'Opening brace should be on the same line as the declaration';
-				$fix   = $phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
+				$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
 
 					for ( $i = ( $parenthesisCloser + 1 ); $i < $scopeOpener; $i++ ) {
-						$phpcsFile->fixer->replaceToken( $i, '' );
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
 					}
 
-					$phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 				return;
 
@@ -416,7 +412,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 
 				// Checking this: if (...) [*]{}.
 				$error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
-				$fix   = $phpcsFile->addFixableError(
+				$fix   = $this->phpcsFile->addFixableError(
 					$error,
 					$stackPtr,
 					'ExtraSpaceAfterCloseParenthesis',
@@ -424,15 +420,15 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				);
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			} // End if().
 		} // End if().
 
 		if ( true === $this->blank_line_check && isset( $scopeOpener ) ) {
-			$firstContent = $phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
+			$firstContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
 
 			// We ignore spacing for some structures that tend to have their own rules.
 			$ignore = array(
@@ -451,24 +447,24 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				&& $this->tokens[ $firstContent ]['line'] > ( $this->tokens[ $scopeOpener ]['line'] + 1 )
 			) {
 				$error = 'Blank line found at start of control structure';
-				$fix   = $phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
+				$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
 
 					for ( $i = ( $scopeOpener + 1 ); $i < $firstContent; $i++ ) {
-						$phpcsFile->fixer->replaceToken( $i, '' );
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
 					}
 
-					$phpcsFile->fixer->addNewline( $scopeOpener );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->addNewline( $scopeOpener );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
 
 			if ( $firstContent !== $scopeCloser ) {
-				$lastContent = $phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
+				$lastContent = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
 
-				$lastNonEmptyContent = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
+				$lastNonEmptyContent = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
 
 				$checkToken = $lastContent;
 				if ( isset( $this->tokens[ $lastNonEmptyContent ]['scope_condition'] ) ) {
@@ -484,17 +480,17 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 						) {
 							// TODO: Reporting error at empty line won't highlight it in IDE.
 							$error = 'Blank line found at end of control structure';
-							$fix   = $phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
+							$fix   = $this->phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
 
 							if ( true === $fix ) {
-								$phpcsFile->fixer->beginChangeset();
+								$this->phpcsFile->fixer->beginChangeset();
 
 								for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
-									$phpcsFile->fixer->replaceToken( $j, '' );
+									$this->phpcsFile->fixer->replaceToken( $j, '' );
 								}
 
-								$phpcsFile->fixer->addNewlineBefore( $scopeCloser );
-								$phpcsFile->fixer->endChangeset();
+								$this->phpcsFile->fixer->addNewlineBefore( $scopeCloser );
+								$this->phpcsFile->fixer->endChangeset();
 							}
 							break;
 						} // End if().
@@ -508,7 +504,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			return;
 		}
 
-		$trailingContent = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
+		$trailingContent = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {
 			return;
 		}
@@ -548,18 +544,18 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			if ( ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line'] ) {
 				// TODO: Won't cover following case: "} echo 'OK';".
 				$error = 'Blank line found after control structure';
-				$fix   = $phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
+				$fix   = $this->phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
 
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
 
 					for ( $i = ( $scopeCloser + 1 ); $i < $trailingContent; $i++ ) {
-						$phpcsFile->fixer->replaceToken( $i, '' );
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
 					}
 
 					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
-					$phpcsFile->fixer->addNewlineBefore( $trailingContent );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
 		} // End if().

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -111,13 +111,12 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return int|void
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process_token( $stackPtr ) {
 		// Merge any custom functions with the defaults, if we haven't already.
 		if ( ! self::$addedCustomFunctions ) {
 			self::$escapingFunctions    = array_merge( self::$escapingFunctions, array_flip( $this->customEscapingFunctions ) );
@@ -126,18 +125,16 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 			if ( ! empty( $this->customSanitizingFunctions ) ) {
 				self::$escapingFunctions = array_merge( self::$escapingFunctions, array_flip( $this->customSanitizingFunctions ) );
-				$phpcsFile->addWarning( 'The customSanitizingFunctions property is deprecated in favor of customEscapingFunctions.', 0, 'DeprecatedCustomSanitizingFunctions' );
+				$this->phpcsFile->addWarning( 'The customSanitizingFunctions property is deprecated in favor of customEscapingFunctions.', 0, 'DeprecatedCustomSanitizingFunctions' );
 			}
 
 			self::$addedCustomFunctions = true;
 		}
 
-		$this->init( $phpcsFile );
-
 		$function = $this->tokens[ $stackPtr ]['content'];
 
 		// Find the opening parenthesis (if present; T_ECHO might not have it).
-		$open_paren = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$open_paren = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If function, not T_ECHO nor T_PRINT.
 		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
@@ -152,7 +149,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 			// These functions only need to have the first argument escaped.
 			if ( in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
-				$end_of_statement = $phpcsFile->findEndOfStatement( $open_paren + 1 );
+				$end_of_statement = $this->phpcsFile->findEndOfStatement( $open_paren + 1 );
 			}
 		}
 
@@ -162,7 +159,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		}
 
 		if ( isset( $end_of_statement, self::$unsafePrintingFunctions[ $function ] ) ) {
-			$error = $phpcsFile->addError( "Expected next thing to be an escaping function (like %s), not '%s'", $stackPtr, 'UnsafePrintingFunction', array( self::$unsafePrintingFunctions[ $function ], $function ) );
+			$error = $this->phpcsFile->addError( "Expected next thing to be an escaping function (like %s), not '%s'", $stackPtr, 'UnsafePrintingFunction', array( self::$unsafePrintingFunctions[ $function ], $function ) );
 
 			// If the error was reported, don't bother checking the function's arguments.
 			if ( $error ) {
@@ -175,14 +172,14 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		// This is already determined if this is a function and not T_ECHO.
 		if ( ! isset( $end_of_statement ) ) {
 
-			$end_of_statement = $phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
-			$last_token       = $phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
+			$end_of_statement = $this->phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
+			$last_token       = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
 
 			// Check for the ternary operator. We only need to do this here if this
 			// echo is lacking parenthesis. Otherwise it will be handled below.
 			if ( T_OPEN_PARENTHESIS !== $this->tokens[ $open_paren ]['code'] || T_CLOSE_PARENTHESIS !== $this->tokens[ $last_token ]['code'] ) {
 
-				$ternary = $phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );
+				$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );
 
 				// If there is a ternary skip over the part before the ?. However, if
 				// the ternary is within parentheses, it will be handled in the loop.
@@ -222,11 +219,11 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 				} else {
 
 					// Skip over the condition part of a ternary (i.e., to after the ?).
-					$ternary = $phpcsFile->findNext( T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
+					$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
 
 					if ( false !== $ternary ) {
 
-						$next_paren = $phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
+						$next_paren = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
 
 						// We only do it if the ternary isn't within a subset of parentheses.
 						if ( false === $next_paren || ( isset( $this->tokens[ $next_paren ]['parenthesis_closer'] ) && $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) ) {


### PR DESCRIPTION
…and change to `process_token()` method in child classes.

This saves us having to call `$this->init()` from every child class, always sets the basic properties and makes them available to the child classes.

This PR addressed the third bullet from issue #765

~~P.S.: For the CronInterval sniff, the changes have been kept to a minimum to avoid large conflicts with #818.~~ As #818 has been merged, fixed up the CronInterval sniff to be inline with the rest of the PR.