### PR TITLE
:sparkles: New sniff to verify that spaces are used for mid-line alignment

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -54,6 +54,8 @@
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.SpaceInEmptyArray"/>
 	</rule>
 
+	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
+	<rule ref="WordPress.WhiteSpace.DisallowInlineTabs"/>
 
 	<!--
 	#############################################################################

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -68,12 +68,12 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	 * This method should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 * 	'groupname' => array(
-	 * 		'type'     => 'error' | 'warning',
-	 * 		'message'  => 'Dont use this one please!',
-	 * 		'keys'     => array( 'key1', 'another_key' ),
-	 * 		'callback' => array( 'class', 'method' ), // Optional.
-	 * 	)
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -36,11 +36,11 @@ abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_Abstra
 	 * This method should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Avoid direct calls to the database.',
-	 * 		'classes'   => array( 'PDO', '\Namespace\Classname' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'    => 'error' | 'warning',
+	 *      'message' => 'Avoid direct calls to the database.',
+	 *      'classes' => array( 'PDO', '\Namespace\Classname' ),
+	 *  )
 	 * )
 	 *
 	 * You can use * wildcards to target a group of (namespaced) classes.

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -71,13 +71,13 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	 * This method should be overridden in extending classes.
 	 *
 	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -269,7 +269,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 		'sanitize_email'             => true,
 		'sanitize_file_name'         => true,
 		'sanitize_hex_color_no_hash' => true,
-		'sanitize_hex_color'	     => true,
+		'sanitize_hex_color'         => true,
 		'sanitize_html_class'        => true,
 		'sanitize_meta'              => true,
 		'sanitize_mime_type'         => true,

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -27,13 +27,12 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 * Groups of variables to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -27,11 +27,11 @@ class WordPress_Sniffs_DB_RestrictedClassesSniff extends WordPress_AbstractClass
 	 * Groups of classes to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Avoid direct calls to the database.',
-	 * 		'classes'   => array( 'PDO', '\Namespace\Classname' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'    => 'error' | 'warning',
+	 *      'message' => 'Avoid direct calls to the database.',
+	 *      'classes' => array( 'PDO', '\Namespace\Classname' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -27,11 +27,11 @@ class WordPress_Sniffs_DB_RestrictedFunctionsSniff extends WordPress_AbstractFun
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -22,11 +22,11 @@ class WordPress_Sniffs_Functions_DontExtractSniff extends WordPress_AbstractFunc
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -26,11 +26,11 @@ class WordPress_Sniffs_Functions_FunctionRestrictionsSniff extends WordPress_Abs
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'eval', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -115,7 +115,7 @@ class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sni
 			return;
 		}
 
-		$className	= $phpcsFile->getDeclarationName( $currScope );
+		$className = $phpcsFile->getDeclarationName( $currScope );
 
 		// Ignore special functions.
 		if ( '' === ltrim( $methodName, '_' ) ) {

--- a/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -20,11 +20,11 @@ class WordPress_Sniffs_PHP_DevelopmentFunctionsSniff extends WordPress_AbstractF
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -20,11 +20,11 @@ class WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff extends WordPress_Abstra
 	 * Groups of functions to discourage.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -25,11 +25,11 @@ class WordPress_Sniffs_PHP_POSIXFunctionsSniff extends WordPress_AbstractFunctio
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -31,11 +31,11 @@ class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends WordPress_Abstr
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'eval', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -31,11 +31,11 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -22,13 +22,13 @@ class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_AbstractVa
 	 * Groups of variables to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -24,11 +24,11 @@ class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends WordPress_Abstract
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'eval', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -24,11 +24,11 @@ class WordPress_Sniffs_VIP_TimezoneChangeSniff extends WordPress_AbstractFunctio
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'eval', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -27,13 +27,13 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff extends WordPress_Abs
 	 * Groups of variables to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'wpdb' => array(
-	 * 		'type' => 'error' | 'warning',
-	 * 		'message' => 'Dont use this one please!',
-	 * 		'variables' => array( '$val', '$var' ),
-	 * 		'object_vars' => array( '$foo->bar', .. ),
-	 * 		'array_members' => array( '$foo['bar']', .. ),
-	 * 	)
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -20,11 +20,11 @@ class WordPress_Sniffs_WP_AlternativeFunctionsSniff extends WordPress_AbstractFu
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -20,11 +20,11 @@ class WordPress_Sniffs_WP_DiscouragedFunctionsSniff extends WordPress_AbstractFu
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
-	 * 	'lambda' => array(
-	 * 		'type'      => 'error' | 'warning',
-	 * 		'message'   => 'Use anonymous functions instead please!',
-	 * 		'functions' => array( 'file_get_contents', 'create_function' ),
-	 * 	)
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
 	 * )
 	 *
 	 * @return array

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Enforces using spaces for mid-line alignment.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_WhiteSpace_DisallowInlineTabsSniff extends WordPress_Sniff {
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$cli_values = $this->phpcsFile->phpcs->cli->getCommandLineValues();
+			if ( ! isset( $cli_values['tabWidth'] ) || 0 === $cli_values['tabWidth'] ) {
+				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
+				$this->tab_width = 4;
+			} else {
+				$this->tab_width = $cli_values['tabWidth'];
+			}
+		}
+
+		$check_tokens = array(
+			T_WHITESPACE             => true,
+			T_DOC_COMMENT_WHITESPACE => true,
+			T_DOC_COMMENT_STRING     => true,
+		);
+
+		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+			// Skip all non-whitespace tokens and skip whitespace at the start of a new line.
+			if ( ! isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) || 1 === $this->tokens[ $i ]['column'] ) {
+				continue;
+			}
+
+			// If tabs are being converted to spaces by the tokenizer, the
+			// original content should be checked instead of the converted content.
+			if ( isset( $this->tokens[ $i ]['orig_content'] ) ) {
+				$content = $this->tokens[ $i ]['orig_content'];
+			} else {
+				$content = $this->tokens[ $i ]['content'];
+			}
+
+			if ( '' === $content || strpos( $content, "\t" ) === false ) {
+				continue;
+			}
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Spaces must be used for alignment; tabs are not allowed',
+				$i,
+				'NonIndentTabsUsed'
+			);
+			if ( true === $fix ) {
+				if ( isset( $this->tokens[ $i ]['orig_content'] ) ) {
+					// Use the replacement that PHPCS has already done.
+					$this->phpcsFile->fixer->replaceToken( $i, $this->tokens[ $i ]['content'] );
+				} else {
+					// Replace tabs with spaces, using an indent of $tab_width.
+					// Other sniffs can then correct the indent if they need to.
+					$spaces     = str_repeat( ' ', $this->tab_width );
+					$newContent = str_replace( "\t", $spaces, $this->tokens[ $i ]['content'] );
+					$this->phpcsFile->fixer->replaceToken( $i, $newContent );
+				}
+			}
+		} // End for().
+
+		// Ignore the rest of the file.
+		return ( $this->phpcsFile->numTokens + 1 );
+
+	} // End process().
+
+} // End class.

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -41,7 +41,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 	 */
 	public function register() {
 		$comparison = PHP_CodeSniffer_Tokens::$comparisonTokens;
-		$operators	= PHP_CodeSniffer_Tokens::$operators;
+		$operators  = PHP_CodeSniffer_Tokens::$operators;
 		$assignment = PHP_CodeSniffer_Tokens::$assignmentTokens;
 
 		// Union the arrays - keeps the array keys and - in this case - automatically de-dups.

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @param int    $var    Description.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 );
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected_value => 'data',
+				$found          => 'more_data',
+			);
+
+/**
+ * @param int	 $var	 Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found	  = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error	  = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data	  = array( // Bad.
+				$expected_value => 'data',
+				$found			=> 'more_data', // Bad.
+			);

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc.fixed
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @param int    $var    Description.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 );
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$data     = array(
+				$expected_value => 'data',
+				$found          => 'more_data',
+			);
+
+/**
+ * @param int     $var     Description - Bad: alignment using tabs.
+ * @param string $string Another description.
+ */
+
+			$expected = ( $column - 1 );
+			$found      = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error      = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data      = array( // Bad.
+				$expected_value => 'data',
+				$found            => 'more_data', // Bad.
+			);

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the DisallowInlineTabs sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_WhiteSpace_DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			17 => 1,
+			22 => 1,
+			23 => 1,
+			24 => 1,
+			26 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
> Tabs should be used at the beginning of the line for indentation, while spaces can be used mid-line for alignment.

This new sniff covers the second part of this rule. (The first part is already covered by the `Generic.WhiteSpace.DisallowSpaceIndent` sniff).

The error which is thrown is auto-fixable.

The new sniff has been added to the `WordPress-Core` ruleset.

Violations against this sniff in the WPCS codebase have been fixed.
Mostly involved `getGroups()` function example comments. Some of these have also been adjusted slightly to be in line with an earlier change (#812) in which these were missed and/or with the comment from the abstract parent class.

N.B.: I consider this sniff a candidate for pulling upstream to `Generic` in due time.

N.B.2: This sniff could probably do with some additional unit tests, but I couldn't think of any more, so ideas/code snippets welcome. (The run over the WPCS code base did not yield any incorrect fixes or false positives, so I'm not too worried)
