### PR TITLE
PreparedSQLSniff: Trigger on variables in sql in heredocs and ignore nowdoc syntax

### DIFF
--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -55,6 +55,11 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 		T_CLOSE_SQUARE_BRACKET     => true,
 		T_COMMA                    => true,
 		T_LNUMBER                  => true,
+		T_START_HEREDOC            => true,
+		T_END_HEREDOC              => true,
+		T_START_NOWDOC             => true,
+		T_NOWDOC                   => true,
+		T_END_NOWDOC               => true,
 	);
 
 	/**
@@ -123,7 +128,9 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				continue;
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code'] ) {
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code']
+				|| T_HEREDOC === $this->tokens[ $this->i ]['code']
+			) {
 
 				$bad_variables = array_filter(
 					$this->get_interpolated_variables( $this->tokens[ $this->i ]['content'] ),

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -31,3 +31,53 @@ $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
 
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . esc_sql( $foo ) . "';" ); // Ok.
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE ID = " . absint( $foo ) . ";" ); // Ok.
+
+// Test multi-line strings.
+$all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
+	'SELECT `post_id`, `meta_value`
+	FROM `%s`
+	WHERE `meta_key` = "sort_order"
+		AND `post_id` IN (%s)',
+	$wpdb->postmeta,
+	implode( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+), $post_ids ) ); // Ok.
+
+$wpdb->query( "
+	SELECT *
+	FROM $wpdb->posts
+	WHERE post_title LIKE '" . esc_sql( $foo ) . "';"
+); // Ok.
+
+$wpdb->query( $wpdb->prepare( "
+	SELECT *
+	FROM $wpdb->posts
+	WHERE post_title = 'The \\$_GET[foo]// var is evil again.'
+		AND ID = %s",
+	array( 123 )
+) ); // Bad.
+
+
+// Test heredoc & nowdoc for query.
+$wpdb->query( <<<EOT
+	SELECT *
+	FROM {$wpdb->posts}
+	WHERE ID = {$foo};
+EOT
+); // Bad.
+
+$wpdb->query( <<<"HD"
+	SELECT *
+	FROM {$wpdb->posts}
+	WHERE post_title LIKE '{$var}';
+HD
+); // Bad.
+
+$all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf( <<<'ND'
+	SELECT `post_id`, `meta_value`
+	FROM `%s`
+	WHERE `meta_key` = "sort_order"
+		AND `post_id` IN (%s)
+ND
+	, $wpdb->postmeta,
+	implode( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+), $post_ids ) ); // OK.

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -23,7 +23,7 @@ class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
+		$errors = array(
 			3 => 1,
 			4 => 1,
 			5 => 1,
@@ -34,7 +34,27 @@ class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
 			18 => 1,
 			20 => 1,
 			21 => 1,
+			54 => 1,
+			64 => 1,
+			71 => 1,
 		);
+
+		// Deal with PHP 5.2 not recognizing quoted heredoc openers, nor nowdoc syntax.
+		// These are all false positives!
+		if ( PHP_VERSION_ID < 50300 ) {
+			$errors[68] = 2;
+			$errors[69] = 2;
+			$errors[70] = 2;
+			$errors[71] = 4;
+			$errors[75] = 2;
+			$errors[76] = 7;
+			$errors[77] = 4;
+			$errors[78] = 5;
+			$errors[79] = 7;
+			$errors[80] = 1;
+		}
+
+		return $errors;
 	}
 
 	/**


### PR DESCRIPTION
Includes unit tests.

Also:
* Adds unit tests for multi-line `T_DOUBLE_QUOTED_STRING` and `T_CONSTANT_ENCAPSED_STRING` which were missing

Related to #764