### PR TITLE
Bypass WordPress.Files.FileName sniff when file is from STDIN

### DIFF
--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -128,7 +128,11 @@ class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 	public function process_token( $stackPtr ) {
 
 		// Usage of `strip_quotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
-		$file     = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		if ( 'STDIN' === $file ) {
+			return;
+		}
+
 		$fileName = basename( $file );
 		$expected = strtolower( str_replace( '_', '-', $fileName ) );
 


### PR DESCRIPTION
When doing `echo '<?php $x=1;' | phpcs`, I was getting:

> Filenames should be all lowercase with hyphens as word separators. Expected stdin, but found STDIN. (WordPress.Files.FileName.NotHyphenatedLowercase)

Naturally this is wrong.