### PR TITLE
:rocket: Minor travis script tweak.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - php: hhvm
     - env: PHPCS_BRANCH=3.0
 
-before_script:
+before_install:
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)


### PR DESCRIPTION
Addresses:

> should be added in the `before_install` section of the .travis.yml, this way if any errors occur the build job will report `Errored` rather than `Failed`, this is important as it determines there was an issue setting up your environment rather than the code you are actually testing against

As per @ntwb's comment https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/753#discussion_r93976823 