### PR TITLE
Up the minimum PHPCS version to 2.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.7.1
+  - PHPCS_BRANCH=2.8.1
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.7.0** or higher, though it is strongly recommended to use PHPCS 2.8.1 or higher as older versions contain a security vulnerability.
+The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.8.1** or higher.
 The WordPress Coding Standards are currently [not compatible with the upcoming PHPCS 3 release](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718).
 
 ### Composer

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.7.0** or higher.
+The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.7.0** or higher, though it is strongly recommended to use PHPCS 2.8.1 or higher as older versions contain a security vulnerability.
 The WordPress Coding Standards are currently [not compatible with the upcoming PHPCS 3 release](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718).
 
 ### Composer

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.7"
+		"squizlabs/php_codesniffer": "^2.8.1"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
PHPCS 2.8.1 has just been released and contains a fix for security vulnerability. I'd like to suggest we up the minimum version as the `Generic.PHP.Syntax` sniff is being used in the `WordPress-Extra`  ruleset.

From the release notes:
> This release contains a fix for a security advisory related to the improper handling of shell commands
>     * Uses of shell_exec() and exec() were not escaping filenames and configuration settings in most cases
>     * A properly crafted filename or configuration option would allow for arbitrary code execution when using some features
>     * All users are encouraged to upgrade to this version, especially if you are checking 3rd-party code
>           * e.g., you run PHPCS over libraries that you did not write
>           * e.g., you provide a web service that runs PHPCS over user-uploaded files or 3rd-party repositories
>           * e.g., you allow external tool paths to be set by user-defined values
>     * If you are unable to upgrade but you check 3rd-party code, ensure you are not using the following features:
>           * The diff report
>           * The notify-send report
>           * The Generic.PHP.Syntax sniff
>           * The Generic.Debug.CSSLint sniff
>           * The Generic.Debug.ClosureLinter sniff
>           * The Generic.Debug.JSHint sniff
>           * The Squiz.Debug.JSLint sniff
>           * The Squiz.Debug.JavaScriptLint sniff
>           * The Zend.Debug.CodeAnalyzer sniff
>     * Thanks to Klaus Purer for the report