### PR TITLE
Fix issue #915: handling of variable variables / hook names / $GLOBALS array keys

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -217,7 +217,10 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 						return;
 					}
 
-					$item_name = $this->phpcsFile->getDeclarationName( $stackPtr );
+					$item_name  = $this->phpcsFile->getDeclarationName( $stackPtr );
+					$error_text = 'Classes declared';
+					$error_code = 'NonPrefixedClassFound';
+
 					switch ( $this->tokens[ $stackPtr ]['type'] ) {
 						case 'T_CLASS':
 							if ( class_exists( $item_name ) ) {
@@ -231,6 +234,9 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 								// Backfill for PHP native interface.
 								return;
 							}
+
+							$error_text = 'Interfaces declared';
+							$error_code = 'NonPrefixedInterfaceFound';
 							break;
 
 						case 'T_TRAIT':
@@ -238,6 +244,9 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 								// Backfill for PHP native trait.
 								return;
 							}
+
+							$error_text = 'Traits declared';
+							$error_code = 'NonPrefixedTraitFound';
 							break;
 
 						default:
@@ -245,8 +254,6 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 							break;
 					}
 
-					$error_text = 'Classes declared';
-					$error_code = 'NonPrefixedClassFound';
 					break;
 
 				case 'T_CONST':

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -339,7 +339,9 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 		$maybe_assignment = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
 
 		while ( false !== $maybe_assignment
-			&& T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
+			&& ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
+			// Next line is temporary. Work around for bug 1381 which will be fixed in PHPCS 2.9.0.
+			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $maybe_assignment ]['code'] )
 			&& isset( $this->tokens[ $maybe_assignment ]['bracket_closer'] )
 		) {
 			$maybe_assignment = $this->phpcsFile->findNext(

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -16,10 +16,13 @@ function ^%&_do_something() {}
  * Bad - not prefixed.
  */
 function do_something() {
-	global $something;
+	global $something, $else;
 
 	$something = 'value';
 	$GLOBALS['something'] = 'value';
+	$GLOBALS[ 'something' . $else ] = 'value';
+	$GLOBALS[ "something_{$else}" ] = 'value';
+	$GLOBALS[ "something$else" ] = 'value';
 }
 
 $var = 'abc';
@@ -33,16 +36,20 @@ trait Example_Trait {}
 
 do_action( 'plugin_action' );
 apply_filters( 'theme_filter', $var );
+do_action( "plugin_action_{$acronym_filter_var}" );
+apply_filters( 'theme_filter_' . $acronym_filter_var );
 
 
 /*
  * OK - prefixed.
  */
 function acronym_do_something() {
-	global $acronym_something;
+	global $acronym_something, $else;
 
 	$acronym_something = 'value';
 	$GLOBALS['acronym_something'] = 'value';
+	$GLOBALS[ 'acronym_' . $else ] = 'value';
+	$GLOBALS[ "acronym_something_{$else}" ] = 'value';
 }
 
 $acronym_var = 'abc';
@@ -56,6 +63,9 @@ trait Acronym_Example_Trait {}
 
 do_action( 'acronym_plugin_action' );
 apply_filters( 'acronym_theme_filter', $var );
+do_action( "acronym_plugin_action_{$acronym_filter_var}" );
+apply_filters( 'acronym_theme_filter_' . $acronym_filter_var );
+
 
 /*
  * OK - test secondary prefix.
@@ -71,6 +81,7 @@ class TGMPA_Example {}
 
 do_action( 'tgmpa_plugin_action' );
 apply_filters( 'tgmpa_theme_filter', $var );
+do_action( "tgmpa_plugin_action_{$acronym_filter_var}" );
 
 
 /*
@@ -88,6 +99,9 @@ function acronym() {
 
 	$acronym = 'value';
 	$GLOBALS['acronym'] = 'value';
+	$GLOBALS[ 'acronym'  . $else ] = 'value'; // Presume the '_' is part of the $else.
+	$GLOBALS[ "acronym{$else}" ] = 'value'; // Presume the '_' is part of the $else.
+	$GLOBALS[ "acronym$else" ] = 'value'; // Presume the '_' is part of the $else.
 }
 
 $acronym = 'abc';
@@ -108,6 +122,7 @@ apply_filters( 'acronym', $var );
  */
 function acronym_do_something( $param = 'default' ) {
 	$var = 'abc';
+	${$something} = 'value';
 }
 
 function ( $param ) {
@@ -200,6 +215,7 @@ $something = 'abc'; // WPCS: prefix ok.
 do_action( 'set_current_user' ); // WPCS: prefix ok.
 apply_filters( 'excerpt_edit_pre', $var ); // WPCS: prefix ok.
 
+
 /*
  * Issue 915: OK/Bad - backfilled PHP functions will be recognized depending on the PHP version PHPCS runs on
  * and the extensions loaded in that version.
@@ -220,4 +236,66 @@ if ( ! defined( 'E_DEPRECATED' ) ) {
 
 if ( ! class_exists( 'IntlTimeZone' ) ) {
 	class IntlTimeZone {} // Introduced in PHP 5.5.0.
+}
+
+
+/*
+ * Issue 915: dynamic names. Names starting with a dynamic part or
+ * which are completely dynamic, will receive a warning.
+ */
+function acronym_something() {
+	global $something;
+
+	$GLOBALS[ $something ] = 'value'; // Warning.
+	$GLOBALS[ "{$something}_something" ] = 'value'; // Warning.
+}
+
+$$something = 'value'; // Warning.
+${$something} = 'value'; // Warning.
+$$$${$something} = 'value'; // Warning.
+${$something}['foo'] = 'value'; // Warning.
+${$something}['foo']['bar'] = 'value'; // Warning.
+${$something['foo']} = 'value'; // Warning.
+$GLOBALS[ $something ] = 'value'; // Warning.
+$GLOBALS[ "{$something}_something" ] = 'value'; // Warning.
+$GLOBALS[ ${$something} ] = 'value'; // Warning.
+
+define( ${$something}, 'value' ); // Warning.
+define( $something, 'value' ); // Warning.
+define( $something . '_CONSTANT', 'value' ); // Warning.
+define( "{$something}_CONSTANT", 'value' ); // Warning.
+define( $something . '_CONSTANT', 'value' ); // Warning.
+
+do_action( "{$acronym_filter_var}_hook_name" ); // Warning.
+do_action( "{$acronym_filter_var}hook_name" ); // Warning.
+do_action( $acronym_filter_var ); // Warning.
+do_action( $GLOBALS['something'] ); // Warning.
+do_action( ${$acronym_filter_var} ); // Warning.
+do_action( $GLOBALS[ ${$something} ] ); // Warning.
+apply_filters( $_REQUEST['else'] ); // Warning.
+
+class Acronym_Dynamic_Hooks {
+	const FILTER = 'acronym';
+	const FILTER_WITH_UNDERSCORE = 'acronym_';
+
+	protected $filter = 'acronym';
+	protected $filter_with_underscore = 'acronym_';
+
+	public function test() {
+		global $acronym_filter_var;
+		${$this->name} = 'value'; // Warning.
+		apply_filters( "{$acronym_filter_var}_hook" ); // Warning.
+		do_action( $acronym_filter_var ); // Warning.
+
+		do_action( $this->filter ); // Warning.
+		apply_filters( $this->filter_array['key'] ); // Warning.
+		do_action( "{$this->filter}_hook_name" ); // Warning.
+		do_action( "{$this->filter_with_underscore}hook_name" ); // Warning.
+
+		apply_filters( self::FILTER ); // Warning.
+		apply_filters( self::FILTER_WITH_UNDERSCORE . 'hook_name' ); // Warning.
+		apply_filters( self::FILTER_ARRAY['key'] ); // Warning.
+
+		do_action( $this->parent_property ); // Warning.
+	}
 }

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -26,30 +26,37 @@ class WordPress_Tests_NamingConventions_PrefixAllGlobalsUnitTest extends Abstrac
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.inc':
 				return array(
-					1   => 2, // 2 x error for incorrect prefix.
+					1   => 2, // 2 x error for incorrect prefix passed.
 					10  => 1,
 					18  => 1,
 					21  => 1,
 					22  => 1,
+					23  => 1,
+					24  => 1,
 					25  => 1,
-					27  => 1,
 					28  => 1,
 					30  => 1,
 					31  => 1,
-					32  => 1,
+					33  => 1,
 					34  => 1,
 					35  => 1,
-					79  => 1,
-					80  => 1,
-					134 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
-					136 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
-					138 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
-					139 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
-					140 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
-					209 => ( function_exists( 'mb_strpos' ) ) ? 0 : 1,
-					214 => ( function_exists( 'array_column' ) ) ? 0 : 1,
-					218 => ( defined( 'E_DEPRECATED' ) ) ? 0 : 1,
-					222 => ( class_exists( 'IntlTimeZone' ) ) ? 0 : 1,
+					37  => 1,
+					38  => 1,
+					39  => 1,
+					40  => 1,
+					90  => 1,
+					91  => 1,
+					// Scoped.
+					149 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					151 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					153 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					154 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					155 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
+					// Backfills.
+					225 => ( function_exists( 'mb_strpos' ) ) ? 0 : 1,
+					230 => ( function_exists( 'array_column' ) ) ? 0 : 1,
+					234 => ( defined( 'E_DEPRECATED' ) ) ? 0 : 1,
+					238 => ( class_exists( 'IntlTimeZone' ) ) ? 0 : 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.1.inc':
@@ -77,10 +84,54 @@ class WordPress_Tests_NamingConventions_PrefixAllGlobalsUnitTest extends Abstrac
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
-		return array();
+	public function getWarningList( $testFile = 'PrefixAllGlobalsUnitTest.inc' ) {
+
+		switch ( $testFile ) {
+			case 'PrefixAllGlobalsUnitTest.inc':
+				return array(
+					249 => 1,
+					250 => 1,
+					253 => 1,
+					254 => 1,
+					255 => 1,
+					256 => 1,
+					257 => 1,
+					258 => 1,
+					259 => 1,
+					260 => 1,
+					261 => 1,
+					263 => 1,
+					264 => 1,
+					265 => 1,
+					266 => 1,
+					267 => 1,
+					269 => 1,
+					270 => 1,
+					271 => 1,
+					272 => 1,
+					273 => 1,
+					274 => 1,
+					275 => 1,
+					286 => 1,
+					287 => 1,
+					288 => 1,
+					290 => 1,
+					291 => 1,
+					292 => 1,
+					293 => 1,
+					295 => 1,
+					296 => 1,
+					297 => 1,
+					299 => 1,
+				);
+
+			default:
+				return array();
+
+		} // End switch().
 
 	}
 


### PR DESCRIPTION
In issue #915 @GaryJones identified some issues with the new `PrefixAllGlobals` sniff.

PR #916 fixed the over-zealousness when non-prefixed functions/constants etc backfilled for PHP functions.

This PR addresses the remaining issues:
* Arrays keys for `$GLOBALS` need to be prefixed too, so throw a warning when these are dynamic. I.e. `$GLOBALS['prefix' . $something]` is fine, `$GLOBALS[ $something ]` will now throw a warning. These cases were previously ignored completely.
* Dynamic hook names or constant names when used with `define()` which start with a prefixed string will now be correctly identified as prefixed. I.e.: `apply_filters( "'genesis_cpt_archive_settings_capability_' . $this->post_type->name" )`
* Dynamic hook names or constant names when used with `define()` *might* be prefixed, but we can't be sure. Previously those would throw an error. This has now been downgraded to a warning for those specific cases. I.e.: `do_action( $action_name )` or `do_action( "{$something}_hook" )`
* Variable variables were up to now completely ignored, however if these are being assigned a value in the global namespace, these should throw a warning too as - again - we can't be sure that these are correctly prefixed. I.e. `${$var} = 'value'`.
	


Also:
* Minor improvement in the error message/code specificity for non-prefixed interfaces/traits.

Fixes #915