### PR TITLE
Add Squiz.Classes.SelfMemberReference to WordPress-Core

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -189,6 +189,13 @@
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
+	<!-- References to self in a class should be lower-case and not have extraneous spaces,
+		 per implicit conventions in the core codebase; the NotUsed code refers to using the
+		 fully-qualified class name instead of self, for which there are instances in core. -->
+	<rule ref="Squiz.Classes.SelfMemberReference" />
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<severity>0</severity>
+	</rule>
 
 	<!--
 	#############################################################################

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -189,14 +189,6 @@
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
-	<!-- References to self in a class should be lower-case and not have extraneous spaces,
-		 per implicit conventions in the core codebase; the NotUsed code refers to using the
-		 fully-qualified class name instead of self, for which there are instances in core. -->
-	<rule ref="Squiz.Classes.SelfMemberReference" />
-	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
-		<severity>0</severity>
-	</rule>
-
 	<!--
 	#############################################################################
 	Handbook: PHP - Formatting SQL statements.
@@ -363,6 +355,13 @@
 	<!-- Class opening braces should be on the same line as the statement. -->
 	<rule ref="Generic.Classes.OpeningBraceSameLine"/>
 
+	<!-- References to self in a class should be lower-case and not have extraneous spaces,
+		 per implicit conventions in the core codebase; the NotUsed code refers to using the
+		 fully-qualified class name instead of self, for which there are instances in core. -->
+	<rule ref="Squiz.Classes.SelfMemberReference"/>
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<severity>0</severity>
+	</rule>
 
 	<!--
 	#############################################################################

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -189,6 +189,7 @@
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
+
 	<!--
 	#############################################################################
 	Handbook: PHP - Formatting SQL statements.

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -42,6 +42,12 @@
 
 	<rule ref="WordPress-Core"/>
 
+	<!-- Warn against using fully-qualified class names instead of the self keyword. -->
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<!-- Restore default severity of 5 which WordPress-Core sets to 0. -->
+		<severity>5</severity>
+	</rule>
+
 	<rule ref="WordPress.XSS.EscapeOutput"/>
 
 	<!-- Verify that a nonce check is done before using values in superglobals.


### PR DESCRIPTION
This will flag the following as errors:

```php
Self::do_something();
self:: do_something();
self ::do_something();
self :: do_something();
```

Note that it excludes the `NotUsed` error code which would flag the following:

```php
MyClassName::do_something();
```

Since there are instances of this in the core codebase, for better or worse.