### PR TITLE
:sparkles: New `WP.DeprecatedClasses` sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -72,6 +72,7 @@
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+	<rule ref="WordPress.WP.DeprecatedClasses"/>
 	<rule ref="WordPress.WP.AlternativeFunctions"/>
 	<rule ref="WordPress.WP.DiscouragedFunctions"/>
 

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Restricts the use of deprecated WordPress classes and suggests alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_WP_DeprecatedClassesSniff extends WordPress_AbstractClassRestrictionsSniff {
+
+	/**
+	 * Minimum WordPress version.
+	 *
+	 * This sniff will throw an error when usage of a deprecated class is
+	 * detected if the class was deprecated before the minimum supported
+	 * WP version; a warning otherwise.
+	 * By default, it is set to presume that a project will support the current
+	 * WP version and up to three releases before.
+	 * This variable allows changing the minimum supported WP version used by
+	 * this sniff by setting a property in a custom phpcs.xml ruleset.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.WP.DeprecatedClasses">
+	 *  <properties>
+	 *   <property name="minimum_supported_version" value="4.3"/>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * @var string WordPress versions.
+	 */
+	public $minimum_supported_version = '4.5';
+
+	/**
+	 * List of deprecated classes with alternative when available.
+	 *
+	 * To be updated after every major release.
+	 *
+	 * Version numbers should be fully qualified.
+	 *
+	 * @var array
+	 */
+	private $deprecated_classes = array(
+
+		// WP 3.1.0.
+		'WP_User_Search' => array(
+			'alt'     => 'WP_User_Query',
+			'version' => '3.1.0',
+		),
+	);
+
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		// Make sure all array keys are lowercase.
+		$keys = array_keys( $this->deprecated_classes );
+		$keys = array_map( 'strtolower', $keys );
+		$this->deprecated_classes = array_combine( $keys, $this->deprecated_classes );
+
+		return array(
+			'deprecated_classes' => array(
+				'classes' => $keys,
+			),
+		);
+
+	} // End getGroups().
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched. Will
+	 *                                always be 'deprecated_functions'.
+	 * @param string $matched_content The token content (class name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+		$class_name = ltrim( strtolower( $matched_content ), '\\' );
+
+		$message = 'The %s class has been deprecated since WordPress version %s.';
+		$data    = array(
+			ltrim( $matched_content, '\\' ),
+			$this->deprecated_classes[ $class_name ]['version'],
+		);
+
+		if ( ! empty( $this->deprecated_classes[ $class_name ]['alt'] ) ) {
+			$message .= ' Use %s instead.';
+			$data[]   = $this->deprecated_classes[ $class_name ]['alt'];
+		}
+
+		$this->addMessage(
+			$message,
+			$stackPtr,
+			( version_compare( $this->deprecated_classes[ $class_name ]['version'], $this->minimum_supported_version, '<' ) ),
+			$this->string_to_errorcode( $matched_content . 'Found' ),
+			$data
+		);
+
+	} // End process_matched_token().
+
+} // End class.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -570,10 +570,6 @@ class WordPress_Sniffs_WP_DeprecatedFunctionsSniff extends WordPress_AbstractFun
 			'alt'     => '',
 			'version' => '3.1',
 		),
-		'WP_User_Search' => array(
-			'alt'     => 'WP_User_Query',
-			'version' => '3.1',
-		),
 		'get_others_unpublished_posts' => array(
 			'alt'     => '',
 			'version' => '3.1',

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+// DEPRECATED WORDPRESS CLASSES.
+
+/*
+ * Error.
+ */
+/* ============ WP 3.1 ============ */
+$a = new WP_User_Search;
+$a = new \WP_User_Search();
+echo WP_User_Search::$users_per_page;
+echo \WP_User_Search::prepare_query();
+class My_User_Search extends WP_User_Search {}
+class Our_User_Search implements WP_User_Search {}
+$a = new WP_User_Search->query();
+
+/*
+ * Warning.
+ */

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -8,13 +8,12 @@
  */
 
 /**
- * Unit test class for the WP_DeprecatedFunctions sniff.
+ * Unit test class for the WP_DeprecatedClasses sniff.
  *
  * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
+ * @since   0.12.0
  */
-class WordPress_Tests_WP_DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
+class WordPress_Tests_WP_DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -22,9 +21,9 @@ class WordPress_Tests_WP_DeprecatedFunctionsUnitTest extends AbstractSniffUnitTe
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array_fill( 8, 235, 1 );
+		return array_fill( 9, 7, 1 );
 
-	}
+	} // End getErrorList().
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -32,7 +31,7 @@ class WordPress_Tests_WP_DeprecatedFunctionsUnitTest extends AbstractSniffUnitTe
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array_fill( 245, 15, 1 );
+		return array();
 
 	}
 

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -132,7 +132,6 @@ get_author_user_ids();
 get_editable_authors();
 get_editable_user_ids();
 get_nonauthor_user_ids();
-WP_User_Search();
 get_others_unpublished_posts();
 get_others_drafts();
 get_others_pending();


### PR DESCRIPTION
New sniff to detect & notify about usage of deprecated WP classes.

Moves one deprecated class which was listed in the `DeprecatedFunctions` to this new class.

Added the new sniff to the `Extra` ruleset in line with the `DeprecatedFunctions` sniff also being there.

Related to #576 and https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/979#issuecomment-310235086

To do once the sniff is merged:
- [ ] Update the customizable properties wiki page for the `$minimum_supported_version`