### PR TITLE
:sparkles: New sniff to verify correct array indentation

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -34,6 +34,7 @@
 			<property name="ignoreIndentationTokens" type="array" value="T_HEREDOC,T_NOWDOC,T_INLINE_HTML"/>
 		</properties>
 	</rule>
+	<rule ref="WordPress.Arrays.ArrayIndentation"/>
 
 	<!-- Covers rule: Use real tabs and not spaces. -->
 	<arg name="tab-width" value="4"/>

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Enforces WordPress array indentation for multi-line arrays.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_ARRAY,
+			T_OPEN_SHORT_ARRAY,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$cli_values = $this->phpcsFile->phpcs->cli->getCommandLineValues();
+			if ( ! isset( $cli_values['tabWidth'] ) || 0 === $cli_values['tabWidth'] ) {
+				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
+				$this->tab_width = 4;
+			} else {
+				$this->tab_width = $cli_values['tabWidth'];
+			}
+		}
+
+		/*
+		 * Determine the array opener & closer.
+		 */
+		if ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( ! isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
+				return; // Live coding.
+			}
+			$opener = $this->tokens[ $stackPtr ]['parenthesis_opener'];
+
+			if ( ! isset( $this->tokens[ $opener ]['parenthesis_closer'] ) ) {
+				return; // Live coding.
+			}
+			$closer = $this->tokens[ $opener ]['parenthesis_closer'];
+		} else {
+			// Short array syntax.
+			$opener = $stackPtr;
+
+			if ( ! isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+				return; // Live coding.
+			}
+			$closer = $this->tokens[ $stackPtr ]['bracket_closer'];
+		}
+
+		if ( $this->tokens[ $opener ]['line'] === $this->tokens[ $closer ]['line'] ) {
+			// Not interested in single line arrays.
+			return;
+		}
+
+		/*
+		 * Determine the indentation of the line containing the array opener.
+		 */
+		$indentation = '';
+		$column      = 1;
+		for ( $i = $stackPtr; $i >= 0; $i-- ) {
+			if ( $this->tokens[ $i ]['line'] === $this->tokens[ $stackPtr ]['line'] ) {
+				continue;
+			}
+
+			if ( T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] ) {
+				// Something weird going on with tabs vs spaces, but this fixes it.
+				$indentation = str_replace( '    ', "\t", $this->tokens[ ( $i + 1 ) ]['content'] );
+				$column      = $this->tokens[ ( $i + 2 ) ]['column'];
+			}
+			break;
+		}
+		unset( $i );
+
+		/*
+		 * Check the closing bracket is lined up with the start of the content on the line
+		 * containing the array opener.
+		 */
+		if ( $this->tokens[ $closer ]['column'] !== $column ) {
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 );
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected,
+				$found,
+			);
+
+			$fix = $this->phpcsFile->addFixableError( $error, $closer, 'CloseBraceNotAligned', $data );
+			if ( true === $fix ) {
+				if ( 0 === $found ) {
+					$this->phpcsFile->fixer->addContent( ( $closer - 1 ), $indentation );
+				} else {
+					$this->phpcsFile->fixer->replaceToken( ( $closer - 1 ), $indentation );
+				}
+			}
+		}
+
+		$array_items = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $array_items ) ) {
+			// Strange, no array items found.
+			return;
+		}
+
+		$expected_indent = "\t" . $indentation;
+		$expected_column = ( $column + $this->tab_width );
+
+		foreach ( $array_items as $item ) {
+			// Find the line on which the item starts.
+			$first_content = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $item['start'], ( $item['end'] + 1 ), true );
+			if ( false === $first_content ) {
+				continue;
+			}
+
+			$whitespace = '';
+			if ( 1 !== $this->tokens[ $first_content ]['column'] ) {
+				$whitespace = $this->tokens[ ( $first_content - 1 ) ]['content'];
+
+				// If tabs are being converted to spaces by the tokenizer, the
+				// original content should be checked instead of the converted content.
+				if ( isset( $this->tokens[ ( $first_content - 1 ) ]['orig_content'] ) ) {
+					$whitespace = $this->tokens[ ( $first_content - 1 ) ]['orig_content'];
+				}
+			}
+
+			if ( $whitespace !== $expected_indent ) {
+				$expected = ( $expected_column - 1 );
+				$found    = ( $this->tokens[ $first_content ]['column'] - 1 );
+				$error    = 'Array item not aligned correctly; expected %s spaces but found %s';
+				$data     = array(
+					$expected,
+					$found,
+				);
+
+				$fix = $this->phpcsFile->addFixableError( $error, $first_content, 'ItemNotAligned', $data );
+				if ( true === $fix ) {
+					if ( 0 === $found ) {
+						$this->phpcsFile->fixer->addContent( ( $first_content - 1 ), $expected_indent );
+					} else {
+						$this->phpcsFile->fixer->replaceToken( ( $first_content - 1 ), $expected_indent );
+					}
+				}
+			}
+		} // End foreach().
+
+	} // End process_token().
+
+} // End class.

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -132,14 +132,22 @@ class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
 			return;
 		}
 
-		$expected_indent = "\t" . $indentation;
-		$expected_column = ( $column + $this->tab_width );
+		$expected_indent  = "\t" . $indentation;
+		$expected_column  = ( $column + $this->tab_width );
+		$end_of_last_item = $opener;
 
 		foreach ( $array_items as $item ) {
 			// Find the line on which the item starts.
 			$first_content = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $item['start'], ( $item['end'] + 1 ), true );
 			if ( false === $first_content ) {
+				$end_of_last_item = ( $item['end'] + 1 );
 				continue;
+			}
+
+			// Bow out from reporting and fixing mixed multi-line/single-line arrays.
+			// That is handled by the ArrayDeclarationSniff.
+			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_last_item ]['line'] ) {
+				return $closer;
 			}
 
 			$whitespace = '';
@@ -171,6 +179,9 @@ class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
 					}
 				}
 			}
+
+			$end_of_last_item = ( $item['end'] + 1 );
+
 		} // End foreach().
 
 	} // End process_token().

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -51,7 +51,7 @@ class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_AbstractVa
 				'message'       => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
 				'variables'     => array(
 					'$_COOKIE',
-					),
+				),
 				'array_members' => array(
 					'$_SERVER[\'HTTP_USER_AGENT\']',
 					'$_SERVER[\'REMOTE_ADDR\']',

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -44,7 +44,7 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 			5 => 1,
 			7 => 2,
 			20 => 1,
-		 );
+		);
 
 	}
 

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
@@ -1,0 +1,66 @@
+<?php
+
+$ok = array(
+	'value',
+	123,
+);
+
+$ok_with_keys = [
+	'key1' => 'value',
+	'key2' => 'value', // Comment after item.
+];
+
+$ok_nested = array(
+	'key1' => array(
+		'key1' => 'value',
+		'key2' => 'value',
+	),
+	'key2' => 'value',
+);
+
+
+$bad_phpcs_style = array(
+					'value',
+					123, // Comment after item.
+				   );
+
+$bad_phpcs_style_with_keys = array(
+							  'key1' => 'value',
+							  'key2' => 'value',
+						     );
+
+$bad_phpcs_style_nested = array(
+						   'key1' => [
+									  'key1' => 'value',
+
+									  'key2' => 'value',
+
+									 ],
+						   'key2' => 'value',
+						  );
+
+// Arrays with initial indent.
+			$bad_mixed_indent = [
+'value',
+										          	123,
+					];
+
+	$bad_mixed_indent_with_keys = array(
+
+			'key1' => 'value',
+'key2' => 'value',
+		);
+
+		$bad_mixed_indent_nested = [
+				'key1' => array(
+					'key1' => 'value',
+						'key2' => 'value',
+							),
+
+								'key2' => 'value',
+	];
+
+$empty = [
+
+
+    ];

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
@@ -64,3 +64,18 @@ $empty = [
 
 
     ];
+
+// Same-line items in mixed arrays should be ignored.
+$mixed_1 = array('something', 'else', array(
+		'key1' => 'value',
+			'key2' => 'value', // Comment after item.
+	),
+);
+
+$mixed_2 = array(
+	array(
+			'key1' => 'value',
+		'key2' => 'value', // Comment after item.
+		),
+		'something', 'else',
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
@@ -64,3 +64,18 @@ $empty = [
 
 
 ];
+
+// Same-line items in mixed arrays should be ignored.
+$mixed_1 = array('something', 'else', array(
+		'key1' => 'value',
+			'key2' => 'value', // Comment after item.
+	),
+);
+
+$mixed_2 = array(
+	array(
+			'key1' => 'value',
+		'key2' => 'value', // Comment after item.
+		),
+	'something', 'else',
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
@@ -1,0 +1,66 @@
+<?php
+
+$ok = array(
+	'value',
+	123,
+);
+
+$ok_with_keys = [
+	'key1' => 'value',
+	'key2' => 'value', // Comment after item.
+];
+
+$ok_nested = array(
+	'key1' => array(
+		'key1' => 'value',
+		'key2' => 'value',
+	),
+	'key2' => 'value',
+);
+
+
+$bad_phpcs_style = array(
+	'value',
+	123, // Comment after item.
+);
+
+$bad_phpcs_style_with_keys = array(
+	'key1' => 'value',
+	'key2' => 'value',
+);
+
+$bad_phpcs_style_nested = array(
+	'key1' => [
+		'key1' => 'value',
+
+		'key2' => 'value',
+
+	],
+	'key2' => 'value',
+);
+
+// Arrays with initial indent.
+			$bad_mixed_indent = [
+				'value',
+				123,
+			];
+
+	$bad_mixed_indent_with_keys = array(
+
+		'key1' => 'value',
+		'key2' => 'value',
+	);
+
+		$bad_mixed_indent_nested = [
+			'key1' => array(
+				'key1' => 'value',
+				'key2' => 'value',
+			),
+
+			'key2' => 'value',
+		];
+
+$empty = [
+
+
+];

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the ArrayIndentation sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_Arrays_ArrayIndentationUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			23 => 1,
+			24 => 1,
+			25 => 1,
+			28 => 1,
+			29 => 1,
+			30 => 1,
+			33 => 1,
+			34 => 1,
+			36 => 1,
+			38 => 1,
+			39 => 1,
+			40 => 1,
+			44 => 1,
+			45 => 1,
+			46 => 1,
+			50 => 1,
+			51 => 1,
+			52 => 1,
+			55 => 1,
+			57 => 1,
+			58 => 1,
+			60 => 1,
+			61 => 1,
+			66 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -46,6 +46,7 @@ class WordPress_Tests_Arrays_ArrayIndentationUnitTest extends AbstractSniffUnitT
 			60 => 1,
 			61 => 1,
 			66 => 1,
+			80 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -22,13 +22,13 @@ class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSn
 	 */
 	public function getErrorList() {
 		return array(
-			 3 => 2,
-			 6 => 2,
-			 9 => 2,
-			 12 => 2,
-			 15 => 2,
-			 18 => 2,
-			 21 => 2,
+			3  => 2,
+			6  => 2,
+			9  => 2,
+			12 => 2,
+			15 => 2,
+			18 => 2,
+			21 => 2,
 		);
 
 	}


### PR DESCRIPTION
* Multi-line arrays should be indented by one tab from the beginning of the line containing the array opener.
* The array closer should be level with the indentation of the line containing the array opener.

While the `ScopeIndent` sniff checks this type of alignment for most structures, it turns out it doesn't do so for arrays (I suspect this is because PHPCS itself prefers a different array style).

This PR fixes that by adding a new sniff. Both the errors this sniff throws have been made fixable.

The new sniff has been added to the `WordPress-Core` ruleset.

Violations against this sniff in the WPCS codebase have been fixed.

N.B.: I consider this sniff a candidate for pulling upstream to `Generic` in due time.