### PR TITLE
PrefixAllGlobalsSniff: Allow for backfills of native PHP functions/classes etc

### DIFF
--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -199,3 +199,25 @@ $something = 'abc'; // WPCS: prefix ok.
 // Executing a WP core action or filter is sometimes ok.
 do_action( 'set_current_user' ); // WPCS: prefix ok.
 apply_filters( 'excerpt_edit_pre', $var ); // WPCS: prefix ok.
+
+/*
+ * Issue 915: OK/Bad - backfilled PHP functions will be recognized depending on the PHP version PHPCS runs on
+ * and the extensions loaded in that version.
+ */
+if ( ! function_exists( 'mb_strpos' ) ) {
+	// Fill in for a PHP function which is not always available (extension needs to be loaded).
+	function mb_strpos() {}
+}
+
+if ( ! function_exists( 'array_column' ) ) {
+	// Fill in for a PHP function which is not always available - introduced in PHP 5.5.
+	function array_column() {}
+}
+
+if ( ! defined( 'E_DEPRECATED' ) ) {
+	define( 'E_DEPRECATED', true ); // Introduced in PHP 5.3.0.
+}
+
+if ( ! class_exists( 'IntlTimeZone' ) ) {
+	class IntlTimeZone {} // Introduced in PHP 5.5.0.
+}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -46,6 +46,10 @@ class WordPress_Tests_NamingConventions_PrefixAllGlobalsUnitTest extends Abstrac
 					138 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
 					139 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
 					140 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					209 => ( function_exists( 'mb_strpos' ) ) ? 0 : 1,
+					214 => ( function_exists( 'array_column' ) ) ? 0 : 1,
+					218 => ( defined( 'E_DEPRECATED' ) ) ? 0 : 1,
+					222 => ( class_exists( 'IntlTimeZone' ) ) ? 0 : 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.1.inc':


### PR DESCRIPTION
This will only prevent false positives when the sniffs are run on a PHP version which contains the backfilled function/class etc., but should diminish annoyances for these.

Related to issue #915