### PR TITLE
Minor tweak: use original content for indentation determination

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -164,8 +164,11 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends Squiz_Sniffs_
 			}
 
 			if ( T_WHITESPACE === $tokens[ ( $i + 1 ) ]['code'] ) {
-				// Something weird going on with tabs vs spaces, but this fixes it.
-				$indentation = str_replace( '    ', "\t", $tokens[ ( $i + 1 ) ]['content'] );
+				// If the tokenizer replaced tabs with spaces, use the original content.
+				$indentation = $tokens[ ( $i + 1 ) ]['content'];
+				if ( isset( $tokens[ ( $i + 1 ) ]['orig_content'] ) ) {
+					$indentation = $tokens[ ( $i + 1 ) ]['orig_content'];
+				}
 			}
 			break;
 		}

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -95,9 +95,12 @@ class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
 			}
 
 			if ( T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] ) {
-				// Something weird going on with tabs vs spaces, but this fixes it.
-				$indentation = str_replace( '    ', "\t", $this->tokens[ ( $i + 1 ) ]['content'] );
-				$column      = $this->tokens[ ( $i + 2 ) ]['column'];
+				// If the tokenizer replaced tabs with spaces, use the original content.
+				$indentation = $this->tokens[ ( $i + 1 ) ]['content'];
+				if ( isset( $this->tokens[ ( $i + 1 ) ]['orig_content'] ) ) {
+					$indentation = $this->tokens[ ( $i + 1 ) ]['orig_content'];
+				}
+				$column = $this->tokens[ ( $i + 2 ) ]['column'];
 			}
 			break;
 		}


### PR DESCRIPTION
The tokenizer sometimes replaces tabs with spaces in the token `content`. Instead of undoing this with a `str_replace()`, use the `orig_content` instead for higher accuracy.