### PR TITLE
:sparkles: New `CodeAnalysis.EmptyStatement` sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -20,6 +20,7 @@
 			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- More generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->

--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Checks against empty statements.
+ *
+ * - Check against two semi-colons with no executable code in between.
+ * - Check against an empty PHP open - close tag combination.
+ *
+ * {@internal This check should at some point in the future be pulled upstream and probably
+ *            merged into the upstream `Generic.CodeAnalysis.EmptyStatement` sniff.
+ *            This will need to wait until the WPCS minimum requirements have gone up
+ *            beyond PHPCS 3.x though as it is not likely that new features will be accepted
+ *            still for the PHPCS 2.x branch.}}
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_CodeAnalysis_EmptyStatementSniff extends WordPress_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_SEMICOLON,
+			T_CLOSE_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+
+		switch ( $this->tokens[ $stackPtr ]['type'] ) {
+			/*
+			 * Detect `something();;`.
+			 */
+			case 'T_SEMICOLON':
+				$prevNonEmpty = $this->phpcsFile->findPrevious(
+					PHP_CodeSniffer_Tokens::$emptyTokens,
+					( $stackPtr - 1 ),
+					null,
+					true
+				);
+
+				if ( false === $prevNonEmpty
+					|| ( T_SEMICOLON !== $this->tokens[ $prevNonEmpty ]['code']
+						&& T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code'] )
+				) {
+					return;
+				}
+
+				$fix = $this->phpcsFile->addFixableWarning(
+					'Empty PHP statement detected: superfluous semi-colon.',
+					$stackPtr,
+					'SemicolonWithoutCodeDetected'
+				);
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					if ( T_OPEN_TAG === $this->tokens[ $prevNonEmpty ]['code'] ) {
+						/*
+						 * Check for superfluous whitespace after the semi-colon which will be
+						 * removed as the `<?php ` open tag token already contains whitespace,
+						 * either a space or a new line and in case of a new line, the indentation
+						 * should be done via tabs, so spaces can be safely removed.
+						 */
+						if ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+							$replacement = str_replace( ' ', '', $this->tokens[ ( $stackPtr + 1 ) ]['content'] );
+							$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $replacement );
+						}
+					}
+
+					for ( $i = $stackPtr; $i > $prevNonEmpty; $i-- ) {
+						if ( T_SEMICOLON !== $this->tokens[ $i ]['code']
+							&& T_WHITESPACE !== $this->tokens[ $i ]['code']
+						) {
+							break;
+						}
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				break;
+
+			/*
+			 * Detect `<?php ?>`.
+			 */
+			case 'T_CLOSE_TAG':
+				$prevNonEmpty = $this->phpcsFile->findPrevious(
+					T_WHITESPACE,
+					( $stackPtr - 1 ),
+					null,
+					true
+				);
+
+				if ( false === $prevNonEmpty || T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code'] ) {
+					return;
+				}
+
+				$fix = $this->phpcsFile->addFixableWarning(
+					'Empty PHP open/close tag combination detected.',
+					$prevNonEmpty,
+					'EmptyPHPOpenCloseTagsDetected'
+				);
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+					for ( $i = $prevNonEmpty; $i <= $stackPtr; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				break;
+
+			default:
+				/* Deliberately left empty. */
+				break;
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Test empty statement: two consecutive semicolons without executable code between them.
+ */
+function_call(); // OK.
+
+// The below examples are all bad.
+function_call();;
+
+function_call();
+;
+
+function_call();
+/* some comment */;
+
+function_call();
+/* some comment */     ;
+
+?>
+<input name="<?php ; something_else(); ?>" />
+<input name="<?php something_else(); ; ?>" />
+
+/*
+ * Test empty statement: no code between PHP open and close tag.
+ */
+<input name="<?php something_else() ?>" /> <!-- OK. -->
+<input name="<?php something_else(); ?>" /> <!-- OK. -->
+<input name="<?php /* comment */ ?>" /> <!-- OK. -->
+
+<input name="<?php ?>" /> <!-- Bad. -->
+
+<input name="<?php
+
+
+?>" /> <!-- Bad. -->
+
+<!--
+/*
+ * Test detecting & fixing a combination of the two above checks.
+ */
+-->
+<?php ; ?>
+
+<input name="<?php ; ?>" />

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.inc.fixed
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.inc.fixed
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Test empty statement: two consecutive semicolons without executable code between them.
+ */
+function_call(); // OK.
+
+// The below examples are all bad.
+function_call();
+
+function_call();
+
+function_call();
+/* some comment */
+
+function_call();
+/* some comment */
+
+?>
+<input name="<?php something_else(); ?>" />
+<input name="<?php something_else(); ?>" />
+
+/*
+ * Test empty statement: no code between PHP open and close tag.
+ */
+<input name="<?php something_else() ?>" /> <!-- OK. -->
+<input name="<?php something_else(); ?>" /> <!-- OK. -->
+<input name="<?php /* comment */ ?>" /> <!-- OK. -->
+
+<input name="" /> <!-- Bad. -->
+
+<input name="" /> <!-- Bad. -->
+
+<!--
+/*
+ * Test detecting & fixing a combination of the two above checks.
+ */
+-->
+
+<input name="" />

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the EmptyStatement sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_CodeAnalysis_EmptyStatementUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			9  => 1,
+			12 => 1,
+			15 => 1,
+			18 => 1,
+			21 => 1,
+			22 => 1,
+			31 => 1,
+			33 => 1,
+			43 => 1,
+			45 => 1,
+		);
+	}
+
+} // End class.


### PR DESCRIPTION
New sniff to detect superfluous semi-colons and empty PHP open-close tag combinations.

Includes an auto-fixer.

Added into a new `CodeAnalysis` category to be in line with the related upstream sniff.

As these issues are not explicitly mentioned in the WP Core Coding Style Handbook and are more along the lines of best practices, I've added the sniff to the `WordPress-Extra` ruleset.
For that same reason, I've elected to let the sniff throw warnings instead of errors.

For the current WP Core codestyle update, it would, however, be advisable to explicitly enable this sniff from the ruleset as issues which this sniff will fix, *have* already been detected in WP Core during a visual inspection.

Fixes #975

N.B. This sniff should eventually be merged with the upstream `Generic.CodeAnalysis.EmptyStatement` sniff and pulled there. This would fix upstream issue https://github.com/squizlabs/PHP_CodeSniffer/issues/1119.