### PR TITLE
Fix the builds for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,17 @@ before_install:
     - export PHPCS_BIN=$(if [[ $PHPCS_BRANCH == master ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
     - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
     - $PHPCS_BIN --config-set installed_paths $(pwd)
-    # Download PHPUnit 5.x for builds on PHP 7, nightly and HHVM as
-    # PHPCS test suite is currently not compatible with PHPUnit 6.x.
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.phar; fi
+    # Download PHPUnit 5.x for builds on PHP 7, nightly and HHVM as the PHPCS
+    # test suite is currently not compatible with PHPUnit 6.x.
+    # Fixed at a very specific PHPUnit version which is also compatible with HHVM.
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-5.7.17.phar && chmod +x $PHPUNIT_DIR/phpunit-5.7.17.phar; fi
 
 script:
     # Lint the PHP files against parse errors.
     - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
     # Run the unit tests.
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.phar --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/


### PR DESCRIPTION
The builds against HHVM have been failing for quite a while. This fixes it for now.

Generally speaking there is no official support for PHPUnit on HHVM. Select versions do appear to work, but this is hit & miss.
The version used to fix it now, is based on going back through Travis build logs to find a previous HHVM build which did pass and checking the PHPUnit version used by Travis at the time.