### PR TITLE
FileNameUnitTest: Re-enable the unit tests for non-strict class names.

### DIFF
--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -90,8 +90,8 @@ class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest {
 	 * @return string[]
 	 */
 	protected function getTestFiles( $testFileBase ) {
-		$sep             = DIRECTORY_SEPARATOR;
-		$test_files      = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . 'TestFiles' . $sep . ',' . $sep . 'ThemeExceptions' . $sep . ',' . $sep . 'wp-includes' . $sep . '}*.inc', GLOB_BRACE );
+		$sep        = DIRECTORY_SEPARATOR;
+		$test_files = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', GLOB_BRACE );
 
 		// Adjust the expected results array for PHP 5.2 as PHP 5.2 does not recognize namespaces.
 		if ( PHP_VERSION_ID < 50300 ) {

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
@@ -1,5 +1,7 @@
 @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+
 <?php
 
 class Non_Strict_Class {}
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+
+// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
@@ -1,5 +1,7 @@
 @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+
 <?php
 
 class Non_Strict_Class {}
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+
+// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
@@ -1,5 +1,7 @@
 @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+
 <?php
 
 class My_Class {}
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+
+// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true


### PR DESCRIPTION
The unit tests for non-strict class names were never enabled as the directory in which the test files live, wasn't listed in the `glob()` call.
This was previously not corrected as the `@codingStandardsChangeSetting` directives did not seem to work well in combination with a PHP open tag as the target token.

This has now been fixed. The unit tests should now pass and the directory has been included by making the `glob()` call more dynamic which will automatically include additional directories if these would be added in the future.