### PR TITLE
:ambulance: Fixes: Whitelist function could sometimes be a bit too eager

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -820,13 +820,13 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 		$last = $this->tokens[ $lastPtr ];
 
-		// Ignore if not a comment.
-		if ( T_COMMENT !== $last['code'] ) {
+		// Ignore if not a comment or not on the same line.
+		if ( T_COMMENT !== $last['code'] || $last['line'] !== $this->tokens[ $end_of_line ]['line'] ) {
 			return false;
 		}
 
 		// Now let's see if the comment contains the whitelist remark we're looking for.
-		return ( preg_match( '#' . preg_quote( $comment, '#' ) . '#i', $last['content'] ) === 1 );
+		return ( preg_match( '#\b' . preg_quote( $comment, '#' ) . '\b#i', $last['content'] ) === 1 );
 	}
 
 	/**

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.inc
@@ -19,3 +19,13 @@ if ( true != $true ) { // Bad.
 if ( true == $true ) { // Loose comparison, OK.
 	echo 'True';
 }
+
+// Test that whitelisting is not too eager.
+if ( true == $true ) {
+	// The line above has a loose comparison, but no whitelist comment.
+	echo 'True';
+}
+
+if ( true == $true ) { // Loose comparisons FTW!
+	echo 'True';
+}

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -32,9 +32,11 @@ class WordPress_Tests_PHP_StrictComparisonsUnitTest extends AbstractSniffUnitTes
 	 */
 	public function getWarningList() {
 		return array(
-			3 => 1,
+			3  => 1,
 			10 => 1,
 			12 => 1,
+			24 => 1,
+			29 => 1,
 		);
 
 	}


### PR DESCRIPTION
If there is no whitelist comment, but a comment on the next line would - for whatever reason - include a whitelist keyword, it was still regarded as a whitelist comment.

This commit fixes that by changing two things:
1. The whitelist comment is now expected to be on the same line as the statement end token.
2. The whitelist keyword will no longer be matched if it is part of another phrase. So the whitelist keyword `key` will now only match `key` and not `keyword`.

Includes unit tests for both fixes.

Found this when testing a sniff where there was a whitelist keyword which was a partial match for a custom property and the inline changing of the custom property on the next line was being regarded as a whitelist comment...