### PR TITLE
Whitelist invalid snake_case WordPress globals

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -54,6 +54,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 */
 	protected $wordpress_mixed_case_vars = array(
 		'EZSQL_ERROR' => true,
+		'$is_IIS'     => true,
 		'PHP_SELF'    => true,
 	);
 

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -54,7 +54,11 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 	 */
 	protected $wordpress_mixed_case_vars = array(
 		'EZSQL_ERROR' => true,
-		'$is_IIS'     => true,
+		'is_IE'       => true,
+		'is_IIS'      => true,
+		'is_macIE'    => true,
+		'is_NS4'      => true,
+		'is_winIE'    => true,
 		'PHP_SELF'    => true,
 	);
 


### PR DESCRIPTION
Probably not often-used, but the global $is_IIS it is giving me a warning in an otherwise pristine coding-standards-adhering file :-(