### PR TITLE
Fix issue 959: account for more template hierarchy file name exceptions.

### DIFF
--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -39,6 +39,7 @@ class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#embeds
 	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#attachment
 	 * @link https://developer.wordpress.org/themes/template-files-section/partial-and-miscellaneous-template-files/#content-slug-php
+	 * @link https://wphierarchy.com/
 	 * @link https://en.wikipedia.org/wiki/Media_type#Naming
 	 *
 	 * @since 0.11.0
@@ -48,7 +49,8 @@ class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 	const THEME_EXCEPTIONS_REGEX = '`
 		^                    # Anchor to the beginning of the string.
 		(?:
-			(?:archive|content|embed|single|taxonomy) # Template prefixes which can have exceptions
+							 # Template prefixes which can have exceptions.
+			(?:archive|category|content|embed|page|single|tag|taxonomy)
 			-[^\.]+          # These need to be followed by a dash and some chars.
 		|
 			(?:application|audio|example|image|message|model|multipart|text|video) #Top-level mime-types

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-another_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-another_slug.inc
@@ -1,0 +1,3 @@
+@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<?php
+/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-slug.inc
@@ -1,0 +1,3 @@
+@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<?php
+/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/page-slug_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/page-slug_slug.inc
@@ -1,0 +1,3 @@
+@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<?php
+/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-another_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-another_slug.inc
@@ -1,0 +1,3 @@
+@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<?php
+/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-slug.inc
@@ -1,0 +1,3 @@
+@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<?php
+/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */


### PR DESCRIPTION
Based on the https://developer.wordpress.org/files/2014/10/template-hierarchy.png and https://wphierarchy.com/

The original list as taken from issue #470 was incomplete.

This still excludes `author-$nicename` templates as the `nicename` used in those is supposed to be with dashes AFAIK.

Fixes #959