### PR TITLE
Core: Enable the `ControlStructures.ControlSignature.NewlineAfterOpenBrace` check

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -65,9 +65,6 @@
 	-->
 	<!-- Covers rule: Braces shall be used for all blocks. -->
 	<rule ref="Squiz.ControlStructures.ControlSignature"/>
-	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
-		<severity>0</severity>
-	</rule>
 
 	<!-- Covers rule: Braces should always be used, even when they are not required. -->
 	<rule ref="Generic.ControlStructures.InlineControlStructure"/>


### PR DESCRIPTION
See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/971#issuecomment-309605603

This was originally disabled in #366 as being too finicky, but fixes issues we are now running into with the WP coding standards update.

Fixes #971
Fixes #974