### PR TITLE
NonceVerification: minor code simplification & efficiency improvement.

### DIFF
--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -19,14 +19,32 @@
 class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
 	/**
+	 * Superglobals to notify about when not accompanied by an nonce check.
+	 *
+	 * A value of `true` results in an error. A value of `false` in a warning.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	protected $superglobals = array(
+		'$_POST'    => true,
+		'$_FILE'    => true,
+		'$_GET'     => false,
+		'$_REQUEST' => false,
+	);
+
+	/**
 	 * Superglobals to give an error for when not accompanied by an nonce check.
 	 *
 	 * @since 0.5.0
 	 * @since 0.11.0 Changed visibility from public to protected.
 	 *
+	 * @deprecated 0.12.0 Replaced by $superglobals property.
+	 *
 	 * @var array
 	 */
-	protected $errorForSuperGlobals = array( '$_POST', '$_FILE' );
+	protected $errorForSuperGlobals = array();
 
 	/**
 	 * Superglobals to give a warning for when not accompanied by an nonce check.
@@ -36,9 +54,11 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 	 * @since 0.5.0
 	 * @since 0.11.0 Changed visibility from public to protected.
 	 *
+	 * @deprecated 0.12.0 Replaced by $superglobals property.
+	 *
 	 * @var array
 	 */
-	protected $warnForSuperGlobals = array( '$_GET', '$_REQUEST' );
+	protected $warnForSuperGlobals = array();
 
 	/**
 	 * Custom list of functions which verify nonces.
@@ -107,12 +127,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 
 		$instance = $this->tokens[ $stackPtr ];
 
-		$superglobals = array_merge(
-			$this->errorForSuperGlobals
-			, $this->warnForSuperGlobals
-		);
-
-		if ( ! in_array( $instance['content'], $superglobals, true ) ) {
+		if ( ! isset( $this->superglobals[ $instance['content'] ] ) ) {
 			return;
 		}
 
@@ -138,7 +153,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 		$this->addMessage(
 			'Processing form data without nonce verification.',
 			$stackPtr,
-			( in_array( $instance['content'], $this->errorForSuperGlobals, true ) ),
+			$this->superglobals[ $instance['content'] ],
 			'NoNonceVerification'
 		);
 


### PR DESCRIPTION
As the `$errorForSuperGlobals` and `$warnForSuperGlobals` properties are no longer public, we might as well simplify the logic used.

Should give a small speed boost too as we no longer `array_merge()` every time a `T_VARIABLE` is processed and use `isset()` instead of `in_array()`.