### PR TITLE
Add `Squiz.PHP.EmbeddedPhp` sniff to `Extra`

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -33,6 +33,15 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
+	<!-- Another generic PHP best practice sniff - inspect embedded PHP.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/465 -->
+	<rule ref="Squiz.PHP.EmbeddedPhp">
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
+	</rule>
+
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
 	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->


### PR DESCRIPTION
Added to the `Extra` ruleset as the requirement to have a closing semi-colon for embedded PHP is not explicitly mentioned in the WP Core Handbook.
It's also perfectly valid PHP and won't cause parse errors, so more of a best practice than anything else.

Fixes #465