### PR TITLE
:rocket: Temporary solution for build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,18 @@ matrix:
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
+    - export PHPUNIT_DIR=/tmp/phpunit
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
+    # Download PHPUnit 5.x for builds on PHP 7, nightly and HHVM as
+    # PHPCS test suite is currently not compatible with PHPUnit 6.x.
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.phar; fi
 
 script:
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
-    - phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.phar --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/


### PR DESCRIPTION
As PHPCS upstream is taking its time to decide whether or not to make the test suite compatible with PHPUnit 6 or not, we might as well get the builds passing again in the mean time, so we can get the 0.11.0 release out the door.

This is intended (fingers crossed) as a temporary solution to be reverted once the testsuite for PHPCS is cross-version compatible with PHPUnit.

I've chosen to *only* download PHPUnit when we need a different version than the one installed by default in the Travis images to keep the build time down.