### PR TITLE
Leverage the WordPress_Sniff class for (most of) the remaining sniffs

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -15,9 +15,10 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.7.0 This sniff now has the ability to fix a number of the issues it flags.
+ * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  */
-class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -34,52 +35,49 @@ class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff implements PHP_Co
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
+	public function process_token( $stackPtr ) {
 
-		$token = $tokens[ $stackPtr ];
+		$token = $this->tokens[ $stackPtr ];
 		if ( ! isset( $token['bracket_closer'] ) ) {
-			$phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr, 'MissingBracketCloser' );
+			$this->phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr, 'MissingBracketCloser' );
 			return;
 		}
 
-		$need_spaces = $phpcsFile->findNext(
+		$need_spaces = $this->phpcsFile->findNext(
 			array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_WHITESPACE, T_MINUS ),
 			( $stackPtr + 1 ),
 			$token['bracket_closer'],
 			true
 		);
 
-		$spaced1 = ( T_WHITESPACE === $tokens[ ( $stackPtr + 1 ) ]['code'] );
-		$spaced2 = ( T_WHITESPACE === $tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
+		$spaced1 = ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] );
+		$spaced2 = ( T_WHITESPACE === $this->tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
 
-		// It should have spaces only if it only has strings or numbers as the key.
+		// It should have spaces unless if it only has strings or numbers as the key.
 		if ( false !== $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
 			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 			if ( true === $fix ) {
 				if ( ! $spaced1 ) {
-					$phpcsFile->fixer->addContentBefore( ( $stackPtr + 1 ), ' ' );
+					$this->phpcsFile->fixer->addContentBefore( ( $stackPtr + 1 ), ' ' );
 				}
 				if ( ! $spaced2 ) {
-					$phpcsFile->fixer->addContentBefore( $token['bracket_closer'], ' ' );
+					$this->phpcsFile->fixer->addContentBefore( $token['bracket_closer'], ' ' );
 				}
 			}
 		} elseif ( false === $need_spaces && ( $spaced1 || $spaced2 ) ) {
 			$error = 'Array keys must NOT be surrounded by spaces if they only contain a string or an integer.';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
 			if ( true === $fix ) {
 				if ( $spaced1 ) {
-					$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+					$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
 				}
 				if ( $spaced2 ) {
-					$phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
+					$this->phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
 				}
 			}
 		}

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -15,8 +15,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  */
-class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -36,20 +37,17 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
+	public function process_token( $stackPtr ) {
 
 		$beginners   = PHP_CodeSniffer_Tokens::$booleanOperators;
 		$beginners[] = T_IF;
 		$beginners[] = T_ELSEIF;
 
-		$beginning = $phpcsFile->findPrevious( $beginners, $stackPtr, null, false, null, true );
+		$beginning = $this->phpcsFile->findPrevious( $beginners, $stackPtr, null, false, null, true );
 
 		$needs_yoda = false;
 
@@ -57,18 +55,20 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 		for ( $i = $stackPtr; $i > $beginning; $i-- ) {
 
 			// Ignore whitespace.
-			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $tokens[ $i ]['code'] ] ) ) {
+			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
 
 			// If this is a variable or array, we've seen all we need to see.
-			if ( T_VARIABLE === $tokens[ $i ]['code'] || T_CLOSE_SQUARE_BRACKET === $tokens[ $i ]['code'] ) {
+			if ( T_VARIABLE === $this->tokens[ $i ]['code']
+				|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+			) {
 				$needs_yoda = true;
 				break;
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ), true ) ) {
+			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ), true ) ) {
 				return;
 			}
 		}
@@ -78,14 +78,14 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 		}
 
 		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 ).
-		$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-		if ( isset( PHP_CodeSniffer_Tokens::$castTokens[ $tokens[ $next_non_empty ]['code'] ] ) ) {
-			$next_non_empty = $phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
+		if ( isset( PHP_CodeSniffer_Tokens::$castTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+			$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
 		}
 
-		if ( in_array( $tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
-			$next_non_empty = $phpcsFile->findNext(
+		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
+			$next_non_empty = $this->phpcsFile->findNext(
 				array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )
 				, ( $next_non_empty + 1 )
 				, null
@@ -93,11 +93,11 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff implements PHP_CodeSniffer_Sniff 
 			);
 		}
 
-		if ( T_VARIABLE === $tokens[ $next_non_empty ]['code'] ) {
+		if ( T_VARIABLE === $this->tokens[ $next_non_empty ]['code'] ) {
 			return;
 		}
 
-		$phpcsFile->addError( 'Use Yoda Condition checks, you must.', $stackPtr, 'NotYoda' );
+		$this->phpcsFile->addError( 'Use Yoda Condition checks, you must.', $stackPtr, 'NotYoda' );
 
 	} // End process().
 

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -18,8 +18,9 @@
  * @since   0.3.0
  * @since   0.10.0 The sniff no longer needlessly extends the Generic_Sniffs_PHP_ForbiddenFunctionsSniff
  *                 which it didn't use.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  */
-class WordPress_Sniffs_VIP_SessionVariableUsageSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -36,18 +37,18 @@ class WordPress_Sniffs_VIP_SessionVariableUsageSniff implements PHP_CodeSniffer_
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-
-		if ( '$_SESSION' === $tokens[ $stackPtr ]['content'] ) {
-			$phpcsFile->addError( 'Usage of $_SESSION variable is prohibited.', $stackPtr, 'SessionVarsProhibited' );
+	public function process_token( $stackPtr ) {
+		if ( '$_SESSION' === $this->tokens[ $stackPtr ]['content'] ) {
+			$this->phpcsFile->addError(
+				'Usage of $_SESSION variable is prohibited.',
+				$stackPtr,
+				'SessionVarsProhibited'
+			);
 		}
-
 	}
 
 } // End class.

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -15,8 +15,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  */
-class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_WP_EnqueuedResourcesSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -30,22 +31,27 @@ class WordPress_Sniffs_WP_EnqueuedResourcesSniff implements PHP_CodeSniffer_Snif
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-		$token  = $tokens[ $stackPtr ];
+	public function process_token( $stackPtr ) {
+		$token = $this->tokens[ $stackPtr ];
 
 		if ( preg_match( '#rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
-			$phpcsFile->addError( 'Stylesheets must be registered/enqueued via wp_enqueue_style', $stackPtr, 'NonEnqueuedStylesheet' );
+			$this->phpcsFile->addError(
+				'Stylesheets must be registered/enqueued via wp_enqueue_style',
+				$stackPtr,
+				'NonEnqueuedStylesheet'
+			);
 		}
 
 		if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'] ) > 0 ) {
-			$phpcsFile->addError( 'Scripts must be registered/enqueued via wp_enqueue_script', $stackPtr, 'NonEnqueuedScript' );
+			$this->phpcsFile->addError(
+				'Scripts must be registered/enqueued via wp_enqueue_script',
+				$stackPtr,
+				'NonEnqueuedScript'
+			);
 		}
 
 	} // End process().

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -17,8 +17,9 @@
  * @since   0.3.0
  * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
  * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  */
-class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff extends WordPress_Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -32,28 +33,25 @@ class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff implements PHP_CodeS
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
+	public function process_token( $stackPtr ) {
 
-		if ( T_WHITESPACE !== $tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
 			$error = 'No space before opening casting parenthesis is prohibited';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 			if ( true === $fix ) {
-				$phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
+				$this->phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
 			}
 		}
 
-		if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 			$error = 'No space after closing casting parenthesis is prohibited';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
 			if ( true === $fix ) {
-				$phpcsFile->fixer->addContent( $stackPtr, ' ' );
+				$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
 			}
 		}
 	}

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -18,11 +18,12 @@
  *
  * @since   0.1.0
  * @since   0.3.0 This sniff now has the ability to fix the issues it flags.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
  *
  * Last synced with base class December 2008 at commit f01746fd1c89e98174b16c76efd325825eb58bf1.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
-class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sniff {
+class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends WordPress_Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -53,32 +54,31 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 	}
 
 	/**
-	 * Processes this sniff, when one of its tokens is encountered.
+	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
+	public function process_token( $stackPtr ) {
 
-		if ( T_EQUAL === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_EQUAL === $this->tokens[ $stackPtr ]['code'] ) {
 			// Skip for '=&' case.
-			if ( isset( $tokens[ ( $stackPtr + 1 ) ] ) && T_BITWISE_AND === $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+			if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] )
+				&& T_BITWISE_AND === $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			) {
 				return;
 			}
 
 			// Skip default values in function declarations.
 			// Skip declare statements.
-			if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-				$bracket = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
-				if ( isset( $tokens[ $bracket ]['parenthesis_owner'] ) ) {
-					$function = $tokens[ $bracket ]['parenthesis_owner'];
-					if ( T_FUNCTION === $tokens[ $function ]['code']
-						|| T_CLOSURE === $tokens[ $function ]['code']
-						|| T_DECLARE === $tokens[ $function ]['code']
+			if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+				$bracket = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+				if ( isset( $this->tokens[ $bracket ]['parenthesis_owner'] ) ) {
+					$function = $this->tokens[ $bracket ]['parenthesis_owner'];
+					if ( T_FUNCTION === $this->tokens[ $function ]['code']
+						|| T_CLOSURE === $this->tokens[ $function ]['code']
+						|| T_DECLARE === $this->tokens[ $function ]['code']
 					) {
 						return;
 					}
@@ -86,32 +86,32 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 			}
 		}
 
-		if ( T_BITWISE_AND === $tokens[ $stackPtr ]['code'] ) {
+		if ( T_BITWISE_AND === $this->tokens[ $stackPtr ]['code'] ) {
 			/*
 			// If it's not a reference, then we expect one space either side of the
 			// bitwise operator.
-			if ( false === $phpcsFile->isReference( $stackPtr ) ) {
+			if ( false === $this->phpcsFile->isReference( $stackPtr ) ) {
 				// @todo Implement or remove ?
 			}
 			*/
 			return;
 
 		} else {
-			if ( T_MINUS === $tokens[ $stackPtr ]['code'] ) {
+			if ( T_MINUS === $this->tokens[ $stackPtr ]['code'] ) {
 				// Check minus spacing, but make sure we aren't just assigning
 				// a minus value or returning one.
-				$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
-				if ( T_RETURN === $tokens[ $prev ]['code'] ) {
+				$prev = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
+				if ( T_RETURN === $this->tokens[ $prev ]['code'] ) {
 					// Just returning a negative value; eg. return -1.
 					return;
 				}
 
-				if ( isset( PHP_CodeSniffer_Tokens::$operators[ $tokens[ $prev ]['code'] ] ) ) {
+				if ( isset( PHP_CodeSniffer_Tokens::$operators[ $this->tokens[ $prev ]['code'] ] ) ) {
 					// Just trying to operate on a negative value; eg. ($var * -1).
 					return;
 				}
 
-				if ( isset( PHP_CodeSniffer_Tokens::$comparisonTokens[ $tokens[ $prev ]['code'] ] ) ) {
+				if ( isset( PHP_CodeSniffer_Tokens::$comparisonTokens[ $this->tokens[ $prev ]['code'] ] ) ) {
 					// Just trying to compare a negative value; eg. ($var === -1).
 					return;
 				}
@@ -124,16 +124,18 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 					T_OPEN_SQUARE_BRACKET,
 				);
 
-				if ( in_array( $tokens[ $prev ]['code'], $invalidTokens, true ) ) {
+				if ( in_array( $this->tokens[ $prev ]['code'], $invalidTokens, true ) ) {
 					// Just trying to use a negative value; eg. myFunction($var, -2).
 					return;
 				}
 
-				$number = $phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-				if ( T_LNUMBER === $tokens[ $number ]['code'] ) {
-					$semi = $phpcsFile->findNext( T_WHITESPACE, ( $number + 1 ), null, true );
-					if ( T_SEMICOLON === $tokens[ $semi ]['code'] ) {
-						if ( false !== $prev && isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $tokens[ $prev ]['code'] ] ) ) {
+				$number = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+				if ( T_LNUMBER === $this->tokens[ $number ]['code'] ) {
+					$semi = $this->phpcsFile->findNext( T_WHITESPACE, ( $number + 1 ), null, true );
+					if ( T_SEMICOLON === $this->tokens[ $semi ]['code'] ) {
+						if ( false !== $prev &&
+							isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $prev ]['code'] ] )
+						) {
 							// This is a negative assignment.
 							return;
 						}
@@ -141,61 +143,63 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffe
 				}
 			}
 
-			$operator = $tokens[ $stackPtr ]['content'];
+			$operator = $this->tokens[ $stackPtr ]['content'];
 
-			if ( T_WHITESPACE !== $tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+			if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
 				$error = 'Expected 1 space before "%s"; 0 found';
 				$data  = array( $operator );
-				$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBefore', $data );
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBefore', $data );
 				if ( true === $fix ) {
-					$phpcsFile->fixer->beginChangeset();
-					$phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
-					$phpcsFile->fixer->endChangeset();
+					$this->phpcsFile->fixer->beginChangeset();
+					$this->phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
+					$this->phpcsFile->fixer->endChangeset();
 				}
-			} elseif ( 1 !== strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] ) && 1 !== $tokens[ ( $stackPtr - 1 ) ]['column'] ) {
+			} elseif ( 1 !== strlen( $this->tokens[ ( $stackPtr - 1 ) ]['content'] )
+				&& 1 !== $this->tokens[ ( $stackPtr - 1 ) ]['column']
+			) {
 				// Don't throw an error for assignments, because other standards allow
 				// multiple spaces there to align multiple assignments.
-				if ( false === isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $tokens[ $stackPtr ]['code'] ] ) ) {
-					$found = strlen( $tokens[ ( $stackPtr - 1 ) ]['content'] );
+				if ( false === isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+					$found = strlen( $this->tokens[ ( $stackPtr - 1 ) ]['content'] );
 					$error = 'Expected 1 space before "%s"; %s found';
 					$data  = array(
 						$operator,
 						$found,
 					);
 
-					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacingBefore', $data );
+					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacingBefore', $data );
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			}
 
 			if ( '-' !== $operator ) {
-				if ( T_WHITESPACE !== $tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+				if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 					$error = 'Expected 1 space after "%s"; 0 found';
 					$data  = array( $operator );
 
-					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfter', $data );
+					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfter', $data );
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->addContent( $stackPtr, ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
-				} elseif ( 1 !== strlen( $tokens[ ( $stackPtr + 1 ) ]['content'] ) ) {
-					$found = strlen( $tokens[ ( $stackPtr + 1 ) ]['content'] );
+				} elseif ( 1 !== strlen( $this->tokens[ ( $stackPtr + 1 ) ]['content'] ) ) {
+					$found = strlen( $this->tokens[ ( $stackPtr + 1 ) ]['content'] );
 					$error = 'Expected 1 space after "%s"; %s found';
 					$data  = array(
 						$operator,
 						$found,
 					);
 
-					$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'SpacingAfter', $data );
+					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacingAfter', $data );
 					if ( true === $fix ) {
-						$phpcsFile->fixer->beginChangeset();
-						$phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
-						$phpcsFile->fixer->endChangeset();
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
+						$this->phpcsFile->fixer->endChangeset();
 					}
 				}
 			}


### PR DESCRIPTION
Most WPCS sniffs extend the `WordPress_Sniff` class. However there were some which so far didn't.

This PR changes that whenever possible.

The affected sniffs do not necessarily *need* to use the `WordPress_Sniff` class as they don't use any of the utility methods or properties contained therein, however it will make future development slightly more intuitive as (nearly) all sniffs now follow the same pattern, as well as make life easier for the PHPCS 3.x branch which is being developed.

The following exceptions still remain:
* `WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_ArrayDeclarationSniff` - this sniff is a partial copy of the upstream sniff with some commented out code
* `WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends Squiz_Sniffs_Arrays_ArrayDeclarationSniff` - this sniff uses the upstream sniff for the single line/multiline determination. Once the upstream sniff has been refactored into several sniffs, we may be able to decouple them. See upstream issue https://github.com/squizlabs/PHP_CodeSniffer/issues/582
* `WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff` - this sniff uses certain properties from the upstream sniff. We may choose to decouple this at some point by having a local copy of the relevant properties, though the maintenance burden would then also fall within WPCS.
* `WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff` - uses the upstream abstract sniff logic for determination of variable vs property.