### PR TITLE
Hotfix for master: Up the minimum PHPCS version to 2.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.6.0
+  - PHPCS_BRANCH=2.8.1
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.6"
+		"squizlabs/php_codesniffer": "^2.8.1"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
PHPCS 2.8.1 has just been released and contains a fix for security vulnerability which affects the `WordPress-Extra` ruleset. See PR #860 

I'd like to suggest releasing v 0.10.1 with this fix as soon as this has been merged.

(Can we still merge to master from another branch than `develop` ?)