### PR TITLE
EnqueuedResourcesSniff: Trigger on enqueued resources in heredoc and nowdoc syntax.

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -28,6 +28,8 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 			T_CONSTANT_ENCAPSED_STRING,
 			T_DOUBLE_QUOTED_STRING,
 			T_INLINE_HTML,
+			T_HEREDOC,
+			T_NOWDOC,
 		);
 
 	}
@@ -45,7 +47,7 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
-		if ( preg_match( '#rel=[\'"]?stylesheet[\'"]?#', $token['content'] ) > 0 ) {
+		if ( preg_match( '#rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
 			$phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr, 'NonEnqueuedStylesheet' );
 		}
 

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
@@ -9,3 +9,24 @@
 
 echo '<script src="' . SOMESCRIPT . '">';
 echo '<link rel="stylesheet" src="' . SOMESCRIPT . '">';
+
+$double_quoted = "<link rel=\"stylesheet\" href=\"{$stylesheet}\">
+<script src=\"{$script}\"></script>";
+
+$double_quoted = "<link rel='stylesheet' href='{$stylesheet}' />
+<script src='{$script}'></script>";
+
+$head = <<<EOT
+<link rel="stylesheet" href="http://someurl/somefile.css">
+<script src="http://someurl/somefile.js"></script>
+EOT;
+
+$head = <<<"EOT"
+<link rel="stylesheet" href="http://someurl/somefile.css">
+<script src="http://someurl/somefile.js"></script>
+EOT;
+
+$head = <<<'EOD'
+<link rel="stylesheet" href="http://someurl/somefile.css">
+<script src="http://someurl/somefile.js"></script>
+EOD;

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -16,17 +16,6 @@
 class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 
 	/**
-	 * Skip this test on PHP 5.2.
-	 *
-	 * @since 0.9.0
-	 *
-	 * @return bool Whether to skip this test.
-	 */
-	protected function shouldSkipTest() {
-		return ( PHP_VERSION_ID < 50300 );
-	}
-
-	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @return array <int line number> => <int number of errors>
@@ -34,11 +23,21 @@ class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest
 	public function getErrorList() {
 		return array(
 			1 => 1,
-			2 => 1,
+			2 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 has a bug tokenizing inline HTML / `<s`.
 			6 => 1,
-			7 => 1,
+			7 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 has a bug tokenizing inline HTML / `<s`.
 			10 => 1,
 			11 => 1,
+			13 => 1,
+			14 => 1,
+			16 => 1,
+			17 => 1,
+			20 => 1,
+			21 => 1,
+			25 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize double quoted T_HEREDOC.
+			26 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize double quoted T_HEREDOC.
+			30 => 1, // PHPCS on PHP 5.2 does not recognize T_NOWDOC, but sees this as a literal string anyway.
+			31 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize T_NOWDOC.
 		);
 
 	}


### PR DESCRIPTION
Includes unit tests.

Also:
* Adds unit tests for `T_DOUBLE_QUOTED_STRING` which were missing
* Fixes bug in regexes which did not allow for quotes around the `stylesheet` phrase to be escaped.
* Removed the blanket test exclusion for PHP 5.2 in favour of selective test exclusion.

Related to #764