### PR TITLE
Recognize clean_*_cache() functions as cacheDeleteFunctions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -424,6 +424,17 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 */
 	protected $cacheDeleteFunctions = array(
 		'wp_cache_delete' => true,
+		'clean_attachment_cache' => true,
+		'clean_blog_cache' => true,
+		'clean_bookmark_cache' => true,
+		'clean_category_cache' => true,
+		'clean_comment_cache' => true,
+		'clean_network_cache' => true,
+		'clean_object_term_cache' => true,
+		'clean_page_cache' => true,
+		'clean_post_cache' => true,
+		'clean_term_cache' => true,
+		'clean_user_cache' => true,
 	);
 
 	/**

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
@@ -191,3 +191,54 @@ function cache_custom() {
 		my_cacheset( 'key', 'group' );
 	}
 }
+
+function custom_modify_attachment() {
+	global $wpdb;
+	$wpdb->update( $wpdb->posts, array( 'post_title' => 'Hello' ), array( 'ID' => 1 ) ); // DB call ok; OK.
+	clean_attachment_cache( 1 );
+}
+function custom_modify_post() {
+	global $wpdb;
+	$wpdb->update( $wpdb->posts, array( 'post_title' => 'Hello' ), array( 'ID' => 1 ) ); // DB call ok; OK.
+	clean_post_cache( 1 );
+}
+function custom_modify_term() {
+	global $wpdb;
+	$wpdb->update( $wpdb->terms, array( 'slug' => 'test' ), array( 'term_id' => 1 ) ); // DB call ok; OK.
+	clean_term_cache( 1 );
+}
+function custom_clean_category_cache() {
+	global $wpdb;
+	$wpdb->update( $wpdb->terms, array( 'slug' => 'test' ), array( 'term_id' => 1 ) ); // DB call ok; OK.
+	clean_category_cache( 1 );
+}
+function custom_modify_links() {
+	global $wpdb;
+	$wpdb->update( $wpdb->links, array( 'link_name' => 'Test' ), array( 'link_id' => 1 ) ); // DB call ok; OK.
+	clean_bookmark_cache( 1 );
+}
+function custom_modify_comments() {
+	global $wpdb;
+	$wpdb->update( $wpdb->comments, array( 'comment_content' => 'Test' ), array( 'comment_ID' => 1 ) ); // DB call ok; OK.
+	clean_comment_cache( 1 );
+}
+function custom_modify_users() {
+	global $wpdb;
+	$wpdb->update( $wpdb->users, array( 'user_email' => 'Test' ), array( 'ID' => 1 ) ); // DB call ok; OK.
+	clean_user_cache( 1 );
+}
+function custom_modify_blogs() {
+	global $wpdb;
+	$wpdb->update( $wpdb->blogs, array( 'domain' => 'example.com' ), array( 'blog_id' => 1 ) ); // DB call ok; OK.
+	clean_blog_cache( 1 );
+}
+function custom_modify_sites() {
+	global $wpdb;
+	$wpdb->update( $wpdb->sites, array( 'domain' => 'example.com' ), array( 'id' => 1 ) ); // DB call ok; OK.
+	clean_network_cache( 1 );
+}
+function custom_modify_term_relationship() {
+	global $wpdb;
+	$wpdb->update( $wpdb->term_relationships, array( 'term_order' => 1 ), array( 'object_id' => 1 ) ); // DB call ok; OK.
+	clean_object_term_cache( 1 );
+}


### PR DESCRIPTION
This eliminates the need to add `// WPCS: cache ok` when you're using one of these functions.

As a possible enhancement to this, we could check to see that specific table that is being used in the `$wpdb` call and then map the specific `clean_*_cache()` function to the table being used. I can see this being error prone, however, especially in the case where `$wpdb->query()` is being used as opposed to `$wpdb->upate()` or `$wpdb->delete()`.