### PR TITLE
OperatorSpacing sniff: check whitespace around logical operators

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -24,9 +24,10 @@ if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true ) ) {
  * @since   0.3.0  This sniff now has the ability to fix the issues it flags.
  * @since   0.12.0 This sniff used to be a copy of a very old and outdated version of the
  *                 upstream sniff.
- *                 Now, the sniff defers completely to the upstream sniff, adding just one
- *                 additional token - T_BOOLEAN_NOT - via the registration method
- *                 and changing the value of the customizable $ignoreNewlines property.
+ *                 Now, the sniff defers completely to the upstream sniff, adding just the
+ *                 T_BOOLEAN_NOT and the logical operators (`&&` and the like) - via the
+ *                 registration method and changing the value of the customizable
+ *                 $ignoreNewlines property.
  *
  * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -49,11 +50,12 @@ class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_Whit
 	 * @return array
 	 */
 	public function register() {
-		$tokens   = parent::register();
-		$tokens[] = T_BOOLEAN_NOT;
+		$tokens                  = parent::register();
+		$tokens[ T_BOOLEAN_NOT ] = T_BOOLEAN_NOT;
+		$logical_operators       = PHP_CodeSniffer_Tokens::$booleanOperators;
 
-		return $tokens;
-
+		// Using array union to auto-dedup.
+		return $tokens + $logical_operators;
 	}
 
 } // End class.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-// All OK.
+// Boolean not operator: All OK.
 if ( 'bb' !== 'bb' ) {
 	if (
 		empty( $_GET['refid'] ) &&
@@ -28,3 +28,39 @@ if (!$var ) {
 if (  !   $var ) {
 	// ...
 }
+
+// Logical operators: Ok.
+if ( $a === $b && $b === $c ) {}
+if ( $a === $b || $b === $c ) {}
+if ( $a === $b and $b === $c ) {}
+if ( $a === $b or $b === $c ) {}
+if ( $a === $b xor $b === $c ) {}
+
+// Logical operators: Too little space.
+if ( $a === $b&&$b === $c ) {}
+if ( $a === $b||$b === $c ) {}
+if ( $a === {$b}and$b === $c ) {}
+if ( $a === {$b}or$b === $c ) {}
+if ( $a === {$b}xor$b === $c ) {}
+
+// Logical operators: Too much space.
+if ( $a === $b     &&     $b === $c ) {}
+if ( $a === $b     ||     $b === $c ) {}
+if ( $a === $b     and     $b === $c ) {}
+if ( $a === $b     or     $b === $c ) {}
+if ( $a === $b     xor     $b === $c ) {}
+
+// Logical operators: Multi-line, OK.
+if ( $a === $b
+	&& $b === $c
+) {}
+if (
+	$a === $b
+	||
+	$b === $c
+) {}
+if ( $a === $b
+	and $b === $c ) {}
+
+if ( $a === $b or
+	$b === $c ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 
-// All OK.
+// Boolean not operator: All OK.
 if ( 'bb' !== 'bb' ) {
 	if (
 		empty( $_GET['refid'] ) &&
@@ -28,3 +28,39 @@ if ( ! $var ) {
 if ( ! $var ) {
 	// ...
 }
+
+// Logical operators: Ok.
+if ( $a === $b && $b === $c ) {}
+if ( $a === $b || $b === $c ) {}
+if ( $a === $b and $b === $c ) {}
+if ( $a === $b or $b === $c ) {}
+if ( $a === $b xor $b === $c ) {}
+
+// Logical operators: Too little space.
+if ( $a === $b && $b === $c ) {}
+if ( $a === $b || $b === $c ) {}
+if ( $a === {$b} and $b === $c ) {}
+if ( $a === {$b} or $b === $c ) {}
+if ( $a === {$b} xor $b === $c ) {}
+
+// Logical operators: Too much space.
+if ( $a === $b && $b === $c ) {}
+if ( $a === $b || $b === $c ) {}
+if ( $a === $b and $b === $c ) {}
+if ( $a === $b or $b === $c ) {}
+if ( $a === $b xor $b === $c ) {}
+
+// Logical operators: Multi-line, OK.
+if ( $a === $b
+	&& $b === $c
+) {}
+if (
+	$a === $b
+	||
+	$b === $c
+) {}
+if ( $a === $b
+	and $b === $c ) {}
+
+if ( $a === $b or
+	$b === $c ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -26,6 +26,16 @@ class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUn
 		return array(
 			23 => 2,
 			28 => 2,
+			40 => 2,
+			41 => 2,
+			42 => 2,
+			43 => 2,
+			44 => 2,
+			47 => 2,
+			48 => 2,
+			49 => 2,
+			50 => 2,
+			51 => 2,
 		);
 
 	}


### PR DESCRIPTION
While working on something else, I realized that the spacing around logical operators - `&&`, `||`, `and`, `or` and `xor` - was not checked at all by the WordPress coding standards so far.

This PR fixes that. Includes unit tests for the WPCS customizations.