### PR TITLE
Fix persistent bug in VariableRestrictions abstract

### DIFF
--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -130,7 +130,9 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 				$patterns = array_merge( $patterns, $group['variables'] );
 				$var      = $token['content'];
 
-			} elseif ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
+			}
+
+			if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
 				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
@@ -138,15 +140,17 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 				$child = $this->phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
 				$var   = implode( '', array( $this->tokens[ $owner ]['content'], $token['content'], $this->tokens[ $child ]['content'] ) );
 
-			} elseif ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
+			}
+
+			if ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 
-				$owner  = $this->phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
-				$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
-				$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
-			} else {
-				continue;
+				if ( isset( $token['bracket_closer'] ) ) {
+					$owner  = $this->phpcsFile->findPrevious( array( T_VARIABLE ), $stackPtr );
+					$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+					$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
+				}
 			}
 
 			if ( empty( $patterns ) ) {


### PR DESCRIPTION
While unit testing something else I ran into this bug.

Basically, the sniff allows for adding several arrays with things to be sniffed for, however when examining a `T_DOUBLE_QUOTED_STRING` or - when I add this (waiting in the backwings) - a `T_HEREDOC`, only the first set of patterns is taken into account instead of all possible patterns.

This in effect meant that the sniff suffered from false negatives.

The original intend seems quite clear what with the $patterns being merged in every part of the control structure. The bug has been in the sniff from the very beginning. De-coupling the `if` statements solves this.

Additionally, within the last `if` structure, `$token['bracket_closer']` is referenced, while this array key will not be available when a `T_DOUBLE_QUOTED_STRING` or `T_HEREDOC` is encountered.
The `$var` setting for this is already corrected further along in the code, so making this part conditional fixes the `Undefined index` notice being thrown.