### PR TITLE
OperatorSpacing: Ignore operators in declare statements

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -71,12 +71,14 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 			}
 
 			// Skip default values in function declarations.
+			// Skip declare statements.
 			if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 				$bracket = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
 				if ( isset( $tokens[ $bracket ]['parenthesis_owner'] ) ) {
 					$function = $tokens[ $bracket ]['parenthesis_owner'];
 					if ( T_FUNCTION === $tokens[ $function ]['code']
 						|| T_CLOSURE === $tokens[ $function ]['code']
+						|| T_DECLARE === $tokens[ $function ]['code']
 					) {
 						return;
 					}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -53,3 +53,6 @@ if (  ! $var ) {
 // Ok: Test skipping of default values in function declarations.
 function my_test( $a=true, $b = 123, $c=  'string' ) {}
 $a = function ( $a=true, $b = 123, $c=  'string' ) {};
+
+// Upstream issue 1163.
+declare(strict_types=1);

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -53,3 +53,6 @@ if ( ! $var ) {
 // Ok: Test skipping of default values in function declarations.
 function my_test( $a=true, $b = 123, $c=  'string' ) {}
 $a = function ( $a=true, $b = 123, $c=  'string' ) {};
+
+// Upstream issue 1163.
+declare(strict_types=1);


### PR DESCRIPTION
Declare statements are typically written without spaces in them.

This commit makes the `OperatorSpacing` sniff ignore them, similarly as is done upstream - https://github.com/squizlabs/PHP_CodeSniffer/pull/1411

It would be a good idea to do a complete compare and sync with upstream for this sniff at some point, but that's another matter.