### PR TITLE
OperatorSpacing sniff: Defer to upstream sniff for improved results.

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -7,8 +7,12 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true ) ) {
+	throw new PHP_CodeSniffer_Exception( 'Class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff not found' );
+}
+
 /**
- * Verify operator spacing, based upon Squiz code.
+ * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the `!` (boolean not) operator.
  *
  * "Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators."
  *
@@ -17,23 +21,27 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.1.0
- * @since   0.3.0 This sniff now has the ability to fix the issues it flags.
- * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.3.0  This sniff now has the ability to fix the issues it flags.
+ * @since   0.12.0 This sniff used to be a copy of a very old and outdated version of the
+ *                 upstream sniff.
+ *                 Now, the sniff defers completely to the upstream sniff, adding just one
+ *                 additional token - T_BOOLEAN_NOT - via the registration method
+ *                 and changing the value of the customizable $ignoreNewlines property.
  *
- * Last synced with base class December 2008 at commit f01746fd1c89e98174b16c76efd325825eb58bf1.
+ * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
-class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends WordPress_Sniff {
+class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff {
 
 	/**
-	 * A list of tokenizers this sniff supports.
+	 * Allow newlines instead of spaces.
 	 *
-	 * @var array
+	 * N.B.: The upstream sniff defaults to `false`.
+	 *
+	 * @var boolean
 	 */
-	public $supportedTokenizers = array(
-		'PHP',
-		'JS',
-	);
+	public $ignoreNewlines = true;
+
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -41,170 +49,11 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends WordPress_Sniff {
 	 * @return array
 	 */
 	public function register() {
-		$comparison = PHP_CodeSniffer_Tokens::$comparisonTokens;
-		$operators  = PHP_CodeSniffer_Tokens::$operators;
-		$assignment = PHP_CodeSniffer_Tokens::$assignmentTokens;
-
-		// Union the arrays - keeps the array keys and - in this case - automatically de-dups.
-		$tokens   = ( $comparison + $operators + $assignment );
+		$tokens   = parent::register();
 		$tokens[] = T_BOOLEAN_NOT;
 
 		return $tokens;
 
 	}
-
-	/**
-	 * Processes this test, when one of its tokens is encountered.
-	 *
-	 * @param int $stackPtr The position of the current token in the stack.
-	 *
-	 * @return void
-	 */
-	public function process_token( $stackPtr ) {
-
-		if ( T_EQUAL === $this->tokens[ $stackPtr ]['code'] ) {
-			// Skip for '=&' case.
-			if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] )
-				&& T_BITWISE_AND === $this->tokens[ ( $stackPtr + 1 ) ]['code']
-			) {
-				return;
-			}
-
-			// Skip default values in function declarations.
-			// Skip declare statements.
-			if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-				$bracket = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-				if ( isset( $this->tokens[ $bracket ]['parenthesis_owner'] ) ) {
-					$function = $this->tokens[ $bracket ]['parenthesis_owner'];
-					if ( T_FUNCTION === $this->tokens[ $function ]['code']
-						|| T_CLOSURE === $this->tokens[ $function ]['code']
-						|| T_DECLARE === $this->tokens[ $function ]['code']
-					) {
-						return;
-					}
-				}
-			}
-		}
-
-		if ( T_BITWISE_AND === $this->tokens[ $stackPtr ]['code'] ) {
-			/*
-			// If it's not a reference, then we expect one space either side of the
-			// bitwise operator.
-			if ( false === $this->phpcsFile->isReference( $stackPtr ) ) {
-				// @todo Implement or remove ?
-			}
-			*/
-			return;
-
-		} else {
-			if ( T_MINUS === $this->tokens[ $stackPtr ]['code'] ) {
-				// Check minus spacing, but make sure we aren't just assigning
-				// a minus value or returning one.
-				$prev = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
-				if ( T_RETURN === $this->tokens[ $prev ]['code'] ) {
-					// Just returning a negative value; eg. return -1.
-					return;
-				}
-
-				if ( isset( PHP_CodeSniffer_Tokens::$operators[ $this->tokens[ $prev ]['code'] ] ) ) {
-					// Just trying to operate on a negative value; eg. ($var * -1).
-					return;
-				}
-
-				if ( isset( PHP_CodeSniffer_Tokens::$comparisonTokens[ $this->tokens[ $prev ]['code'] ] ) ) {
-					// Just trying to compare a negative value; eg. ($var === -1).
-					return;
-				}
-
-				// A list of tokens that indicate that the token is not
-				// part of an arithmetic operation.
-				$invalidTokens = array(
-					T_COMMA,
-					T_OPEN_PARENTHESIS,
-					T_OPEN_SQUARE_BRACKET,
-				);
-
-				if ( in_array( $this->tokens[ $prev ]['code'], $invalidTokens, true ) ) {
-					// Just trying to use a negative value; eg. myFunction($var, -2).
-					return;
-				}
-
-				$number = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-				if ( T_LNUMBER === $this->tokens[ $number ]['code'] ) {
-					$semi = $this->phpcsFile->findNext( T_WHITESPACE, ( $number + 1 ), null, true );
-					if ( T_SEMICOLON === $this->tokens[ $semi ]['code'] ) {
-						if ( false !== $prev &&
-							isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $prev ]['code'] ] )
-						) {
-							// This is a negative assignment.
-							return;
-						}
-					}
-				}
-			}
-
-			$operator = $this->tokens[ $stackPtr ]['content'];
-
-			if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
-				$error = 'Expected 1 space before "%s"; 0 found';
-				$data  = array( $operator );
-				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBefore', $data );
-				if ( true === $fix ) {
-					$this->phpcsFile->fixer->beginChangeset();
-					$this->phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
-					$this->phpcsFile->fixer->endChangeset();
-				}
-			} elseif ( 1 !== strlen( $this->tokens[ ( $stackPtr - 1 ) ]['content'] )
-				&& 1 !== $this->tokens[ ( $stackPtr - 1 ) ]['column']
-			) {
-				// Don't throw an error for assignments, because other standards allow
-				// multiple spaces there to align multiple assignments.
-				if ( false === isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
-					$found = strlen( $this->tokens[ ( $stackPtr - 1 ) ]['content'] );
-					$error = 'Expected 1 space before "%s"; %s found';
-					$data  = array(
-						$operator,
-						$found,
-					);
-
-					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacingBefore', $data );
-					if ( true === $fix ) {
-						$this->phpcsFile->fixer->beginChangeset();
-						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), ' ' );
-						$this->phpcsFile->fixer->endChangeset();
-					}
-				}
-			}
-
-			if ( '-' !== $operator ) {
-				if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
-					$error = 'Expected 1 space after "%s"; 0 found';
-					$data  = array( $operator );
-
-					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfter', $data );
-					if ( true === $fix ) {
-						$this->phpcsFile->fixer->beginChangeset();
-						$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
-						$this->phpcsFile->fixer->endChangeset();
-					}
-				} elseif ( 1 !== strlen( $this->tokens[ ( $stackPtr + 1 ) ]['content'] ) ) {
-					$found = strlen( $this->tokens[ ( $stackPtr + 1 ) ]['content'] );
-					$error = 'Expected 1 space after "%s"; %s found';
-					$data  = array(
-						$operator,
-						$found,
-					);
-
-					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacingAfter', $data );
-					if ( true === $fix ) {
-						$this->phpcsFile->fixer->beginChangeset();
-						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
-						$this->phpcsFile->fixer->endChangeset();
-					}
-				}
-			}
-		}
-
-	} // End process().
 
 } // End class.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -1,63 +1,30 @@
 <?php
 
-$posts = get_posts( 'cat=3' );
-// Bad, no operator spacing.
-for ( $i=0; $i<sizeof( $posts ); $i++ ) {
-	// ...
-}
-
-// Good.
-for ( $i = 0; $i < sizeof( $posts ); $i++ ) {
-	// ...
-}
-// Good.
-if ( ! $var ) {
-	// ...
-}
-// Bad.
-if ( !$var ) {
-	// ...
-}
-
-while ( have_posts() ) {
-	$ok = (
-		! is_author()
-		||
-		is_front_page()
-	);
-}
-
 // All OK.
 if ( 'bb' !== 'bb' ) {
 	if (
-		empty($_GET['refid']) &&
-		empty($_GET['nolinks']) &&
-		! is_page_template('page_strategy-center.php') &&
-		! is_page_template('page_confirmation.php') &&
-		! is_page_template('page_debartolo.php') &&
-		! is_singular('offer')
+		empty( $_GET['refid'] ) &&
+		empty( $_GET['nolinks'] ) &&
+		! is_page_template( 'page_strategy-center.php' ) &&
+		! is_page_template( 'page_confirmation.php' ) &&
+		! is_page_template( 'page_debartolo.php' ) &&
+		! is_singular( 'offer' )
 	) {
 		hello();
 	}
 }
 
-// Bad.
-for ( $i =  0; $i < sizeof( $posts ); $i++ ) {
-	// ...
-}
-// Bad.
-if (  ! $var ) {
+// Good.
+if ( ! $var ) {
 	// ...
 }
 
-// Ok: Test skipping of default values in function declarations.
-function my_test( $a=true, $b = 123, $c=  'string' ) {}
-$a = function ( $a=true, $b = 123, $c=  'string' ) {};
+// Bad.
+if (!$var ) {
+	// ...
+}
 
-// Upstream issue 1163.
-declare(strict_types=1);
-
-$a = $b??$c;
-$a = $b<=>$c;
-
-$a    ??= $b; // Multiple spaces before assignment is OK.
+// Bad.
+if (  !   $var ) {
+	// ...
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -1,63 +1,30 @@
 <?php
 
-$posts = get_posts( 'cat=3' );
-// Bad, no operator spacing.
-for ( $i = 0; $i < sizeof( $posts ); $i++ ) {
-	// ...
-}
-
-// Good.
-for ( $i = 0; $i < sizeof( $posts ); $i++ ) {
-	// ...
-}
-// Good.
-if ( ! $var ) {
-	// ...
-}
-// Bad.
-if ( ! $var ) {
-	// ...
-}
-
-while ( have_posts() ) {
-	$ok = (
-		! is_author()
-		||
-		is_front_page()
-	);
-}
-
 // All OK.
 if ( 'bb' !== 'bb' ) {
 	if (
-		empty($_GET['refid']) &&
-		empty($_GET['nolinks']) &&
-		! is_page_template('page_strategy-center.php') &&
-		! is_page_template('page_confirmation.php') &&
-		! is_page_template('page_debartolo.php') &&
-		! is_singular('offer')
+		empty( $_GET['refid'] ) &&
+		empty( $_GET['nolinks'] ) &&
+		! is_page_template( 'page_strategy-center.php' ) &&
+		! is_page_template( 'page_confirmation.php' ) &&
+		! is_page_template( 'page_debartolo.php' ) &&
+		! is_singular( 'offer' )
 	) {
 		hello();
 	}
 }
 
-// Bad.
-for ( $i = 0; $i < sizeof( $posts ); $i++ ) {
+// Good.
+if ( ! $var ) {
 	// ...
 }
+
 // Bad.
 if ( ! $var ) {
 	// ...
 }
 
-// Ok: Test skipping of default values in function declarations.
-function my_test( $a=true, $b = 123, $c=  'string' ) {}
-$a = function ( $a=true, $b = 123, $c=  'string' ) {};
-
-// Upstream issue 1163.
-declare(strict_types=1);
-
-$a = $b ?? $c;
-$a = $b <=> $c;
-
-$a    ??= $b; // Multiple spaces before assignment is OK.
+// Bad.
+if ( ! $var ) {
+	// ...
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -12,6 +12,8 @@
  *
  * @package WPCS\WordPressCodingStandards
  * @since   2013-06-11
+ * @since   0.12.0     Now only tests the WPCS specific addition of T_BOOLEAN_NOT.
+ *                     The rest of the sniff is unit tested upstream.
  */
 class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 
@@ -22,12 +24,8 @@ class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUn
 	 */
 	public function getErrorList() {
 		return array(
-			5  => 4,
-			18 => 1,
-			45 => 1,
-			49 => 1,
-			60 => 2,
-			61 => 2,
+			23 => 2,
+			28 => 2,
 		);
 
 	}


### PR DESCRIPTION
Up to now, this sniff was based on a copy of a very old and outdated version of the upstream sniff.
The upstream and downstream sniffs had diverged quite widely code-wise, but not intention-wise.

I've run both the `WordPress.WhiteSpace.OperatorSpacing` sniff as well as its upstream version `Squiz.WhiteSpace.OperatorSpacing` over both the WPCS unit tests for this sniff as well as the Squiz unit tests for this sniff.

While there were differences in the results, they were for the better in favour of the upstream version of the sniff.

The unit test file has been adjusted to only test for the WPCS additional token.

Fixes #988

## Summary of the differences:

### 1. "Boolean not" was not handled by the upstream sniff:
This was added to the WPCS version in #67
```php
if (!$var ) {}
```
**Fixed**: by overloading the `register()` method and adding the token to the sniff.

### 2. Operator spacing after `-` (minus) was not verified in the WPCS version
This was [previously disabled](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/d6c64115ec48889176f030b931c92829a8efbf2a) to prevent the sniff from triggering on code like:
```php
$a = -1;
return -1
```
However, as a side effect, this also prevented the sniff from triggering & fixing this:
```php
$result = 1  -        2;
```

The `+` operator can be used in a similar vain, but was unaccounted for in WPCS, so the below code *would* trigger an error with the WPCS version of the sniff:
```php
$a = +1;
```
**Fixed**: the current upstream sniff already accounts for these situations and will not throw errors for it (example 1 and 3), but will correctly throw an error for example 2.

### 3. Checking for spacing around the `&` (bitwise and) was removed from the WPCS version
I suspect this was done to prevent false positives for `&` being used as a reference.
This also meant however that spacing around *real* "bitwise and" was not being checked, so code like this would not trigger any errors nor be fixed:
```php
if ($result&4 && $result  &  4) {}
```
**Fixed**: the upstream sniff correctly accounts for and bow out if `&` is being used as a reference operator, so there should be no problem with that check.

### 4. New lines should always be acceptable instead of a space
Code like the below should not trigger the sniff:
```php
$y = 1
   + 2  
   - 3;
```
**Fixed**: since PHPCS 2.2.0 / early 2015 the upstream sniff has had a `$ignoreNewLines` property which can be set to `true` to handle this. Fixed by setting that property to `true` in our child class.
