### PR TITLE
Updated: Add 'slow query' whitelist flag

### DIFF
--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -42,6 +42,7 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @since 0.10.0
+	 * @since 0.12.0 Introduced new 'slow query' whitelist comment.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
@@ -50,7 +51,12 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
+		if (
+			$this->has_whitelist_comment( 'slow query', $stackPtr )
+			||
+			$this->has_whitelist_comment( 'tax_query', $stackPtr )
+		) {
+
 			return;
 		}
 

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -15,6 +15,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
+ *                 comment, replacing the 'tax_query' whitelist comment which is now
+ *                 deprecated.
  */
 class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
 
@@ -42,7 +45,6 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @since 0.10.0
-	 * @since 0.12.0 Introduced new 'slow query' whitelist comment.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
@@ -51,11 +53,22 @@ class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssig
 	 */
 	public function process_token( $stackPtr ) {
 
-		if (
-			$this->has_whitelist_comment( 'slow query', $stackPtr )
-			||
-			$this->has_whitelist_comment( 'tax_query', $stackPtr )
-		) {
+		if ( $this->has_whitelist_comment( 'slow query', $stackPtr ) ) {
+			return;
+		}
+
+		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
+			/*
+			 * Only throw the warning about a deprecated comment when the sniff would otherwise
+			 * have been triggered on the array key.
+			 */
+			if ( in_array( $this->tokens[ $stackPtr ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				$this->phpcsFile->addWarning(
+					'The "tax_query" whitelist comment is deprecated in favor of the "slow query" whitelist comment.',
+					$stackPtr,
+					'DeprecatedWhitelistFlagFound'
+				);
+			}
 
 			return;
 		}

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
@@ -28,7 +28,7 @@ $test = array(
 
 	// Single-line statements.
 	'tax_query' => array(), // Bad.
-	'tax_query' => array(), // WPCS: tax_query ok.
+	'tax_query' => array(), // WPCS: slow query ok.
 
 	// Multi-line statement.
 	'tax_query' => array( // WPCS: tax_query ok.

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.inc
@@ -29,9 +29,10 @@ $test = array(
 	// Single-line statements.
 	'tax_query' => array(), // Bad.
 	'tax_query' => array(), // WPCS: slow query ok.
+	'tax_query' => array(), // WPCS: tax_query ok.
 
 	// Multi-line statement.
-	'tax_query' => array( // WPCS: tax_query ok.
+	'tax_query' => array( // WPCS: slow query ok.
 		array(
 			'taxonomy' => 'foo',
 		),

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -38,6 +38,7 @@ class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			19 => 2,
 			30 => 1,
+			32 => 1, // Warning about deprecated whitelist comment.
 		);
 
 	}


### PR DESCRIPTION
Continuation of @barryceelen's work in #897 to replace the `tax_query` whitelist flag with a `slow_query` whitelist flag.

Differences with the previous PR:
* Rebased the previous PR & squashed the commits.
* Moved the changelog comment from the function docblock to the class docblock.
* Uses `slow_query` instead of `slow query` (underscore, not space) as the whitelist flag.
* Throws a _"deprecated whitelist comment"_ warning when a `tax_query` whitelist comment is encountered.
* Prevents that message being thrown more than once.

Fixes #894
Fixes #897 (superseded by this PR)

* [ ] Update the whitelist flag documentation once this PR has been merged