### PR TITLE
Adding missing escaping check for `<?=`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
       env: PHPCS_BRANCH=master
     - php: nightly
       env: PHPCS_BRANCH=master
+    # Test PHP 5.3 with short_open_tags set to On (is Off by default)
+    - php: 5.3
+      env: PHPCS_BRANCH=master SHORT_OPEN_TAGS=true
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
@@ -44,6 +47,7 @@ before_script:
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
+    - if [[ "$SHORT_OPEN_TAGS" == "true" ]]; then echo "short_open_tag = On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -116,6 +116,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			T_PRINT,
 			T_EXIT,
 			T_STRING,
+			T_OPEN_TAG_WITH_ECHO,
 		);
 
 	}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -124,7 +124,6 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		 * which is how open short tags are being handled in that case.
 		 */
 		if ( false === $this->is_short_open_tag_enabled() ) {
-			var_export( 'Short open tag is disabled!' );
 			$tokens[] = T_INLINE_HTML;
 		}
 		return $tokens;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -131,7 +131,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			T_OPEN_TAG_WITH_ECHO,
 		);
 
-		/**
+		/*
 		 * In case open_short_tag is turned off, we can attempt to regex T_INLINE_HTML
 		 * which is how open short tags are being handled in that case.
 		 */

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -181,7 +181,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 				return;
 			}
 
-			// Report on what very likely is a PHP short open tag outputing variable.
+			// Report on what very likely is a PHP short open tag outputting variable.
 			if ( preg_match( '/\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:(?:->\S+|\[[^\]]+\]))*)[\s]*;?[\s]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
 				$this->phpcsFile->addError( 'Expected next thing to be an escaping function, not %s.', $stackPtr, 'OutputNotEscaped', $matches[1] );
 				return;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -120,7 +120,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	 * @return array
 	 */
 	public function register() {
-		// Check whether short_open_tag is disabled on PHP version < 5.4 (it''s enabled by default in later versions).
+		// Check whether short_open_tag is disabled on PHP version < 5.4 (it's enabled by default in later versions).
 		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 			$this->short_open_tag_enabled = false;
 		}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -182,7 +182,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			}
 
 			// Report on what very likely is a PHP short open tag outputing variable.
-			if ( preg_match( '/\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)[\s]*;?[\s]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
+			if ( preg_match( '//\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:(?:->\S+|\[[^\]]+\]))*)[\s]*;?[\s]*\?\>//', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
 				$this->phpcsFile->addError( 'Expected next thing to be an escaping function, not %s.', $stackPtr, 'OutputNotEscaped', $matches[1] );
 				return;
 			}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -132,8 +132,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		);
 
 		/*
-		 * In case open_short_tag is turned off, we can attempt to regex T_INLINE_HTML
-		 * which is how open short tags are being handled in that case.
+		 * In case short_open_tag is turned off, we can attempt to regex T_INLINE_HTML
+		 * which is how short open tags are being handled in that case.
 		 */
 		if ( false === $this->short_open_tag_enabled ) {
 			$tokens[] = T_INLINE_HTML;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -179,16 +179,16 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 				return;
 			}
 
-			// Report on what very likely is a PHP short open tag outputing variable
+			// Report on what very likely is a PHP short open tag outputing variable.
 			if ( preg_match( '/\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)[\s]*;?[\s]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
-				$this->phpcsFile->addError( "Expected next thing to be an escaping function, not %s.", $stackPtr, 'OutputNotEscaped', $matches[1] );
+				$this->phpcsFile->addError( 'Expected next thing to be an escaping function, not %s.', $stackPtr, 'OutputNotEscaped', $matches[1] );
 				return;
 			}
 
-			// Throw warning in case the T_INLINE_HTML looks like a open_short_tag
-			if ( false !== strpos( $this->tokens[$stackPtr]['content'], '<?=' ) ) {
+			// Throw warning in case the T_INLINE_HTML looks like a open_short_tag.
+			if ( false !== strpos( $this->tokens[ $stackPtr ]['content'], '<?=' ) ) {
 				$this->phpcsFile->addWarning( 'Possible use of PHP short open tag ( "<?=" ) detected. Needs manual inspection.', $stackPtr, 'PossibleShortOpenTag' );
-				return;	
+				return;
 			}
 			return;
 		}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -123,7 +123,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			$this->short_open_tag_enabled = false;
 		}
 
-		$tokens =  array(
+		$tokens = array(
 			T_ECHO,
 			T_PRINT,
 			T_EXIT,

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -108,6 +108,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	/**
 	 * Status of short_open_tag feature
 	 *
+	 * @since 0.11.0
+	 *
 	 * @var bool
 	 */
 	private $short_open_tag_enabled = true;

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -180,7 +180,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			}
 
 			// Report on what very likely is a PHP short open tag outputing variable
-			if ( preg_match( '/\<\?\=[\s\t]*(\$[a-zA-Z_][[:alnum:]_]+)[\s\t]*\;?[\s\t]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
+			if ( preg_match( '/\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)[\s]*;?[\s]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
 				$this->phpcsFile->addError( "Expected next thing to be an escaping function, not %s.", $stackPtr, 'OutputNotEscaped', $matches[1] );
 				return;
 			}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -182,7 +182,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			}
 
 			// Report on what very likely is a PHP short open tag outputing variable.
-			if ( preg_match( '//\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:(?:->\S+|\[[^\]]+\]))*)[\s]*;?[\s]*\?\>//', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
+			if ( preg_match( '/\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:(?:->\S+|\[[^\]]+\]))*)[\s]*;?[\s]*\?\>/', $this->tokens[ $stackPtr ]['content'], $matches ) ) {
 				$this->phpcsFile->addError( 'Expected next thing to be an escaping function, not %s.', $stackPtr, 'OutputNotEscaped', $matches[1] );
 				return;
 			}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -120,8 +120,8 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 		);
 
 		/**
-		 * In case open_short_tag are turned off, we can attempt to regex T_INLINE_HTML
-		 * which is how open_short_tags are being handled in that case.
+		 * In case open_short_tag is turned off, we can attempt to regex T_INLINE_HTML
+		 * which is how open short tags are being handled in that case.
 		 */
 		if ( false === $this->is_short_open_tag_enabled() ) {
 			var_export( 'Short open tag is disabled!' );

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -119,7 +119,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	 */
 	public function register() {
 		// Check whether short_open_tag is disabled on PHP version < 5.4 (it''s enabled by default in later versions).
-		if ( true === version_compare(phpversion(), '5.4', '<' ) && false === (bool) ini_get( 'short_open_tag' ) ) {
+		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 			$this->short_open_tag_enabled = false;
 		}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -209,5 +209,7 @@ echo cpt_info( $post_type, 'query' ); // Bad.
 ?>
 <?= $var ?><!-- Bad. -->
 <?= esc_html( $var ); ?><!-- Ok. -->
+<?= $var['foo']; ?><!-- Bad. -->
+<?= $var->foo ?><!-- Bad. -->
 <?php
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -205,3 +205,13 @@ to_screen( esc_form_field( $var1), esc_attr( $var2 ) ); // Ok.
 echo esc_form_field( $var ); // Bad.
 echo post_info( $post_id, 'field' ); // Bad.
 echo cpt_info( $post_type, 'query' ); // Bad.
+
+// Bad.
+?>
+<?= $var ?>
+<?php
+
+// Ok.
+<?= esc_html( $var ); ?>
+<?php
+

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -206,13 +206,8 @@ echo esc_form_field( $var ); // Bad.
 echo post_info( $post_id, 'field' ); // Bad.
 echo cpt_info( $post_type, 'query' ); // Bad.
 
-// Bad.
 ?>
-<?= $var ?>
-<?php
-
-// Ok.
-?>
-<?= esc_html( $var ); ?>
+<?= $var ?><!-- Bad. -->
+<?= esc_html( $var ); ?><!-- Ok. -->
 <?php
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -212,6 +212,7 @@ echo cpt_info( $post_type, 'query' ); // Bad.
 <?php
 
 // Ok.
+?>
 <?= esc_html( $var ); ?>
 <?php
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -63,6 +63,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			205 => 1,
 			206 => 1,
 			207 => 1,
+			211 => 1,
 		);
 
 	} // end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -77,7 +77,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 		$list = array();
 
 		//Adding Warning which is triggerred in case open_short_tag is set to Off
-		if ( false === (bool) ini_get( 'short_open_tag' ) ) {
+		if ( true === version_compare(phpversion(), '5.4', '<' ) && false === (bool) ini_get( 'short_open_tag' ) ) {
 			$list[211] = 1;
 		}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -74,8 +74,14 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		$list = array();
 
+		//Adding Warning which is triggerred in case open_short_tag is set to Off
+		if ( false === (bool) ini_get( 'short_open_tag' ) ) {
+			$list[211] = 1;
+		}
+
+		return $list;
 	}
 
 } // End class.

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -64,6 +64,8 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			206 => 1,
 			207 => 1,
 			210 => 1,
+			212 => 1,
+			213 => 1,
 		);
 
 	} // end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -76,7 +76,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		$list = array();
 
-		//Adding Warning which is triggerred in case open_short_tag is set to Off
+		// Adding Warning which is triggerred in case open_short_tag is set to Off.
 		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 			$list[211] = 1;
 		}

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -63,7 +63,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			205 => 1,
 			206 => 1,
 			207 => 1,
-			211 => 1,
+			210 => 1,
 		);
 
 	} // end getErrorList()

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -77,7 +77,7 @@ class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
 		$list = array();
 
 		//Adding Warning which is triggerred in case open_short_tag is set to Off
-		if ( true === version_compare(phpversion(), '5.4', '<' ) && false === (bool) ini_get( 'short_open_tag' ) ) {
+		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 			$list[211] = 1;
 		}
 


### PR DESCRIPTION
This commit registers `T_OPEN_TAG_WITH_ECHO` in EscapeOutputSniff and adds new test for those cases

Fixes #857 

cc @westonruter 