### PR TITLE
:books: Document the list style used for properties in the `WordPress_Sniff`

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -14,6 +14,17 @@
  *
  * @package WPCS\WordPressCodingStandards
  * @since   0.4.0
+ *
+ * {@internal This class contains numerous properties where the array format looks
+ *            like `'string' => true`, i.e. the array item is set as the array key.
+ *            This allows for sniffs to verify whether something is in one of these
+ *            lists using `isset()` rather than `in_array()` which is a much more
+ *            efficient (faster) check to execute and therefore improves the
+ *            performance of the sniffs.
+ *            The `true` value in those cases is used as a placeholder and has no
+ *            meaning in and of itself.
+ *            In the rare few cases where the array values *do* have meaning, this
+ *            is documented in the property documentation.}}
  */
 abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 


### PR DESCRIPTION
This PR documents the list style used for properties throughout the library in response to concerns raised about this in #904.