### PR TITLE
Remove long construct end comments sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -69,16 +69,6 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Covers rule: If you consider a long block unavoidable, please put a short comment at the end ...
-		 - typically this is appropriate for a logic block, longer than about 35 rows. -->
-	<rule ref="Squiz.Commenting.LongConditionClosingComment">
-		<properties>
-			<property name="lineLimit" value="35"/>
-			<property name="commentFormat" value="// End %s()."/>
-		</properties>
-		<exclude name="Squiz.Commenting.LongConditionClosingComment.SpacingBefore"/>
-	</rule>
-
 	<!-- Covers rule: Braces should always be used, even when they are not required. -->
 	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
 

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -184,7 +184,7 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 					);
 				}
 			}
-		} // End foreach().
+		}
 
 	} // End process_token().
 

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -180,7 +180,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 
 			return; // Show one error only.
 
-		} // End foreach().
+		}
 
 	} // End process_token().
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1641,7 +1641,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 
 			$scope_end = $stackPtr;
 
-		} // End if().
+		}
 
 		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
@@ -1988,7 +1988,7 @@ abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
 			// Prepare for the next parameter.
 			$param_start = ( $next_comma + 1 );
 			$cnt++;
-		} // End while().
+		}
 
 		return $parameters;
 	}

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -182,7 +182,7 @@ class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
 
 			$end_of_last_item = ( $item['end'] + 1 );
 
-		} // End foreach().
+		}
 
 	} // End process_token().
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -206,7 +206,7 @@ class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
 					}
 				}
 			}
-		} // End if().
+		}
 
 		// Only run this sniff once per file, no need to run it again.
 		return ( $this->phpcsFile->numTokens + 1 );

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -287,7 +287,7 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 					// Left empty on purpose.
 					break;
 
-			} // End switch().
+			}
 
 			if ( empty( $item_name ) || $this->is_prefixed( $item_name ) === true ) {
 				return;
@@ -302,7 +302,7 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 					$item_name,
 				)
 			);
-		} // End if().
+		}
 
 	} // End process_token().
 
@@ -526,8 +526,8 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 
 				unset( $condition, $has_global, $end_of_statement, $ptr, $imported );
 
-			} // End if().
-		} // End if().
+			}
+		}
 
 		// Still here ? In that case, the variable name should be prefixed.
 		$this->addMessage(
@@ -611,7 +611,7 @@ class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress
 				// Dynamic hook/constant name, throw a warning.
 				$is_error = false;
 			}
-		} // End if().
+		}
 
 		if ( 'define' === $matched_content ) {
 			if ( defined( $raw_content ) ) {

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -137,7 +137,7 @@ class WordPress_Sniffs_NamingConventions_ValidHookNameSniff extends WordPress_Ab
 					$underscores++;
 				}
 			}
-		} // End for().
+		}
 
 		$data = array(
 			implode( '', $expected ),

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -166,9 +166,9 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 						$data  = array( $original_var_name );
 						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
 					}
-				} // End if().
-			} // End if().
-		} // End if().
+				}
+			}
+		}
 
 		$in_class     = false;
 		$obj_operator = $phpcs_file->findPrevious( array( T_WHITESPACE ), ( $stack_ptr - 1 ), null, true );

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -152,7 +152,7 @@ class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
 					}
 				}
 			}
-		} // End if().
+		}
 
 	} // End process_token().
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -253,7 +253,7 @@ class WordPress_Sniffs_WP_CapitalPDangitSniff extends WordPress_Sniff {
 
 				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
 			}
-		} // End if().
+		}
 
 	} // End process_token().
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -203,7 +203,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				}
 				$i = $this_token['parenthesis_closer'];
 			}
-		} // End for().
+		}
 
 		if ( ! empty( $argument_tokens ) ) {
 			$arguments_tokens[] = $argument_tokens;
@@ -295,7 +295,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				'arg_name' => 'domain',
 				'tokens'   => array_shift( $arguments_tokens ),
 			);
-		} // End if().
+		}
 
 		if ( ! empty( $arguments_tokens ) ) {
 			$this->phpcsFile->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $translation_function ) );
@@ -481,7 +481,7 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 				$this->phpcsFile->fixer->replaceToken( $stack_ptr, $fixed_str );
 				$this->phpcsFile->fixer->endChangeset();
 			}
-		} // End if().
+		}
 
 		/*
 		 * NoEmptyStrings.
@@ -580,8 +580,8 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 								return;
 							}
 						}
-					} // End if().
-				} // End if().
+					}
+				}
 
 				// Found placeholders but no translators comment.
 				$this->phpcsFile->addWarning(
@@ -590,8 +590,8 @@ class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
 					'MissingTranslatorsComment'
 				);
 				return;
-			} // End foreach().
-		} // End foreach().
+			}
+		}
 
 	} // End check_for_translator_comment().
 

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -188,7 +188,7 @@ class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
 				'NotPrepared',
 				array( $this->tokens[ $this->i ]['content'] )
 			);
-		} // End for().
+		}
 
 		return $this->end;
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -164,7 +164,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					}
 				}
 			}
-		} // End if().
+		}
 
 		$parenthesisOpener = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
@@ -232,7 +232,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$scopeOpener = $usePtr;
 				}
 			}
-		} // End if().
+		}
 
 		if (
 			T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
@@ -273,7 +273,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
-		} // End if().
+		}
 
 		if (
 			T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
@@ -376,7 +376,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
-			} // End if().
+			}
 
 			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
 				&& ( isset( $scopeOpener )
@@ -416,8 +416,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$this->phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
 					$this->phpcsFile->fixer->endChangeset();
 				}
-			} // End if().
-		} // End if().
+			}
+		}
 
 		if ( false !== $this->blank_line_check && isset( $scopeOpener ) ) {
 			$firstContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
@@ -485,12 +485,12 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 								$this->phpcsFile->fixer->endChangeset();
 							}
 							break;
-						} // End if().
-					} // End for().
-				} // End if().
-			} // End if().
+						}
+					}
+				}
+			}
 			unset( $ignore );
-		} // End if().
+		}
 
 		if ( ! isset( $scopeCloser ) || true !== $this->blank_line_after_check ) {
 			return;
@@ -550,7 +550,7 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
-		} // End if().
+		}
 
 	} // End process_token().
 

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -95,7 +95,7 @@ class WordPress_Sniffs_WhiteSpace_DisallowInlineTabsSniff extends WordPress_Snif
 					$this->phpcsFile->fixer->replaceToken( $i, $newContent );
 				}
 			}
-		} // End for().
+		}
 
 		// Ignore the rest of the file.
 		return ( $this->phpcsFile->numTokens + 1 );

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -139,7 +139,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 						}
 					}
 				}
-			} // End if().
+			}
 
 			$operator = $tokens[ $stackPtr ]['content'];
 
@@ -170,7 +170,7 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 						$phpcsFile->fixer->endChangeset();
 					}
 				}
-			} // End if().
+			}
 
 			if ( '-' !== $operator ) {
 				if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
@@ -197,9 +197,9 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 						$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
 						$phpcsFile->fixer->endChangeset();
 					}
-				} // End if().
-			} // End if().
-		} // End if().
+				}
+			}
+		}
 
 	} // End process().
 

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -384,7 +384,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 			} else {
 				$content = $this->tokens[ $i ]['content'];
 				$ptr     = $i;
-			} // End if().
+			}
 
 			$this->phpcsFile->addError(
 				"Expected next thing to be an escaping function (see Codex for 'Data Validation'), not '%s'",
@@ -392,7 +392,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 				'OutputNotEscaped',
 				$content
 			);
-		} // End for().
+		}
 
 		return $end_of_statement;
 


### PR DESCRIPTION
As per recent change in the PHP coding standards handbook after discussion in https://core.trac.wordpress.org/ticket/41057

Fixes #964

In the second commit, these type of end comments as previously added to the WPCS codebase are removed as well.