### PR TITLE
Make the impact of the errorcode change slightly less.

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -686,7 +686,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 	 * @return string
 	 */
 	protected function string_to_errorcode( $base_string ) {
-		return preg_replace( '`[^a-z0-9_]`i', '_', strtolower( $base_string ) );
+		return preg_replace( '`[^a-z0-9_]`i', '_', $base_string );
 	}
 
 	/**


### PR DESCRIPTION
A number of sniffs use capitalization in the errorcodes to improve readability. This was unnecessarily undone by the `string_to_errorcode()` implementation.

For the sniffs were the errorcodes have not necessarily changed while using this function, this maintains BC instead of breaking it.