### PR TITLE
ControlStructureSpacing sniff: fix blank line after control structure / disappearing comment

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -496,7 +496,8 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			return;
 		}
 
-		$trailingContent = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
+		// {@internal This is just for the blank line check. Only whitespace should be considered.}}
+		$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {
 			return;
 		}
@@ -504,6 +505,16 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] && T_IF === $this->tokens[ $stackPtr ]['code'] ) {
 			// IF with ELSE.
 			return;
+		}
+
+		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
+			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
+				if ( '//end' === substr( $this->tokens[ $trailingContent ]['content'], 0, 5 ) ) {
+					// There is an end comment, so we have to get the next piece
+					// of content.
+					$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1), null, true );
+				}
+			}
 		}
 
 		if ( T_BREAK === $this->tokens[ $trailingContent ]['code'] ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -496,10 +496,29 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			return;
 		}
 
-		// {@internal This is just for the blank line check. Only whitespace should be considered.}}
+		// {@internal This is just for the blank line check. Only whitespace should be considered,
+		// not "other" empty tokens.}}
 		$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {
 			return;
+		}
+
+		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
+			// Special exception for code where the comment about
+			// an ELSE or ELSEIF is written between the control structures.
+			$nextCode = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
+
+			if ( T_ELSE === $this->tokens[ $nextCode ]['code'] || T_ELSEIF === $this->tokens[ $nextCode ]['code'] ) {
+				$trailingContent = $nextCode;
+			}
+
+			// Move past end comments.
+			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
+				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'], $matches ) > 0 ) {
+					$scopeCloser     = $trailingContent;
+					$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1 ), null, true );
+				}
+			}
 		}
 
 		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] && T_IF === $this->tokens[ $stackPtr ]['code'] ) {
@@ -507,25 +526,9 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			return;
 		}
 
-		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
-			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
-				if ( '//end' === substr( $this->tokens[ $trailingContent ]['content'], 0, 5 ) ) {
-					// There is an end comment, so we have to get the next piece
-					// of content.
-					$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1), null, true );
-				}
-			}
-		}
-
-		if ( T_BREAK === $this->tokens[ $trailingContent ]['code'] ) {
-			// If this BREAK is closing a CASE, we don't need the
-			// blank line after this control structure.
-			if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] ) ) {
-				$condition = $this->tokens[ $trailingContent ]['scope_condition'];
-				if ( T_CASE === $this->tokens[ $condition ]['code'] || T_DEFAULT === $this->tokens[ $condition ]['code'] ) {
-					return;
-				}
-			}
+		if ( T_WHILE === $this->tokens[ $trailingContent ]['code'] && T_DO === $this->tokens[ $stackPtr ]['code'] ) {
+			// DO with WHILE.
+			return;
 		}
 
 		if ( T_CLOSE_TAG === $this->tokens[ $trailingContent ]['code'] ) {
@@ -533,15 +536,15 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 			return;
 		}
 
-		if ( T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code'] ) {
+		if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] )
+			&& T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code']
+		) {
 			// Another control structure's closing brace.
-			if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] ) ) {
-				$owner = $this->tokens[ $trailingContent ]['scope_condition'];
-				if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
-					// The next content is the closing brace of a function, class, interface or trait
-					// so normal function/class rules apply and we can ignore it.
-					return;
-				}
+			$owner = $this->tokens[ $trailingContent ]['scope_condition'];
+			if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+				// The next content is the closing brace of a function, class, interface or trait
+				// so normal function/class rules apply and we can ignore it.
+				return;
 			}
 
 			if ( ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line'] ) {
@@ -552,12 +555,16 @@ class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress
 				if ( true === $fix ) {
 					$this->phpcsFile->fixer->beginChangeset();
 
-					for ( $i = ( $scopeCloser + 1 ); $i < $trailingContent; $i++ ) {
+					$i = ( $scopeCloser + 1 );
+					while ( $this->tokens[ $i ]['line'] !== $this->tokens[ $trailingContent ]['line'] ) {
 						$this->phpcsFile->fixer->replaceToken( $i, '' );
+						$i++;
 					}
 
 					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
-					$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );
+					if ( T_COMMENT !== $this->tokens[ $scopeCloser ]['code'] ) {
+						$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );
+					}
 					$this->phpcsFile->fixer->endChangeset();
 				}
 			}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -211,3 +211,14 @@ if (
 ) { // Ok.
 	echo 'bye';
 }
+
+// Bug #976 - the case of the disappearing comment.
+if ( isset( $submenu_file ) ) {
+	if ( $submenu_file == $sub_item[2] ) {
+		$class[] = 'current';
+	}
+// If plugin_page is set the parent must either match the current page or not physically exist.
+// This allows plugin pages with the same hook to exist under different parents.
+} else {
+	$class[] = 'current';
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -222,3 +222,49 @@ if ( isset( $submenu_file ) ) {
 } else {
 	$class[] = 'current';
 }
+
+// Test finding & fixing blank line after control structure.
+if ( $one ) {
+}
+elseif ( $two ) {
+}
+// else if something
+else if ( $three ) {
+} // else do something
+else {
+}
+
+do {
+}
+// Comment
+while ( $a === $b );
+
+if ( $foo ) {
+	try {
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	}
+
+
+}
+
+if ( $foo ) {
+	try {
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	}//end try/catch <- Bad: "blank line after".
+
+
+}
+
+if ( $foo ) {
+	try { // Bad.
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	} // End try/catch <- Bad: "blank line after".
+
+
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -206,3 +206,14 @@ if (
 ) { // Ok.
 	echo 'bye';
 }
+
+// Bug #976 - the case of the disappearing comment.
+if ( isset( $submenu_file ) ) {
+	if ( $submenu_file == $sub_item[2] ) {
+		$class[] = 'current';
+	}
+// If plugin_page is set the parent must either match the current page or not physically exist.
+// This allows plugin pages with the same hook to exist under different parents.
+} else {
+	$class[] = 'current';
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -217,3 +217,43 @@ if ( isset( $submenu_file ) ) {
 } else {
 	$class[] = 'current';
 }
+
+// Test finding & fixing blank line after control structure.
+if ( $one ) {
+}
+elseif ( $two ) {
+}
+// else if something
+else if ( $three ) {
+} // else do something
+else {
+}
+
+do {
+}
+// Comment
+while ( $a === $b );
+
+if ( $foo ) {
+	try {
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	}
+}
+
+if ( $foo ) {
+	try {
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	}//end try/catch <- Bad: "blank line after".
+}
+
+if ( $foo ) {
+	try { // Bad.
+		// Something
+	} catch ( Exception $e ) {
+		// Something
+	} // End try/catch <- Bad: "blank line after".
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -67,6 +67,9 @@ class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends Abstrac
 			192 => 1,
 			196 => 2,
 			200 => 2,
+			247 => 1,
+			257 => 1,
+			267 => 1,
 		);
 
 		/*


### PR DESCRIPTION
This bug was introduced in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/789/commits/786c9bb5855b3bdeb6c33852dd92f089b160a5fa but had so far gone unreported. This PR effectively reverts the offending part of that commit.

Fixes #976