### PR TITLE
Fix 0.11.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a C
 
 _Nothing yet._
 
-## [0.11.0] - 2017-03-08
+## [0.11.0] - 2017-03-20
 
 ### Important notes for end-users:
 


### PR DESCRIPTION
Release date was still based on when the changelog PR was finished. Now set to this upcoming Monday.