### PR TITLE
Update the `project.ruleset.xml` example file.

### DIFF
--- a/project.ruleset.xml.example
+++ b/project.ruleset.xml.example
@@ -2,6 +2,7 @@
 <ruleset name="Example Project">
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
+	<!-- Exclude select folders and files from being checked. -->
 	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-*.php</exclude-pattern>
@@ -10,25 +11,75 @@
 	<exclude-pattern>/docroot/wp-content/plugins/*</exclude-pattern>
 	<exclude-pattern>*.twig</exclude-pattern>
 
-	<rule ref="Squiz.PHP.CommentedOutCode"/>
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
-	<rule ref="Generic.Commenting.Todo"/>
-	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
+	<!-- Exclude Composer Vendor directory. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
 
 	<!--
-	We may also want to to include all the rules in a standard
+	We may also want to to include all the rules in a standard.
 	-->
-	<rule ref="WordPress-Core">
+	<rule ref="WordPress-Extra">
 		<!--
 		We may want a middle ground though. The best way to do this is add the
-		entire ruleset, then rule by rule, remove ones that don't suit a project. We
-		can do this by running `phpcs` with the '-s' flag, to see the names of the
-		different Sniffs, as their rules are broken. From here, we can opt to
+		entire ruleset, then rule by rule, remove ones that don't suit a project.
+		We can do this by running `phpcs` with the '-s' flag, to see the names of
+		the different Sniffs, as their rules are broken. From here, we can opt to
 		exclude problematic sniffs like so.
 		-->
 
 		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
 		<exclude name="WordPress.XSS.EscapeOutput"/>
 	</rule>
+
+	<!-- Let's also check that everything is properly documented. -->
+	<rule ref="WordPress-Docs"/>
+
+	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Commenting.Todo"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<!--
+	To enable this, the PHPCompatibility standard needs
+	to be installed.
+	See the readme for installation instructions:
+	https://github.com/wimg/PHPCompatibility
+	-->
+	<!--
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
+	-->
+
+	<!--
+	To get the optimal benefits of using WPCS, we should add a couple of
+	custom properties.
+	Adjust the values of these properties to fit our needs.
+
+	For information on additional custom properties available, check out
+	the wiki:
+	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="my-textdomain,library-textdomain"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="my_prefix"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="4.5"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.DeprecatedParameters">
+		<properties>
+			<property name="minimum_supported_version" value="4.5"/>
+		</properties>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
* Recommend using the `WordPress-Extra` + `WordPress-Docs` ruleset rather than `WordPress-Core`.
* Add example to exclude the Composer vendor directory.
* Remove some of the "extra" included rules which are already included by the WP rulesets (and move the rest of them down).
* Add info and example on how to include the `PHPCompatibility` standard. We already recommend its use in the readme, so we might as well show how.
* Add a number of the recommended custom properties to the example ruleset.
* Add/Clarify some documentation.