### PR TITLE
Prevent erroneous dropping of customPropertiesWhitelist array on ValidVariableName sniff

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -293,8 +293,10 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			// Potentially correct incorrect format.
 			if ( is_string( $this->customPropertiesWhitelist ) ) {
 				$this->customPropertiesWhitelist = array_map( 'trim', explode( ',', $this->customPropertiesWhitelist ) );
-			} else {
-				// Otherwise, disregard the value.
+			}
+
+			// Otherwise, disregard the value.
+			if ( ! is_array( $this->customPropertiesWhitelist ) ) {
 				$this->customPropertiesWhitelist = array();
 			}
 		}


### PR DESCRIPTION
My PHPCS ruleset included:

```xml
<rule ref="WordPress.NamingConventions.ValidVariableName">
	<properties>
		<property name="customPropertiesWhitelist" type="array" value="textContent,nodeName,nodeValue" />
	</properties>
</rule>
```

Nevertheless, I was still getting flagged for code like:

```php
'label' => $link->textContent,
```

I found that the conditions surrounding the retrieval of the `customPropertiesWhitelist` property were inadvertently dropping the value when it was defined properly as an `array`.