### PR TITLE
ArrayIndentation sniff: Fix disappearing close brace when close brace not on its own line

### DIFF
--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc
@@ -79,3 +79,10 @@ $mixed_2 = array(
 		),
 		'something', 'else',
 );
+
+// Issue 998: don't fix the indentation for the closer if it's not on its own line.
+$a = array(
+	'foo' => bar(1, 29));
+
+$a = array(
+	'foo' => bar(1, 29) );

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.inc.fixed
@@ -79,3 +79,10 @@ $mixed_2 = array(
 		),
 	'something', 'else',
 );
+
+// Issue 998: don't fix the indentation for the closer if it's not on its own line.
+$a = array(
+	'foo' => bar(1, 29));
+
+$a = array(
+	'foo' => bar(1, 29) );

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -47,6 +47,8 @@ class WordPress_Tests_Arrays_ArrayIndentationUnitTest extends AbstractSniffUnitT
 			61 => 1,
 			66 => 1,
 			80 => 1,
+			85 => 1,
+			88 => 1,
 		);
 	}
 


### PR DESCRIPTION
For multi-line array declarations, the close brace of the array is supposed to be on its own line + aligned with the line containing the array keyword.

The `ArrayDeclaration` sniff will move the close brace to its own line.
The `ArrayIndentation` sniff is only intended to fix the close brace indentation.

The `ArrayIndentation` sniff was until now - incorrectly - presuming the close brace would already be on its own line with only whitespace before it.

While the array *item* indentation part of the sniff did not suffer from this issue, I've build in a little extra check in that part just to make sure.

Fixes the "case of the disappearing array close brace" as identified in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/998#issuecomment-310837386