### PR TITLE
:sparkles: New sniff: FunctionCallSignatureNoParams

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -171,6 +171,8 @@
 	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
 		<severity>0</severity>
 	</rule>
+	<!-- Related to issue #970 / https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 -->
+	<rule ref="WordPress.Functions.FunctionCallSignatureNoParams"/>
 
 	<!-- Rule: Perform logical comparisons, like so: if ( ! $foo ) { -->
 

--- a/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Enforces no whitespace between the parenthesis of a function call without parameters.
+ *
+ * @link    https://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_Functions_FunctionCallSignatureNoParamsSniff extends WordPress_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return PHP_CodeSniffer_Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+
+		// Find the next non-empty token.
+		$openParenthesis = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openParenthesis ]['code'] ) {
+			// Not a function call.
+			return;
+		}
+
+		if ( ! isset( $this->tokens[ $openParenthesis ]['parenthesis_closer'] ) ) {
+			// Not a function call.
+			return;
+		}
+
+		// Find the previous non-empty token.
+		$search   = PHP_CodeSniffer_Tokens::$emptyTokens;
+		$search[] = T_BITWISE_AND;
+		$previous = $this->phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
+		if ( T_FUNCTION === $this->tokens[ $previous ]['code'] ) {
+			// It's a function definition, not a function call.
+			return;
+		}
+
+		$closer = $this->tokens[ $openParenthesis ]['parenthesis_closer'];
+
+		if ( ( $closer - 1 ) === $openParenthesis ) {
+			return;
+		}
+
+		$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $openParenthesis + 1 ), null, true );
+
+		if ( $nextNonWhitespace !== $closer ) {
+			// Function has params or comment between parenthesis.
+			return;
+		}
+
+		$fix = $this->phpcsFile->addFixableError(
+			'Function calls without parameters should have no spaces between the parenthesis.',
+			( $openParenthesis + 1 ),
+			'WhitespaceFound'
+		);
+		if ( true === $fix ) {
+			// If there is only whitespace between the parenthesis, it will just be the one token.
+			$this->phpcsFile->fixer->replaceToken( ( $openParenthesis + 1 ), '' );
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.inc
+++ b/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+ms_cookie_constants(); // OK.
+ms_cookie_constants(  ); // Bad.
+ms_cookie_constants(      ); // Bad.
+
+// These should be ignored as these are handled by the PEAR.Functions.FunctionCallSignature sniff.
+ms_cookie_constants($something);
+ms_cookie_constants( $something );

--- a/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.inc.fixed
+++ b/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+
+ms_cookie_constants(); // OK.
+ms_cookie_constants(); // Bad.
+ms_cookie_constants(); // Bad.
+
+// These should be ignored as these are handled by the PEAR.Functions.FunctionCallSignature sniff.
+ms_cookie_constants($something);
+ms_cookie_constants( $something );

--- a/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
+++ b/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the FunctionCallSignatureNoParams sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_Functions_FunctionCallSignatureNoParamsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			4 => 1,
+			5 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
Report on and remove whitespace between function call parenthesis when the function call has no parameters.

This sniff *will* result in contradictory messages when run with PHPCS, but that can't really be helped.

```
 5 | ERROR | [x] Expected 1 spaces after opening bracket; 6 found
   |       |     (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 5 | ERROR | [x] Expected 1 spaces before closing bracket; 6 found
   |       |     (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 5 | ERROR | [x] Function calls without parameters should have no spaces
   |       |     between the parenthesis.
   |       |     (WordPress.Functions.FunctionCallSignatureNoParams.WhitespaceFound)
```

I've chosen to put this sniff in the `Functions` category to be consistent with the related sniff in the `PEAR` standard.

Includes an auto-fixer.

This auto-fixer has been tested to not conflict with the `PEAR.Functions.FunctionCallSignature` sniff (at this time).

Fixes #970

N.B.: I've also opened upstream issue https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 about this, but there are two reasons to pull this PR anyway:
1. Chances are that a fix for this won't make it into PHPCS 2.x which is where we currently need it.
2. The inconsistency I reported upstream can be fixed in two different manners. The most _consistent_ way to fix it would be to end up with 1 space between the parenthesis, which is not what we want.

As it is currently unclear how, when and in which branch this will be fixed upstream, pulling this as an interim solution seems appropriate. Depending on if & when this will be addressed upstream and in which branch, this sniff may be removed at a later date or may need adjusting to not conflict with the updated version of the PEAR sniff.
