### PR TITLE
AbstractArrayAssignmentRestrictions: Fix method documentation.

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -68,12 +68,11 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	 * This method should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
+	 * 	'groupname' => array(
+	 * 		'type'     => 'error' | 'warning',
+	 * 		'message'  => 'Dont use this one please!',
+	 * 		'keys'     => array( 'key1', 'another_key' ),
+	 * 		'callback' => array( 'class', 'method' ), // Optional.
 	 * 	)
 	 * )
 	 *

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -20,17 +20,6 @@ class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_AbstractArrayAssi
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
-	 *
-	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type'          => 'error' | 'warning',
-	 * 		'message'       => 'Dont use this one please!',
-	 * 		'variables'     => array( '$val', '$var' ),
-	 * 		'object_vars'   => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
-	 * )
 	 *
 	 * @return array
 	 */

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -20,17 +20,6 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 
 	/**
 	 * Groups of variables to restrict.
-	 * This should be overridden in extending classes.
-	 *
-	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type'          => 'error' | 'warning',
-	 * 		'message'       => 'Dont use this one please!',
-	 * 		'variables'     => array( '$val', '$var' ),
-	 * 		'object_vars'   => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
-	 * )
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
The method documentation for the `getGroups()` method in the `AbstractArrayAssignmentRestrictionsSniff` was incorrect (belonged to the `AbstractVariableRestrictionsSniff`).

Corrected now for both the abstract as well as the child classes.