### PR TITLE
Add 'slow query' whitelist flag

### DIFF
--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -42,7 +42,7 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @since 0.10.0
-	 * @since 0.12.0 Introduced new 'slow_query' whitelist comment.
+	 * @since 0.12.0 Introduced new 'slow query' whitelist comment.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -42,7 +42,7 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @since 0.10.0
-	 * @since 0.12.0 Added the 'slow query' comment.
+	 * @since 0.12.0 Introduced new 'slow_query' whitelist comment.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -42,6 +42,8 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @since 0.10.0
+	 * @since 0.12.0 Added the 'slow query' comment.
+	 *
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
@@ -49,6 +51,10 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 *                  normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
+
+		if ( $this->has_whitelist_comment( 'slow query', $stackPtr ) ) {
+			return;
+		}
 
 		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
 			return;

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -51,11 +51,12 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( $this->has_whitelist_comment( 'slow query', $stackPtr ) ) {
-			return;
-		}
+		if (
+			$this->has_whitelist_comment( 'slow query', $stackPtr )
+			||
+			$this->has_whitelist_comment( 'tax_query', $stackPtr )
+		) {
 
-		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -44,7 +44,6 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * @since 0.10.0
 	 * @since 0.12.0 Added the 'slow query' comment.
 	 *
-	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
@@ -28,10 +28,10 @@ $test = array(
 
 	// Single-line statements.
 	'tax_query' => array(), // Bad.
-	'tax_query' => array(), // WPCS: tax_query ok.
+	'tax_query' => array(), // WPCS: slow query ok.
 
 	// Multi-line statement.
-	'tax_query' => array( // WPCS: tax_query ok.
+	'tax_query' => array( // WPCS: slow query ok.
 		array(
 			'taxonomy' => 'foo',
 		),

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
@@ -31,7 +31,7 @@ $test = array(
 	'tax_query' => array(), // WPCS: slow query ok.
 
 	// Multi-line statement.
-	'tax_query' => array( // WPCS: slow query ok.
+	'tax_query' => array( // WPCS: tax_query ok.
 		array(
 			'taxonomy' => 'foo',
 		),


### PR DESCRIPTION
Adds the `slow query` whitelist flag to better cover the cases the `SlowDBQuerySniff` applies to.
The `tax_query` flag it aims to replace is still respected.

Closes #894 