### PR TITLE
Fix codestyle for latest XML rule addition.

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -367,7 +367,7 @@
 	<!-- Check for correct usage of the WP i18n functions. -->
 	<rule ref="WordPress.WP.I18n"/>
 
-		<!-- Check for correct spelling of WordPress. -->
-		<rule ref="WordPress.WP.CapitalPDangit"/>
+	<!-- Check for correct spelling of WordPress. -->
+	<rule ref="WordPress.WP.CapitalPDangit"/>
 
 </ruleset>


### PR DESCRIPTION
The WP spelling sniff was pulled before the XML ruleset validation changes, so the associated XML still needed to be adjusted to comply.