### PR TITLE
FileNameUnitTest: fix false positive unit test.

### DIFF
--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -54,9 +54,7 @@ class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest {
 		'test-sample-phpunit.inc'     => 0,
 		'test-sample-phpunit6.inc'    => 0,
 		'test-sample-wpunit.inc'      => 0,
-		// @todo Fix this! False positive, custom property setting not recognized.
-		// Is issue with unit tests, not with the sniff. If the property is set from the ruleset, it "should" work.
-		'test-sample-custom-unit.inc' => 1,
+		'test-sample-custom-unit.inc' => 0,
 
 		/*
 		 * In /FileNameUnitTests/ThemeExceptions.

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
@@ -1,8 +1,5 @@
-<?php
-// @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist My_TestClass
-?>
-
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist My_TestClass
 <?php
 
 class TestSample extends My_TestClass {}
-// @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */


### PR DESCRIPTION
This was an issue with the PHPCS annotations not being picked up correctly. This should now work as expected.