### PR TITLE
Stop using wpcom_vip_get_term_by() instead of get_term_by()

### DIFF
--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -58,13 +58,11 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				),
 			),
 
-			'get_term_link' => array(
+			'wpcom_vip_get_term_link' => array(
 				'type'      => 'error',
-				'message'   => '%s() is prohibited, please use wpcom_vip_get_term_link() instead.',
+				'message'   => '%s() is deprecated, please use get_term_link(), get_tag_link(), or get_category_link() instead.',
 				'functions' => array(
-					'get_term_link',
-					'get_tag_link',
-					'get_category_link',
+					'wpcom_vip_get_term_link',
 				),
 			),
 

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -92,11 +92,11 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				),
 			),
 
-			'get_category_by_slug' => array(
+			'wpcom_vip_get_category_by_slug' => array(
 				'type'      => 'error',
-				'message'   => '%s() is prohibited, please use wpcom_vip_get_category_by_slug() instead.',
+				'message'   => '%s() is deprecated, please use get_category_by_slug() instead.',
 				'functions' => array(
-					'get_category_by_slug',
+					'wpcom_vip_get_category_by_slug',
 				),
 			),
 

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -84,12 +84,11 @@ class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFu
 				),
 			),
 
-			'get_term_by' => array(
+			'wpcom_vip_get_term_by' => array(
 				'type'      => 'error',
-				'message'   => '%s() is prohibited, please use wpcom_vip_get_term_by() instead.',
+				'message'   => '%s() is deprecated, please use get_term_by() or get_cat_ID() instead.',
 				'functions' => array(
-					'get_term_by',
-					'get_cat_ID',
+					'wpcom_vip_get_term_by',
 				),
 			),
 

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -46,6 +46,7 @@ class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTe
 			48 => 1,
 			49 => 1,
 			50 => 1,
+			51 => 1,
 
 			54 => 1,
 			55 => 1,

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -38,7 +38,7 @@ class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTe
 			39 => 1,
 			40 => 1,
 			41 => 1,
-			42 => 1,
+			
 			43 => 1,
 			44 => 1,
 
@@ -46,7 +46,6 @@ class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTe
 			48 => 1,
 			49 => 1,
 			50 => 1,
-			51 => 1,
 
 			54 => 1,
 			55 => 1,

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -38,7 +38,7 @@ class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTe
 			39 => 1,
 			40 => 1,
 			41 => 1,
-			
+			42 => 1,
 			43 => 1,
 			44 => 1,
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -39,7 +39,7 @@ get_page_by_title( $page_title ); // Error.
 
 wpcom_vip_get_term_by( $field, $value, $taxonomy ); // Error.
 
-get_category_by_slug( $slug ); // Ok.
+wpcom_vip_get_category_by_slug( $slug ); // Ok.
 
 url_to_postid( $url ); // Error.
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -31,7 +31,7 @@ $y = Bar::add_role(); // Ok.
 
 \add_role(); // Error.
 
-get_term_link( $term ); // Error.
+wpcom_vip_get_term_link( $term ); // Error.
 
 get_page_by_path( $path ); // Error.
 
@@ -46,8 +46,8 @@ url_to_postid( $url ); // Error.
 attachment_url_to_postid( $url ); // Error.
 wpcom_vip_attachment_url_to_postid( $url ); // Ok.
 
-get_tag_link(); // Error.
-get_category_link(); // Error.
+get_tag_link(); // Ok.
+get_category_link(); // Ok.
 get_cat_ID(); // Ok.
 url_to_post_id(); // Error.
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -39,7 +39,7 @@ get_page_by_title( $page_title ); // Error.
 
 wpcom_vip_get_term_by( $field, $value, $taxonomy ); // Error.
 
-wpcom_vip_get_category_by_slug( $slug ); // Ok.
+wpcom_vip_get_category_by_slug( $slug ); // Error.
 
 url_to_postid( $url ); // Error.
 

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -37,9 +37,9 @@ get_page_by_path( $path ); // Error.
 
 get_page_by_title( $page_title ); // Error.
 
-get_term_by( $field, $value, $taxonomy ); // Error.
+wpcom_vip_get_term_by( $field, $value, $taxonomy ); // Error.
 
-get_category_by_slug( $slug ); // Error.
+get_category_by_slug( $slug ); // Ok.
 
 url_to_postid( $url ); // Error.
 
@@ -48,7 +48,7 @@ wpcom_vip_attachment_url_to_postid( $url ); // Ok.
 
 get_tag_link(); // Error.
 get_category_link(); // Error.
-get_cat_ID(); // Error.
+get_cat_ID(); // Ok.
 url_to_post_id(); // Error.
 
 get_posts(); // Warning.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -35,7 +35,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			46 => 1,
 			49 => 1,
 			50 => 1,
-			51 => 1,
 			52 => 1,
 			58 => 1,
 			59 => 1,

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -33,8 +33,6 @@ class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitT
 			42 => 1,
 			44 => 1,
 			46 => 1,
-			49 => 1,
-			50 => 1,
 			52 => 1,
 			58 => 1,
 			59 => 1,


### PR DESCRIPTION
As of WordPress 4.8, the core function `get_term_by()` is cached so we're going to stop recommending the use of `wpcom_vip_get_term_by()` instead. The function `wpcom_vip_get_term_by()`will be deprecated.