### PR TITLE
Fix custom properties whitelist in valid variable name sniff

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -280,15 +280,16 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			return;
 		}
 
-		if ( ! empty( $this->customPropertiesWhitelist ) ) {
-			if ( ! is_array( $this->customPropertiesWhitelist ) ) {
-				// Incorrectly set property.
-				$phpcs_file->addWarning(
-					'The customVariablesWhitelist property should be provided with type="array".',
-					0,
-					'WrongFormatCustomVariablesWhitelist'
-				);
-			}
+		if (
+			! empty( $this->customPropertiesWhitelist )
+			&& ! is_array( $this->customPropertiesWhitelist )
+		) {
+			// Incorrectly set property.
+			$phpcs_file->addWarning(
+				'The customVariablesWhitelist property should be provided with type="array".',
+				0,
+				'WrongFormatCustomVariablesWhitelist'
+			);
 
 			// Potentially correct incorrect format.
 			if ( is_string( $this->customPropertiesWhitelist ) ) {


### PR DESCRIPTION
The value of the `customPropertiesWhitelist` property of the `WordPress.NamingConventions.ValidVariableName` sniff was always being discarded. This is because the logic that was intended to only be dealing with a non-array value was actually being applied even when the value was properly set as an array. (See line 299.) I noticed this while running against a rulseset that utilizes this property, and so I fixed it, and now it is working properly.

Apparently this isn't covered by the tests, which only cover the sniffs themselves and not rulesets. Not sure if there is a way to remedy that right now or not.