### PR TITLE
:sparkles: New CapitalPDangitSniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -327,5 +327,7 @@
 		<!-- Check for correct usage of the WP i18n functions. -->
 		<rule ref="WordPress.WP.I18n"/>
 
+		<!-- Check for correct spelling of WordPress. -->
+		<rule ref="WordPress.WP.CapitalPDangit"/>
 
 </ruleset>

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Capital P Dangit!
+ *
+ * Verify the correct spelling of `WordPress` in text strings, comments and class names.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_WP_CapitalPDangitSniff extends WordPress_Sniff {
+
+	/**
+	 * Regex to match a large number or spelling variations of WordPress in text strings.
+	 *
+	 * Prevents matches on:
+	 * - URLs for wordpress.org/com/net/tv.
+	 * - `@...` usernames starting with `wordpress`
+	 * - email addresses with a domain starting with `wordpress`
+	 * - email addresses with a user name ending with `wordpress`
+	 * - (most) variable names.
+	 * - directory paths containing a folder starting or ending with `wordpress`.
+	 * - file names containing `wordpress` for a limited set of extensions.
+	 * - `wordpress` prefixed or suffixed with dashes as those are indicators that the
+	 *   term is probably used as part of a CSS class, such as `fa-wordpress`
+	 *   or filename/path like `class-wordpress-importer.php`.
+	 * - back-tick quoted `wordpress`.
+	 *
+	 * @var string
+	 */
+	const WP_REGEX = '#(?<![\\\\/\$@`-])\b(Word[ _-]*Pres+)\b(?![@/`-]|\.(?:org|com|net|tv)|[^\s<>\'"()]*?\.(?:php|js|css|png|j[e]?pg|gif))#i';
+
+	/**
+	 * Regex to match a large number or spelling variations of WordPress in class names.
+	 *
+	 * @var string
+	 */
+	const WP_CLASSNAME_REGEX = '`(?:^|_)(Word[_]*Pres+)(?:_|$)`i';
+
+	/**
+	 * String tokens we want to listen for.
+	 *
+	 * @var array
+	 */
+	private $text_string_tokens = array(
+		T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+		T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
+		T_HEREDOC                  => T_HEREDOC,
+		T_NOWDOC                   => T_NOWDOC,
+		T_INLINE_HTML              => T_INLINE_HTML,
+	);
+
+	/**
+	 * Comment tokens we want to listen for as they contain text strings.
+	 *
+	 * @var array
+	 */
+	private $comment_text_tokens = array(
+		T_DOC_COMMENT        => T_DOC_COMMENT,
+		T_DOC_COMMENT_STRING => T_DOC_COMMENT_STRING,
+		T_COMMENT            => T_COMMENT,
+	);
+
+	/**
+	 * Class-like structure tokens to listen for.
+	 *
+	 * Using proper spelling in class, interface and trait names does not conflict with the naming conventions.
+	 *
+	 * @var array
+	 */
+	private $class_tokens = array(
+		T_CLASS     => T_CLASS,
+		T_INTERFACE => T_INTERFACE,
+		T_TRAIT     => T_TRAIT,
+	);
+
+	/**
+	 * Combined text string and comment tokens array.
+	 *
+	 * This property is set in the register() method and used for lookups.
+	 *
+	 * @var array
+	 */
+	private $text_and_comment_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Union the arrays - keeps the array keys.
+		$this->text_and_comment_tokens = ( $this->text_string_tokens + $this->comment_text_tokens );
+
+		$targets = ( $this->text_and_comment_tokens + $this->class_tokens );
+
+		// Also sniff for array tokens to make skipping anything within those more efficient.
+		$targets[ T_ARRAY ]            = T_ARRAY;
+		$targets[ T_OPEN_SHORT_ARRAY ] = T_OPEN_SHORT_ARRAY;
+
+		return $targets;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( $this->has_whitelist_comment( 'spelling', $stackPtr ) ) {
+			return;
+		}
+
+		/*
+		 * Ignore tokens within an array definition as this is a false positive in 80% of all cases.
+		 *
+		 * The return values skip to the end of the array.
+		 * This prevents the sniff "hanging" on very long configuration arrays.
+		 */
+		if ( T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+			return $this->tokens[ $stackPtr ]['bracket_closer'];
+		} elseif ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] ) ) {
+			return $this->tokens[ $stackPtr ]['parenthesis_closer'];
+		}
+
+		/*
+		 * Deal with misspellings in class/interface/trait names.
+		 * These are not auto-fixable, but need the attention of a developer.
+		 */
+		if ( isset( $this->class_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+			$classname = $this->phpcsFile->getDeclarationName( $stackPtr );
+			if ( empty( $classname ) ) {
+				return;
+			}
+
+			if ( preg_match_all( self::WP_CLASSNAME_REGEX, $classname, $matches, PREG_PATTERN_ORDER ) > 0 ) {
+				$mispelled = $this->retrieve_misspellings( $matches[1] );
+
+				if ( ! empty( $mispelled ) ) {
+					$this->phpcsFile->addWarning(
+						'Please spell "WordPress" correctly. Found: "%s" as part of the class/interface/trait name.',
+						$stackPtr,
+						'MisspelledClassName',
+						array( implode( ', ', $mispelled ) )
+					);
+				}
+			}
+
+			return;
+		}
+
+		/*
+		 * Deal with misspellings in text strings and documentation.
+		 */
+
+		// Ignore content of docblock @link tags.
+		if ( T_DOC_COMMENT_STRING === $this->tokens[ $stackPtr ]['code']
+			|| T_DOC_COMMENT === $this->tokens[ $stackPtr ]['code']
+		) {
+
+			$comment_start = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $stackPtr - 1 ) );
+			if ( false !== $comment_start ) {
+				$comment_tag = $this->phpcsFile->findPrevious( T_DOC_COMMENT_TAG, ( $stackPtr - 1 ), $comment_start );
+				if ( false !== $comment_tag && '@link' === $this->tokens[ $comment_tag ]['content'] ) {
+					// @link tag, so ignore.
+					return;
+				}
+			}
+		}
+
+		// Ignore any text strings which are array keys `$var['key']` as this is a false positive in 80% of all cases.
+		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			$prevToken = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+			if ( false !== $prevToken && T_OPEN_SQUARE_BRACKET === $this->tokens[ $prevToken ]['code'] ) {
+				$nextToken = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+				if ( false !== $nextToken && T_CLOSE_SQUARE_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
+					return;
+				}
+			}
+		}
+
+		$content = $this->tokens[ $stackPtr ]['content'];
+
+		if ( preg_match_all( self::WP_REGEX, $content, $matches, ( PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE ) ) > 0 ) {
+			/*
+			 * Prevent some typical false positives.
+			 */
+			if ( isset( $this->text_and_comment_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+				$offset = 0;
+				foreach ( $matches[1] as $key => $match_data ) {
+					$next_offset = ( $match_data[1] + strlen( $match_data[0] ) );
+
+					// Prevent matches on part of a URL.
+					if ( preg_match( '`http[s]?://[^\s<>\'"()]*' . preg_quote( $match_data[0], '`' ) . '`', $content, $discard, 0, $offset ) === 1 ) {
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`[a-z]+=(["\'])' . preg_quote( $match_data[0], '`' ) . '\1`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on html attributes like: `value="wordpress"`.
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`\\\\\'' . preg_quote( $match_data[0], '`' ) . '\\\\\'`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on xpath queries and such: `\'wordpress\'`.
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`(?:\?|&amp;|&)[a-z0-9_]+=' . preg_quote( $match_data[0], '`' ) . '(?:&|$)`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on url query strings: `?something=wordpress`.
+						unset( $matches[1][ $key ] );
+					}
+
+					$offset = $next_offset;
+				}
+
+				if ( empty( $matches[1] ) ) {
+					return;
+				}
+			}
+
+			$mispelled = $this->retrieve_misspellings( $matches[1] );
+
+			if ( empty( $mispelled ) ) {
+				return;
+			}
+
+			$fix = $this->phpcsFile->addFixableWarning(
+				'Please spell "WordPress" correctly. Found %s misspelling(s): %s',
+				$stackPtr,
+				'Misspelled',
+				array(
+					count( $mispelled ),
+					implode( ', ', $mispelled ),
+				)
+			);
+
+			if ( true === $fix ) {
+				// Apply fixes based on offset to ensure we don't replace false positives.
+				$replacement = $content;
+				foreach ( $matches[1] as $match ) {
+					$replacement = substr_replace( $replacement, 'WordPress', $match[1], strlen( $match[0] ) );
+				}
+
+				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
+			}
+		} // End if().
+
+	} // End process_token().
+
+	/**
+	 * Retrieve a list of misspellings based on an array of matched variations on the target word.
+	 *
+	 * @param array $match_stack Array of matched variations of the target word.
+	 * @return array Array containing only the misspelled variants.
+	 */
+	protected function retrieve_misspellings( $match_stack ) {
+		$mispelled = array();
+		foreach ( $match_stack as $match ) {
+			// Deal with multi-dimensional arrays when capturing offset.
+			if ( is_array( $match ) ) {
+				$match = $match[0];
+			}
+
+			if ( 'WordPress' !== $match ) {
+				$mispelled[] = $match;
+			}
+		}
+
+		return $mispelled;
+	}
+
+} // End class.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * Test Nowdoc separately as the fixer breaks on this in PHP 5.2.
+ */
+
+// Bad.
+$text = <<<'EOD'
+This is an explanation about word-press.
+EOD;

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
@@ -1,0 +1,173 @@
+<?php
+
+// Bad: This is a comment with WORDPRESS spelled incorrectly.
+
+/* Bad: This is a comment with wordpress spelled incorrectly. */
+
+/*
+ * Bad: This is a comment with Wordpress spelled incorrectly.
+ */
+
+/**
+ * Function comment
+ *
+ * @param string $wordpress OK: Here the incorrect spelling is OK to comply with the variable name rules.
+ */
+function something( $wordpress ) {} // OK.
+
+/**
+ * Function comment
+ *
+ * @param string $my_wordpress_test OK: Here the incorrect spelling is OK to comply with the variable name rules.
+ */
+function something( $my_wordpress_test ) {} // OK.
+
+/**
+ * Bad: In this comment wordPresss should be fixed.
+ *
+ * @param string $test Bad: In this comment word press should be fixed.
+ */
+function something( $test ) {} // OK.
+
+function wordpress_function() {} // OK - comply with the function name rules.
+
+class Wordpress_Something {} // Bad.
+class Something_Word_press_Something {} // Bad.
+class Something_wordpressss {} // Bad.
+class WordPress_Something {} // OK.
+class Something_WordPress {} // OK.
+
+echo 'This is an explanation about wordpress.'; // Bad.
+echo "This is an {$explanation} about wordpress."; // Bad.
+
+// Bad.
+echo <<<EOD
+This is an {$explanation} about wordpress.
+EOD;
+
+echo 'http://wordpress.org/something'; // OK - part of a URL.
+?>
+
+<div class="copyright"><?php printf( wp_kses_post( __( 'Powered by <a href="%s">WordPress</a>', 'theme-slug' ) ), 'https://wordpress.org/' ); ?></div><!-- OK. -->
+
+<p>Here we have an inline HTML tag with wordpress spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with WordPress spelled correctly.</p><!-- OK. -->
+
+<p>Here we have an inline HTML tag with a URL, of course this should be coded differently, but even when it isn't, it should be ignored, so here goes: http://wordpress.org/ spelled incorrectly.</p><!-- OK. -->
+
+<p>Here we have an inline HTML tag with wordpressers spelled incorrectly.</p><!-- OK, part of another word. -->
+
+<p>Here we have an inline HTML tag with word press spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with word-press spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with word - presssss spelled incorrectly.</p><!-- Bad. -->
+
+<p class="fa-wordpress">In this case it's a CSS class name and we should leave well alone.</p><!-- OK. -->
+<p class="wordpress-class">CSS class, but also wordPres spelled incorrectly in the text.</p><!-- Bad. -->
+<p class="wordpress-class">Same again, this time with same spelling in both the class as well as in the text wordpress.</p><!-- Bad. -->
+
+<p>And lets have another test with wordpress spelled incorrectly more than once. Wordpress, wordPress, word pres.</p><!-- Bad. -->
+
+<?php
+/*
+ * Some additional examples found in WP core.
+ */
+$first_comment_email = ! empty( $first_comment_email ) ? $first_comment_email : 'wapuu@wordpress.example'; // OK.
+
+$wordpress_rules = $xpath->query('/configuration/system.webServer/rewrite/rules/rule[starts-with(@name,\'wordpress\')] | /configuration/system.webServer/rewrite/rules/rule[starts-with(@name,\'WordPress\')]'); // OK.
+
+// If we don't have an email from the input headers default to wordpress@$sitename <= OK.
+$from_email = 'wordpress@' . $sitename; // OK.
+
+if ( $counts['wordpress'] ) { // OK.
+	/* translators: 1: Number of updates available to WordPress */
+	$titles['wordpress'] = sprintf( __( '%d WordPress Update'), $counts['wordpress'] ); // OK.
+}
+
+?>
+<td><input name="dbname" id="dbname" type="text" size="25" value="wordpress" /></td><!-- OK. -->
+
+<ol id="authors"><form action="?import=wordpress&amp;step=2&amp;id=" method="post"><input type="hidden" name="_wpnonce" value="855ae98911" /><!-- OK. -->
+
+<?php
+/*
+ * More examples found in themes which should be accounted for.
+ * Based on a run of this sniff against 180 recently updated themes (7500+ files).
+ */
+
+/**
+ * @wordpress-plugin <= OK.
+ * Plugin Name: TGM Plugin Activation
+ *
+ * @package Wordpress <= Bad.
+ *
+ * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
+ */
+ 
+if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
+	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+	return is_plugin_active( 'wordpress-importer/wordpress-importer.php' ); // OK.
+}
+
+$check = array(
+	'wordpress-importer'       => array( 'installed' => false, 'active' => false ), // OK.
+	'widget-importer-exporter' => array( 'installed' => false, 'active' => false )
+);
+
+$default_editor_settings = [
+	'textarea_name' => $textarea_name,
+	'media_buttons' => false,
+	'tinymce' => [ 'plugins' => 'wordpress' ] // OK.
+];
+
+	$wp_customize->add_control(
+		new Arouse_Custom_Content(
+			$wp_customize,
+			'arouse_documentation_link',
+			array(
+				'section' 		=> 'arouse_theme_info',
+				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
+				'content' 		=> __( '<a class="button" href="http://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
+			)
+		) 
+	);	
+
+?>
+
+	<a href="https://wordpress.org/support/theme/{{ data.theme_slug }}/reviews/#new-post" class="button button-primary activello-wordpress"><span class="dashicons dashicons-wordpress"></span>Review this theme on w.org</a><!-- OK. -->
+
+		<p><?php _e( 'This page will help you get up and running quickly with <strong>Adamos</strong>. Please use the <a href="https://wordpress.org/support/theme/adamos">Wordpress Support Forums</a> if you have experience issues with this theme.', 'adamos' ); ?></p><!-- Bad. -->
+
+<a target="_blank" href="<?php echo esc_url( 'https://www.themeinprogress.com/alhena-free-responsive-corporate-wordpress-theme/?ref=2&campaign=alhena-notice' ); ?>" class="button"><?php _e( 'Upgrade to Alhena Premium', 'alhena-lite' ); ?></a><!-- OK. -->
+
+<?php
+	comment_form( array(
+		'fields' => apply_filters( 'comment_form_default_fields', $fields ),
+		/* translators: %s: wordpress login url */ // Bad, but false negative as within an array.
+		'must_log_in' => '<p class="must-log-in">' .  sprintf( __( 'You must be <a href="%s">logged in</a> to post a comment.' , 'annina' ), wp_login_url( apply_filters( 'the_permalink', get_permalink( ) ) ) ) . '</p>',
+	));
+
+$wl_theme_options['service_3_icons']="fa fa-wordpress"; // OK.
+
+if ( get_theme_mod('header_icon', 'fa-wordpress') ) echo '<i class="fa '  .esc_attr(get_theme_mod('header_icon' , 'fa-wordpress')) . '"></i>'; // OK.
+
+/**
+ * Bootstrap styled Caption shortcode.
+ * Hat tip: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress <= OK.
+ */
+
+$render = '<div class="redux-field-locked"><div class="redux-locked-inner' . (empty($message) ? ' empty' : '') . '"><a target="_blank" href="' . $t4p_url . 'evolve-multipurpose-wordpress-theme/" class="el el-lock">&nbsp;</a>' . $message . '</div></div>' . $render; // OK.
+
+$installed = self::check_plugin_is_installed( 'wordpress-importer' ); // OK.
+
+
+/*
+ * Test whitelisting
+ */
+echo 'This is an explanation about wordpress.'; // WPCS: spelling ok.
+
+/*
+ * Test fixer with an ignored and a fixable misspelling in the same line.
+ */
+?>
+<p class="wordpress" href="http://x.org/?something=wordpress">The first two should be ignored for the purpose of replacing, this wordpress however should be fixed and this wordpress too.</p><!-- Bad. -->

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
@@ -1,0 +1,173 @@
+<?php
+
+// Bad: This is a comment with WordPress spelled incorrectly.
+
+/* Bad: This is a comment with WordPress spelled incorrectly. */
+
+/*
+ * Bad: This is a comment with WordPress spelled incorrectly.
+ */
+
+/**
+ * Function comment
+ *
+ * @param string $wordpress OK: Here the incorrect spelling is OK to comply with the variable name rules.
+ */
+function something( $wordpress ) {} // OK.
+
+/**
+ * Function comment
+ *
+ * @param string $my_wordpress_test OK: Here the incorrect spelling is OK to comply with the variable name rules.
+ */
+function something( $my_wordpress_test ) {} // OK.
+
+/**
+ * Bad: In this comment WordPress should be fixed.
+ *
+ * @param string $test Bad: In this comment WordPress should be fixed.
+ */
+function something( $test ) {} // OK.
+
+function wordpress_function() {} // OK - comply with the function name rules.
+
+class Wordpress_Something {} // Bad.
+class Something_Word_press_Something {} // Bad.
+class Something_wordpressss {} // Bad.
+class WordPress_Something {} // OK.
+class Something_WordPress {} // OK.
+
+echo 'This is an explanation about WordPress.'; // Bad.
+echo "This is an {$explanation} about WordPress."; // Bad.
+
+// Bad.
+echo <<<EOD
+This is an {$explanation} about WordPress.
+EOD;
+
+echo 'http://wordpress.org/something'; // OK - part of a URL.
+?>
+
+<div class="copyright"><?php printf( wp_kses_post( __( 'Powered by <a href="%s">WordPress</a>', 'theme-slug' ) ), 'https://wordpress.org/' ); ?></div><!-- OK. -->
+
+<p>Here we have an inline HTML tag with WordPress spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with WordPress spelled correctly.</p><!-- OK. -->
+
+<p>Here we have an inline HTML tag with a URL, of course this should be coded differently, but even when it isn't, it should be ignored, so here goes: http://wordpress.org/ spelled incorrectly.</p><!-- OK. -->
+
+<p>Here we have an inline HTML tag with wordpressers spelled incorrectly.</p><!-- OK, part of another word. -->
+
+<p>Here we have an inline HTML tag with WordPress spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with WordPress spelled incorrectly.</p><!-- Bad. -->
+<p>Here we have an inline HTML tag with WordPress spelled incorrectly.</p><!-- Bad. -->
+
+<p class="fa-wordpress">In this case it's a CSS class name and we should leave well alone.</p><!-- OK. -->
+<p class="wordpress-class">CSS class, but also WordPress spelled incorrectly in the text.</p><!-- Bad. -->
+<p class="wordpress-class">Same again, this time with same spelling in both the class as well as in the text WordPress.</p><!-- Bad. -->
+
+<p>And lets have another test with WordPress spelled incorrectly more than once. WordPress, WordPress, WordPress.</p><!-- Bad. -->
+
+<?php
+/*
+ * Some additional examples found in WP core.
+ */
+$first_comment_email = ! empty( $first_comment_email ) ? $first_comment_email : 'wapuu@wordpress.example'; // OK.
+
+$wordpress_rules = $xpath->query('/configuration/system.webServer/rewrite/rules/rule[starts-with(@name,\'wordpress\')] | /configuration/system.webServer/rewrite/rules/rule[starts-with(@name,\'WordPress\')]'); // OK.
+
+// If we don't have an email from the input headers default to wordpress@$sitename <= OK.
+$from_email = 'wordpress@' . $sitename; // OK.
+
+if ( $counts['wordpress'] ) { // OK.
+	/* translators: 1: Number of updates available to WordPress */
+	$titles['wordpress'] = sprintf( __( '%d WordPress Update'), $counts['wordpress'] ); // OK.
+}
+
+?>
+<td><input name="dbname" id="dbname" type="text" size="25" value="wordpress" /></td><!-- OK. -->
+
+<ol id="authors"><form action="?import=wordpress&amp;step=2&amp;id=" method="post"><input type="hidden" name="_wpnonce" value="855ae98911" /><!-- OK. -->
+
+<?php
+/*
+ * More examples found in themes which should be accounted for.
+ * Based on a run of this sniff against 180 recently updated themes (7500+ files).
+ */
+
+/**
+ * @wordpress-plugin <= OK.
+ * Plugin Name: TGM Plugin Activation
+ *
+ * @package WordPress <= Bad.
+ *
+ * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
+ */
+ 
+if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
+	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+	return is_plugin_active( 'wordpress-importer/wordpress-importer.php' ); // OK.
+}
+
+$check = array(
+	'wordpress-importer'       => array( 'installed' => false, 'active' => false ), // OK.
+	'widget-importer-exporter' => array( 'installed' => false, 'active' => false )
+);
+
+$default_editor_settings = [
+	'textarea_name' => $textarea_name,
+	'media_buttons' => false,
+	'tinymce' => [ 'plugins' => 'wordpress' ] // OK.
+];
+
+	$wp_customize->add_control(
+		new Arouse_Custom_Content(
+			$wp_customize,
+			'arouse_documentation_link',
+			array(
+				'section' 		=> 'arouse_theme_info',
+				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
+				'content' 		=> __( '<a class="button" href="http://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
+			)
+		) 
+	);	
+
+?>
+
+	<a href="https://wordpress.org/support/theme/{{ data.theme_slug }}/reviews/#new-post" class="button button-primary activello-wordpress"><span class="dashicons dashicons-wordpress"></span>Review this theme on w.org</a><!-- OK. -->
+
+		<p><?php _e( 'This page will help you get up and running quickly with <strong>Adamos</strong>. Please use the <a href="https://wordpress.org/support/theme/adamos">WordPress Support Forums</a> if you have experience issues with this theme.', 'adamos' ); ?></p><!-- Bad. -->
+
+<a target="_blank" href="<?php echo esc_url( 'https://www.themeinprogress.com/alhena-free-responsive-corporate-wordpress-theme/?ref=2&campaign=alhena-notice' ); ?>" class="button"><?php _e( 'Upgrade to Alhena Premium', 'alhena-lite' ); ?></a><!-- OK. -->
+
+<?php
+	comment_form( array(
+		'fields' => apply_filters( 'comment_form_default_fields', $fields ),
+		/* translators: %s: wordpress login url */ // Bad, but false negative as within an array.
+		'must_log_in' => '<p class="must-log-in">' .  sprintf( __( 'You must be <a href="%s">logged in</a> to post a comment.' , 'annina' ), wp_login_url( apply_filters( 'the_permalink', get_permalink( ) ) ) ) . '</p>',
+	));
+
+$wl_theme_options['service_3_icons']="fa fa-wordpress"; // OK.
+
+if ( get_theme_mod('header_icon', 'fa-wordpress') ) echo '<i class="fa '  .esc_attr(get_theme_mod('header_icon' , 'fa-wordpress')) . '"></i>'; // OK.
+
+/**
+ * Bootstrap styled Caption shortcode.
+ * Hat tip: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress <= OK.
+ */
+
+$render = '<div class="redux-field-locked"><div class="redux-locked-inner' . (empty($message) ? ' empty' : '') . '"><a target="_blank" href="' . $t4p_url . 'evolve-multipurpose-wordpress-theme/" class="el el-lock">&nbsp;</a>' . $message . '</div></div>' . $render; // OK.
+
+$installed = self::check_plugin_is_installed( 'wordpress-importer' ); // OK.
+
+
+/*
+ * Test whitelisting
+ */
+echo 'This is an explanation about wordpress.'; // WPCS: spelling ok.
+
+/*
+ * Test fixer with an ignored and a fixable misspelling in the same line.
+ */
+?>
+<p class="wordpress" href="http://x.org/?something=wordpress">The first two should be ignored for the purpose of replacing, this WordPress however should be fixed and this WordPress too.</p><!-- Bad. -->

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the CapitalPDangit sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_WP_CapitalPDangitUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList( $testFile = 'CapitalPDangitUnitTest.inc' ) {
+
+		switch ( $testFile ) {
+			case 'CapitalPDangitUnitTest.inc':
+				return array(
+					3   => 1,
+					5   => 1,
+					8   => 1,
+					26  => 1,
+					28  => 1,
+					34  => 1,
+					35  => 1,
+					36  => 1,
+					40  => 1,
+					41  => 1,
+					45  => 1,
+					53  => 1,
+					60  => 1,
+					61  => 1,
+					62  => 1,
+					65  => 1,
+					66  => 1,
+					68  => ( PHP_VERSION_ID >= 50300 ) ? 1 : 2, // PHPCS on PHP 5.2 apparently breaks the token up into two tokens.
+					101 => 1,
+					139 => 1,
+					146 => 0, // False negative.
+					173 => 1,
+				);
+
+			case 'CapitalPDangitUnitTest.1.inc':
+				return array(
+					9 => ( PHP_VERSION_ID >= 50300 ) ? 1 : 0, // PHPCS on PHP 5.2 does not recognize nowdocs.
+				);
+
+			default:
+				return array();
+
+		} // End switch().
+	}
+
+} // End class.


### PR DESCRIPTION
This PR adds a new sniff which checks whether `WordPress` is spelled correctly in text strings, comment text and class/interface/trait names and can catch a wide range of typical misspellings.

For this sniff, I've erred on the side of caution as this is **_very_** prone to false positives.
This means that some misspellings will likely be missed by this sniff, but that seemed the better choice than to have everyone be terribly annoyed by the sniff being really buggy.

Notes:
* The sniff has been added to the `WordPress-Core` ruleset.
* The sniff will throw a `warning` when a misspelling is found.
* The sniff will only throw one warning per token, even when more than one misspelling is found in the same phrase. The warning will in that case contain a count of the number of misspellings found + list them.
* For misspellings in text strings and comments, the sniff includes a fixer. For class names and the like, no fixer is included as that will always need attention from a developer.
* The fixer has been primed to be able to deal with text strings which contain exceptions as well as misspellings which should be corrected, and will deal with this properly.
* The sniff adds a new whitelist comment `spelling`, though this can obviously not be used to whitelist misspellings in comments.

The sniff takes the following situations into account and will ignore these when encountered:
- URLs for wordpress.org/com/net/tv.
- `@...` usernames starting with `wordpress`
- email addresses with a domain starting with `wordpress`
- email addresses with a user name ending with `wordpress` (typical default email address set up by core)
- (most) variable names (as used in docblock @param comments).
- directory paths containing a folder starting or ending with `wordpress`.
- file names containing `wordpress` for a limited set of extensions.
- `wordpress` prefixed or suffixed with dashes as those are indicators that the
   term is probably used as part of a CSS class, such as `fa-wordpress`
   or filename/path like `class-wordpress-importer.php`.
- back-tick quoted `wordpress` (to help with deliberate misspellings in comments)
- URL query strings containing `wordpress`
- Any docblock `@link` tag content (if not previously ignored already)
- HTML attributes containing `wordpress`
- escape quoted `\'wordpress\'` as used in xpath queries.

The sniff will ignore *anything* within an array, as well as string array keys like `$var['wordpress']` as these will generate false positives in 80% of the cases.
The sniff will skip forward to the end of the array when one is encountered. This also prevents the sniff "hanging" when processing large configuration arrays.

The sniff is accompanied by extensive unit tests and has been run over both WP core as well as some 180+ recently updated themes (7500+ php files) to try and eliminate most false positives.

The only "common" (1 instance in core) false positive I've not eliminated is when the term is used in a parameter in a function call. Excluding that would also exclude examining text strings passed to translation functions which would be counter-productive.

I expect we'll see some more false positives reports over the next few months, but am hopeful this will be a good base to start from.

Fixes #876

To do if/when this PR is merged:
- [ ] Add information about the new whitelist comment to the wiki.