### PR TITLE
DisallowInlineTabs sniff: make error text clearer

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -79,7 +79,7 @@ class WordPress_Sniffs_WhiteSpace_DisallowInlineTabsSniff extends WordPress_Snif
 			}
 
 			$fix = $this->phpcsFile->addFixableError(
-				'Spaces must be used for alignment; tabs are not allowed',
+				'Spaces must be used for mid-line alignment; tabs are not allowed',
 				$i,
 				'NonIndentTabsUsed'
 			);


### PR DESCRIPTION
Came across this error message in one of my own projects and realized that - unless you run PHPCS with the error codes showing -, the error message was not clear enough and could cause confusion about alignment (spaces) versus indentation (tabs).