### PR TITLE
AbstractVariableRestrictionsSniff: add support for heredoc syntax.

### DIFF
--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -60,6 +60,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 			T_DOUBLE_COLON,
 			T_OPEN_SQUARE_BRACKET,
 			T_DOUBLE_QUOTED_STRING,
+			T_HEREDOC,
 		);
 
 	}
@@ -126,13 +127,13 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 			$patterns = array();
 
 			// Simple variable.
-			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['variables'] ) ) {
+			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
 				$patterns = array_merge( $patterns, $group['variables'] );
 				$var      = $token['content'];
 
 			}
 
-			if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['object_vars'] ) ) {
+			if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
 				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
@@ -142,7 +143,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 			}
 
-			if ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING ), true ) && ! empty( $group['array_members'] ) ) {
+			if ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 
@@ -159,9 +160,9 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
 			$pattern  = implode( '|', $patterns );
-			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] ) ? '\b' : '';
+			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] && T_HEREDOC !== $token['code'] ) ? '\b' : '';
 
-			if ( T_DOUBLE_QUOTED_STRING === $token['code'] ) {
+			if ( T_DOUBLE_QUOTED_STRING === $token['code'] || T_HEREDOC === $token['code'] ) {
 				$var = $token['content'];
 			}
 

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.inc
@@ -17,3 +17,13 @@ if ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // Warning.
 $x = $_COOKIE['bar']; // Warning.
 
 $y = $_SERVER['REQUEST_URI']; // Ok.
+
+// Error.
+$query = <<<EOD
+SELECT * FROM $wpdb->usermeta
+EOD;
+
+// Warning
+$phrase = <<<EOD
+Your user-agent is {$_SERVER['HTTP_USER_AGENT']}
+EOD;

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -22,10 +22,11 @@ class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitT
 	 */
 	public function getErrorList() {
 		return array(
-			3 => 1,
-			5 => 1,
-			7 => 1,
-			9 => 1,
+			3  => 1,
+			5  => 1,
+			7  => 1,
+			9  => 1,
+			23 => 1,
 		);
 
 	}
@@ -40,6 +41,7 @@ class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitT
 			13 => 1,
 			14 => 1,
 			17 => 1,
+			28 => 1,
 		);
 
 	}


### PR DESCRIPTION
Includes unit tests for a concrete child implementation. (includes a unit test which wouldn't have passed without the fix in #889)