### PR TITLE
Document the availability of the `$custom_test_class_whitelist` property…

### DIFF
--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -22,6 +22,8 @@
  *                 - This sniff will now allow for underscores in file names for certain theme
  *                   specific exceptions if the `$is_theme` property is set to `true`.
  * @since   0.12.0 - Now extends the `WordPress_Sniff` class.
+ *
+ * @uses    WordPress_Sniff::$custom_test_class_whitelist
  */
 class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -16,6 +16,8 @@
  *
  * @since   0.3.0
  * @since   0.4.0 This class now extends WordPress_Sniff.
+ *
+ * @uses    WordPress_Sniff::$custom_test_class_whitelist
  */
 class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 


### PR DESCRIPTION
… in the relevant sniffs.

As it is not obvious in the sniff itself that this property is used by the sniff, it seems prudent to document the availability of the property.

N.B.: I've also updated the custom properties page in the wiki to document the second class for which the property is now available since the merge of #883