### PR TITLE
Update for PHPCS 2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ php:
     - 7.1
 
 env:
-  - PHPCS_BRANCH=master
+  # Branch for patches against 2.x. `master` is now 3.x which WPCS is not (yet) compatible with.
+  - PHPCS_BRANCH=2.9
+  # Tagged release
   - PHPCS_BRANCH=2.9.0
 
 matrix:
@@ -21,29 +23,29 @@ matrix:
   include:
     # Run PHPCS against WPCS. I just picked to run it against 5.5.
     - php: 5.5
-      env: PHPCS_BRANCH=master SNIFF=1
+      env: PHPCS_BRANCH=2.9 SNIFF=1
     # Run against PHPCS 3.0. I just picked to run it against 5.6.
     - php: 5.6
-      env: PHPCS_BRANCH=3.0
+      env: PHPCS_BRANCH=master
     # Run against HHVM and PHP nightly.
     - php: hhvm
       sudo: required
       dist: trusty 
-      group: edge 
-      env: PHPCS_BRANCH=master
+      group: edge
+      env: PHPCS_BRANCH=2.9
     - php: nightly
-      env: PHPCS_BRANCH=master
+      env: PHPCS_BRANCH=2.9
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
     - php: hhvm
-    - env: PHPCS_BRANCH=3.0
+    - env: PHPCS_BRANCH=master
 
 before_install:
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit
-    - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
+    - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == master ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
     # Download PHPUnit 5.x for builds on PHP 7, nightly and HHVM as

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   - PHPCS_BRANCH=master
-  - PHPCS_BRANCH=2.8.1
+  - PHPCS_BRANCH=2.9.0
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.8.1** or higher.
+The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.9.0** or higher.
 The WordPress Coding Standards are currently [not compatible with the upcoming PHPCS 3 release](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718).
 
 ### Composer

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -339,9 +339,7 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 		$maybe_assignment = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
 
 		while ( false !== $maybe_assignment
-			&& ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
-			// Next line is temporary. Work around for bug 1381 which will be fixed in PHPCS 2.9.0.
-			|| T_OPEN_SHORT_ARRAY === $this->tokens[ $maybe_assignment ]['code'] )
+			&& T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
 			&& isset( $this->tokens[ $maybe_assignment ]['bracket_closer'] )
 		) {
 			$maybe_assignment = $this->phpcsFile->findNext(

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -135,12 +135,9 @@ class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFuncti
 	 */
 	public function register() {
 		// Set up all string targets.
-		$targets                  = PHP_CodeSniffer_Tokens::$stringTokens;
-		$targets[ T_INLINE_HTML ] = T_INLINE_HTML;
-		$targets[ T_HEREDOC ]     = T_HEREDOC;
-		$targets[ T_NOWDOC ]      = T_NOWDOC;
+		$this->string_tokens = PHP_CodeSniffer_Tokens::$textStringTokens;
 
-		$this->string_tokens = $targets;
+		$targets = $this->string_tokens;
 
 		// Add CSS style target.
 		$targets[] = T_STYLE;

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -147,7 +147,7 @@ class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff extends WordPress_Sniff {
 
 		// Check for Database Schema Changes.
 		$_pos = $stackPtr;
-		while ( $_pos = $this->phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING, T_HEREDOC, T_NOWDOC ), ( $_pos + 1 ), $endOfStatement, false, null, true ) ) {
+		while ( $_pos = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$textStringTokens, ( $_pos + 1 ), $endOfStatement, false, null, true ) ) {
 			if ( preg_match( '#\b(?:ALTER|CREATE|DROP)\b#i', $this->tokens[ $_pos ]['content'] ) > 0 ) {
 				$this->phpcsFile->addError( 'Attempting a database schema change is highly discouraged.', $_pos, 'SchemaChange' );
 			}

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -24,14 +24,7 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 	 * @return array
 	 */
 	public function register() {
-		return array(
-			T_CONSTANT_ENCAPSED_STRING,
-			T_DOUBLE_QUOTED_STRING,
-			T_INLINE_HTML,
-			T_HEREDOC,
-			T_NOWDOC,
-		);
-
+		return PHP_CodeSniffer_Tokens::$textStringTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -183,9 +183,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 			}
 
 			// Merge consecutive single or double quoted strings (when they span multiple lines).
-			if ( T_CONSTANT_ENCAPSED_STRING === $this_token['code'] || 'T_DOUBLE_QUOTED_STRING' === $this_token['type']
-				|| T_HEREDOC === $this_token['code'] || 'T_NOWDOC' === $this_token['type']
-			) {
+			if ( isset( PHP_CodeSniffer_Tokens::$textStringTokens[ $this_token['code'] ] ) ) {
 				for ( $j = ( $i + 1 ); $j < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
 					if ( $this_token['code'] === $this->tokens[ $j ]['code'] ) {
 						$this_token['content'] .= $this->tokens[ $j ]['content'];

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -160,3 +160,6 @@ output( <<<EOD
 some string {$_POST[some_var]} {$_GET['evil']}
 EOD
 ); // Bad x2.
+
+if ( ( $_POST['foo'] ?? 'post' ) === 'post' ) {} // OK.
+if ( ( $_POST['foo'] <=> 'post' ) === 0 ) {} // OK.

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.inc
@@ -129,3 +129,5 @@ add_filter( 'comments_open', new class {
 		return 'page' === $page->post_type;
 	}
 }, 10, 2 );
+
+$GLOBALS['totals']   ??= 10; // Bad.

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -33,6 +33,7 @@ class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUni
 			54  => 1,
 			95  => 1,
 			128 => 1,
+			133 => 1,
 		);
 
 	}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -56,3 +56,8 @@ $a = function ( $a=true, $b = 123, $c=  'string' ) {};
 
 // Upstream issue 1163.
 declare(strict_types=1);
+
+$a = $b??$c;
+$a = $b<=>$c;
+
+$a    ??= $b; // Multiple spaces before assignment is OK.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -56,3 +56,8 @@ $a = function ( $a=true, $b = 123, $c=  'string' ) {};
 
 // Upstream issue 1163.
 declare(strict_types=1);
+
+$a = $b ?? $c;
+$a = $b <=> $c;
+
+$a    ??= $b; // Multiple spaces before assignment is OK.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -26,6 +26,8 @@ class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUn
 			18 => 1,
 			45 => 1,
 			49 => 1,
+			60 => 2,
+			61 => 2,
 		);
 
 	}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.8.1"
+		"squizlabs/php_codesniffer": "^2.9.0"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
PHPCS 2.9.0 has just been released. See https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/2.9.0

-----
#### Commit 1
PHPCS 2.9.0 contains a new `PHP_CodeSniffer_Tokens::$textStringTokens` array as well as several other improvements to some of the predefined arrays in `PHP_CodeSniffer_Tokens` which are being used by WPCS.

It therefore makes sense to take advantage of these upstream improvements to automatically improve the results of our sniffing.

In two places, replacing an existing manually created array with the new `PHP_CodeSniffer_Tokens::$textStringTokens` array means that the `T_INLINE_HTML` token is added to the array.
For both instances, the code has been reviewed and it was determined that the `T_INLINE_HTML` token can never be encountered there anyway as both examine function calls, so this should not cause any issues.

Includes some extra unit tests.

Note: in some unit tests the `??=` syntax is being used. This is a new syntax which is expected to be introduced in PHP 7.2.
The RFC for this has been approved, though the actual change has not been merged yet into PHP itself. All the same, PHPCS already accounts for it, so we may as well test that it does so correctly.

-----
#### Commit 2

Remove a work-around for a bug in PHPCS which was fixed in 2.9.0.

-----
#### Commit 3

Build against the 2.x branch as WPCS is currently not compatible with PHPCS 3.0.