### PR TITLE
:books: Fix some end comments

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -186,7 +186,7 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 			}
 		} // End foreach().
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Callback to process each confirmed key, to check value.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -168,7 +168,7 @@ abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sni
 			return $this->check_for_matches( $stackPtr );
 		}
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Verify is the current token is a function call.

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -182,7 +182,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 		} // End foreach().
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Transform a wildcard pattern to a usable regex pattern.

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -157,7 +157,7 @@ class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
 			'NoNonceVerification'
 		);
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -201,6 +201,6 @@ class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 		// Only run this sniff once per file, no need to run it again.
 		return ( $this->phpcsFile->numTokens + 1 );
 
-	} // End process().
+	} // End process_token().
 
 } // End class.

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -153,7 +153,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff extends WordPress_Ab
 			$this->phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
 		}
 
-	} // End process().
+	} // End process_parameters().
 
 	/**
 	 * Prepare the punctuation regular expression.

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -193,7 +193,7 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 			return parent::process_token( $stackPtr );
 		}
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Process the parameters of a matched function.

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -167,7 +167,7 @@ class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
 			return;
 		}
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Add warning about unclear cron schedule change.

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -211,7 +211,7 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff extends WordPress_Sniff {
 
 		return $endOfStatement;
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -145,7 +145,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			$this->phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
 		}
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -400,7 +400,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 			}
 		} // End if().
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Add the error if there is no whitelist comment present and the assignment

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -192,7 +192,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 
 		return $this->end;
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Checks whether this is a call to a $wpdb method that we want to sniff.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -552,6 +552,6 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			}
 		} // End if().
 
-	} // End process().
+	} // End process_token().
 
 } // End class.

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -396,7 +396,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 
 		return $end_of_statement;
 
-	} // End process().
+	} // End process_token().
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.


### PR DESCRIPTION
A number of function names have changed in the 0.11.0 release, but some of the end comments still reflected their old function names.