### PR TITLE
ValidVariableNameSniff: fix typo

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -304,7 +304,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			$customProperties = WordPress_Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
 
 			if ( ! empty( $this->customVariablesWhitelist ) ) {
-				$properties = WordPress_Sniff::merge_custom_array(
+				$customProperties = WordPress_Sniff::merge_custom_array(
 					$this->customVariablesWhitelist,
 					$customProperties,
 					false


### PR DESCRIPTION
As expected, as soon as its merged, I see a typo in a property name ;-)