### PR TITLE
:sparkles: New `CommaAfterArrayItem` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -45,10 +45,18 @@
 	<!-- Covers rule: Use real tabs and not spaces. -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 
-	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
+	<!-- Generic array layout check. -->
 	<rule ref="WordPress.Arrays.ArrayDeclaration">
 		<exclude name="WordPress.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+		<exclude name="WordPress.Arrays.ArrayDeclaration.CommaAfterLast"/>
+		<exclude name="WordPress.Arrays.ArrayDeclaration.NoSpaceAfterComma"/>
+		<exclude name="WordPress.Arrays.ArrayDeclaration.SpaceAfterComma"/>
+		<exclude name="WordPress.Arrays.ArrayDeclaration.SpaceBeforeComma"/>
 	</rule>
+
+	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
+	<rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
+
 	<!-- Covers rule: For associative arrays, values should start on a new line.
 		 Also covers various single-line array whitespace issues. -->
 	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -142,6 +142,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			$currentEntry = array();
 
 			if ($tokens[$nextToken]['code'] === T_COMMA) {
+				/*
 				$stackPtrCount = 0;
 				if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
 					$stackPtrCount = count( $tokens[ $stackPtr ]['nested_parenthesis'] );
@@ -163,7 +164,6 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					continue;
 				}
 
-				/*
 				if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
 					$error = 'No key specified for array entry; first entry specifies key';
 					$phpcsFile->addError( $error, $nextToken, 'NoKeySpecified' );
@@ -172,6 +172,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				*/
 
 				if ($keyUsed === false) {
+					/*
 					if ($tokens[($nextToken - 1)]['code'] === T_WHITESPACE) {
 						$content = $tokens[ ( $nextToken - 2 ) ]['content'];
 						if ( $tokens[ ( $nextToken - 1 ) ]['content'] === $phpcsFile->eolChar ) {
@@ -191,6 +192,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 							$phpcsFile->fixer->replaceToken( ( $nextToken - 1 ), '' );
 						}
 					}
+					*/
 
 					$valueContent = $phpcsFile->findNext(
 						PHP_CodeSniffer_Tokens::$emptyTokens,
@@ -200,7 +202,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					);
 
 					$indices[]  = array( 'value' => $valueContent );
-					$singleUsed = true;
+					// $singleUsed = true;
 				}//end if
 
 				$lastToken = $nextToken;
@@ -320,6 +322,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 				true
 			);
 
+			/*
 			if ($tokens[$trailingContent]['code'] !== T_COMMA) {
 				$phpcsFile->recordMetric( $stackPtr, 'Array end comma', 'no' );
 				$error = 'Comma required after last value in array declaration';
@@ -330,6 +333,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			} else {
 				$phpcsFile->recordMetric( $stackPtr, 'Array end comma', 'yes' );
 			}
+			*/
 
 			$lastValueLine = false;
 			foreach ( $indices as $value ) {
@@ -531,6 +535,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 			*/
 
 			// Check each line ends in a comma.
+			/*
 			$valueLine = $tokens[ $index['value'] ]['line'];
 			$nextComma = false;
 			for ( $i = $index['value']; $i < $arrayEnd; $i++ ) {
@@ -604,6 +609,7 @@ class WordPress_Sniffs_Arrays_ArrayDeclarationSniff extends Squiz_Sniffs_Arrays_
 					$phpcsFile->fixer->replaceToken( ( $nextComma - 1 ), '' );
 				}
 			}
+			*/
 		}//end foreach
 
 	}//end processMultiLineArray()

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Enforces a comma after each array item and the spacing around it.
+ *
+ * Rules:
+ * - For multi-line arrays, a comma is needed after each array item.
+ * - Same for single-line arrays, but no comma is allowed after the last array item.
+ * - There should be no space between the comma and the end of the array item.
+ * - There should be exactly one space between the comma and the start of the
+ *   next array item for single-line items.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_Arrays_CommaAfterArrayItemSniff extends WordPress_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_ARRAY,
+			T_OPEN_SHORT_ARRAY,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		/*
+		 * Determine the array opener & closer.
+		 */
+		$array_open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $array_open_close ) {
+			// Array open/close could not be determined.
+			return;
+		}
+
+		$opener = $array_open_close['opener'];
+		$closer = $array_open_close['closer'];
+		unset( $array_open_close );
+
+		// This array is empty, so the below checks aren't necessary.
+		if ( ( $opener + 1 ) === $closer ) {
+			return;
+		}
+
+		$single_line = true;
+		if ( $this->tokens[ $opener ]['line'] !== $this->tokens[ $closer ]['line'] ) {
+			$single_line = false;
+		}
+
+		$array_items = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $array_items ) ) {
+			// Strange, no array items found.
+			return;
+		}
+
+		$array_item_count = count( $array_items );
+
+		// Note: $item_index is 1-based and the array items are split on the commas!
+		foreach ( $array_items as $item_index => $item ) {
+			$maybe_comma = ( $item['end'] + 1 );
+			$is_comma    = false;
+			if ( isset( $this->tokens[ $maybe_comma ] ) && T_COMMA === $this->tokens[ $maybe_comma ]['code'] ) {
+				$is_comma = true;
+			}
+
+			/*
+			 * Check if this is a comma at the end of the last item in a single line array.
+			 */
+			if ( true === $single_line && $item_index === $array_item_count ) {
+
+				if ( true === $is_comma ) {
+					$fix = $this->phpcsFile->addFixableError(
+						'Comma not allowed after last value in single-line array declaration',
+						$maybe_comma,
+						'CommaAfterLast'
+					);
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( $maybe_comma, '' );
+					}
+				}
+
+				/*
+				 * No need to do the spacing checks for the last item in a single line array.
+				 * This is handled by another sniff checking the spacing before the array closer.
+				 */
+				continue;
+			}
+
+			$last_content = $this->phpcsFile->findPrevious(
+				PHP_CodeSniffer_Tokens::$emptyTokens,
+				$item['end'],
+				$item['start'],
+				true
+			);
+
+			if ( false === $last_content ) {
+				// Shouldn't be able to happen, but just in case, ignore this array item.
+				continue;
+			}
+
+			/**
+			 * Make sure every item in a multi-line array has a comma at the end.
+			 *
+			 * Should in reality only be triggered by the last item in a multi-line array
+			 * as otherwise we'd have a parse error already.
+			 */
+			if ( false === $is_comma && false === $single_line ) {
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Each array item in a multi-line array declaration must end in a comma',
+					$last_content,
+					'NoComma'
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $last_content, ',' );
+				}
+			}
+
+			if ( false === $is_comma ) {
+				// Can't check spacing around the comma if there is no comma.
+				continue;
+			}
+
+			/*
+			 * Check for whitespace at the end of the array item.
+			 */
+			if ( $last_content !== $item['end']
+				// Ignore whitespace at the end of a multi-line item if it is the end of a heredoc/nowdoc.
+				&& ( true === $single_line
+					|| ! isset( PHP_CodeSniffer_Tokens::$heredocTokens[ $this->tokens[ $last_content ]['code'] ] ) )
+			) {
+				$newlines = 0;
+				$spaces   = 0;
+				for ( $i = $item['end']; $i > $last_content; $i-- ) {
+
+					if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+
+						if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
+							$newlines++;
+						} else {
+							$spaces += $this->tokens[ $i ]['length'];
+						}
+					} elseif ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+						break;
+					}
+				}
+
+				$space_phrases = array();
+				if ( $spaces > 0 ) {
+					$space_phrases[] = $spaces . ' spaces';
+				}
+				if ( $newlines > 0 ) {
+					$space_phrases[] = $newlines . ' newlines';
+				}
+				unset( $newlines, $spaces );
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 0 spaces between "%s" and comma; %s found',
+					$maybe_comma,
+					'SpaceBeforeComma',
+					array(
+						$this->tokens[ $last_content ]['content'],
+						implode( ' and ', $space_phrases ),
+					)
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+					for ( $i = $item['end']; $i > $last_content; $i-- ) {
+
+						if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+
+						} elseif ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+							// We need to move the comma to before the comment.
+							$this->phpcsFile->fixer->addContent( $last_content, ',' );
+							$this->phpcsFile->fixer->replaceToken( $maybe_comma, '' );
+
+							/*
+							 * No need to worry about removing too much whitespace in
+							 * combination with a `//` comment as in that case, the newline
+							 * is part of the comment, so we're good.
+							 */
+
+							break;
+						}
+					}
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			if ( ! isset( $this->tokens[ ( $maybe_comma + 1 ) ] ) ) {
+				// Shouldn't be able to happen, but just in case.
+				continue;
+			}
+
+			/*
+			 * Check whitespace after the comma.
+			 */
+			$next_token = $this->tokens[ ( $maybe_comma + 1 ) ];
+
+			if ( T_WHITESPACE === $next_token['code'] ) {
+
+				if ( false === $single_line && $this->phpcsFile->eolChar === $next_token['content'] ) {
+					continue;
+				}
+
+				$next_non_whitespace = $this->phpcsFile->findNext(
+					T_WHITESPACE,
+					($maybe_comma + 1 ),
+					$closer,
+					true
+				);
+
+				if ( false === $next_non_whitespace
+					|| ( false === $single_line
+						&& $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $maybe_comma ]['line']
+						&& T_COMMENT === $this->tokens[ $next_non_whitespace ]['code'] )
+				) {
+					continue;
+				}
+
+				$space_length = $next_token['length'];
+				if ( 1 === $space_length ) {
+					continue;
+				}
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 1 space between comma and "%s"; %s found',
+					$maybe_comma,
+					'SpaceAfterComma',
+					array(
+						$this->tokens[ $next_non_whitespace ]['content'],
+						$space_length,
+					)
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->replaceToken( ( $maybe_comma + 1 ), ' ' );
+				}
+			} else {
+				// This is either a comment or a mixed single/multi-line array.
+				// Just add a space and let other sniffs sort out the array layout.
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 1 space between comma and "%s"; 0 found',
+					$maybe_comma,
+					'NoSpaceAfterComma',
+					array( $next_token['content'] )
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $maybe_comma, ' ' );
+				}
+			}
+		}
+	}
+
+} // End class.

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Good.
+ */
+$good = array();
+
+$good = array( 1, 2, 3 );
+$good = [ 'a', 'b', 'c' ];
+
+$good = array(
+	1,
+	2,
+	3,
+);
+$good = [
+	'a',
+	'b',
+	'c',
+];
+
+$good = array(
+	1 => 'value',
+	2 => array( 1 ),
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$good = [
+	'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 ),
+	'c' => apply_filters( 'filter', $input, $var ),
+];
+
+// OK: that this should be a multi-line array is not the concern of this sniff.
+$good = array( 1 => 'a', 2 => 'b', 3 => 'c' );
+$good = [ 'a' => 1, 'b' => 2, 'c' => 3 ];
+
+$good = array( 1, 2, // OK: that each item should be on its own line or single line array is not the concern of this sniff.
+	3, ); // OK: that the brace should be on another line is not the concern of this sniff.
+
+/*
+ * Bad.
+ */
+// Spacing before comma.
+$bad = array( 1 , 2         , 3 ); // Bad x2.
+$bad = [ 'a' , 'b'    , 'c' ]; // Bad x2.
+
+// Spacing after comma.
+$bad = array( 1,2,    3 ); // Bad x2.
+$bad = [ 'a','b',    'c' ]; // Bad x2.
+
+// Comma after last.
+$bad = array( 1, 2, 3, );
+$bad = [ 'a', 'b', 'c', ];
+
+// Spacing before comma.
+$bad = array(
+	1 => 'value'  ,
+	2 => array( 1 ) ,
+	3 => apply_filters( 'filter', $input, $var )       , /* Comment. */
+);
+$bad = [
+	'a' => 'value'  ,          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 )
+
+
+	 ,
+	'c' => apply_filters( 'filter', $input, $var )     ,
+];
+
+// NO spacing after comma.
+$bad = array(
+	3 => apply_filters( 'filter', $input, $var ),/* Comment. */
+);
+$bad = [
+	'a' => 'value',// Comment.
+];
+
+// NO comma after last.
+$bad = array(
+	1 => 'value',
+	2 => array( 1 ),
+	3 => apply_filters( 'filter', $input, $var )/* Comment. */
+);
+$bad = [
+	'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 ),
+	'c' => apply_filters( 'filter', $input, $var )
+];
+
+$bad = array( 1 => 'a' ,    2 => 'b',3 => 'c', );
+$bad = [ 'a' => 1   ,   'b' => 2,'c' => 3, ];
+
+$bad = array( 1  ,    2,
+	3 );
+
+// Combining a lot of errors in a nested array.
+$bad = array(
+	1 => 'value' ,
+	2 => [
+		'a' => 'value'     ,// Comment - the extra spacing is fine, might be for alignment with other comments.
+		'b' => array(
+			1
+		),
+		'c' => apply_filters( 'filter', $input, $var )
+	],
+	3 => apply_filters( 'filter', $input, $var )/* Comment. */
+);
+
+// Alternative array style.
+$bad = array(
+          1 => 'value'
+        , 2 => array( 1 )
+        , 3 => apply_filters( 'filter', $input, $var )/* Comment. */
+);
+$bad = [
+	  'a' => 'value'          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	, 'b' => array( 1 )
+	, 'c' => apply_filters( 'filter', $input, $var )
+];
+$bad = [
+	 'a' => 'value'          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	,'b' => array( 1 )
+	,'c' => apply_filters( 'filter', $input, $var ),
+];
+
+$bad = array(
+         'first',
+         'second'
+         //'third',
+        );
+
+$bad = array(
+ 'key3' => function($bar) {
+    return $bar;
+ }
+);
+
+// Issue #998.
+$a = array(
+	'foo' => bar( 1, 29 ));
+
+// Issue #986.
+get_current_screen()->add_help_tab( array(
+		'id'		=> <<<EOD
+Here comes some text.
+EOD
+,
+) );
+
+get_current_screen()->add_help_tab( array(
+'id'		=> <<<EOD
+Here comes some text.
+EOD
+. '</hr>',
+) );

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc.fixed
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * Good.
+ */
+$good = array();
+
+$good = array( 1, 2, 3 );
+$good = [ 'a', 'b', 'c' ];
+
+$good = array(
+	1,
+	2,
+	3,
+);
+$good = [
+	'a',
+	'b',
+	'c',
+];
+
+$good = array(
+	1 => 'value',
+	2 => array( 1 ),
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$good = [
+	'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 ),
+	'c' => apply_filters( 'filter', $input, $var ),
+];
+
+// OK: that this should be a multi-line array is not the concern of this sniff.
+$good = array( 1 => 'a', 2 => 'b', 3 => 'c' );
+$good = [ 'a' => 1, 'b' => 2, 'c' => 3 ];
+
+$good = array( 1, 2, // OK: that each item should be on its own line or single line array is not the concern of this sniff.
+	3, ); // OK: that the brace should be on another line is not the concern of this sniff.
+
+/*
+ * Bad.
+ */
+// Spacing before comma.
+$bad = array( 1, 2, 3 ); // Bad x2.
+$bad = [ 'a', 'b', 'c' ]; // Bad x2.
+
+// Spacing after comma.
+$bad = array( 1, 2, 3 ); // Bad x2.
+$bad = [ 'a', 'b', 'c' ]; // Bad x2.
+
+// Comma after last.
+$bad = array( 1, 2, 3 );
+$bad = [ 'a', 'b', 'c' ];
+
+// Spacing before comma.
+$bad = array(
+	1 => 'value',
+	2 => array( 1 ),
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$bad = [
+	'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 ),
+	'c' => apply_filters( 'filter', $input, $var ),
+];
+
+// NO spacing after comma.
+$bad = array(
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$bad = [
+	'a' => 'value', // Comment.
+];
+
+// NO comma after last.
+$bad = array(
+	1 => 'value',
+	2 => array( 1 ),
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$bad = [
+	'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+	'b' => array( 1 ),
+	'c' => apply_filters( 'filter', $input, $var ),
+];
+
+$bad = array( 1 => 'a', 2 => 'b', 3 => 'c' );
+$bad = [ 'a' => 1, 'b' => 2, 'c' => 3 ];
+
+$bad = array( 1, 2,
+	3, );
+
+// Combining a lot of errors in a nested array.
+$bad = array(
+	1 => 'value',
+	2 => [
+		'a' => 'value', // Comment - the extra spacing is fine, might be for alignment with other comments.
+		'b' => array(
+			1,
+		),
+		'c' => apply_filters( 'filter', $input, $var ),
+	],
+	3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+
+// Alternative array style.
+$bad = array(
+          1 => 'value', 2 => array( 1 ), 3 => apply_filters( 'filter', $input, $var ), /* Comment. */
+);
+$bad = [
+	  'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+ 'b' => array( 1 ), 'c' => apply_filters( 'filter', $input, $var ),
+];
+$bad = [
+	 'a' => 'value',          // Comment - the extra spacing is fine, might be for alignment with other comments.
+'b' => array( 1 ), 'c' => apply_filters( 'filter', $input, $var ),
+];
+
+$bad = array(
+         'first',
+         'second',
+         //'third',
+        );
+
+$bad = array(
+ 'key3' => function($bar) {
+    return $bar;
+ },
+);
+
+// Issue #998.
+$a = array(
+	'foo' => bar( 1, 29 ), );
+
+// Issue #986.
+get_current_screen()->add_help_tab( array(
+		'id'		=> <<<EOD
+Here comes some text.
+EOD
+,
+) );
+
+get_current_screen()->add_help_tab( array(
+'id'		=> <<<EOD
+Here comes some text.
+EOD
+. '</hr>',
+) );

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the Arrays.CommaAfterArrayItem sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_Arrays_CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			44  => 2,
+			45  => 2,
+			48  => 2,
+			49  => 2,
+			52  => 1,
+			53  => 1,
+			57  => 1,
+			58  => 1,
+			59  => 1,
+			62  => 1,
+			66  => 1,
+			67  => 1,
+			72  => 1,
+			75  => 1,
+			82  => 1,
+			87  => 1,
+			90  => 4,
+			91  => 4,
+			93  => 2,
+			94  => 1,
+			98  => 1,
+			100 => 2,
+			102 => 1,
+			104 => 1,
+			106 => 1,
+			112 => 1,
+			113 => 2,
+			117 => 1,
+			118 => 2,
+			122 => 2,
+			123 => 2,
+			128 => 1,
+			135 => 1,
+			140 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
New sniff to enforce a comma after each array item and check the spacing around it.

Rules:
- For multi-line arrays, a comma is needed after each array item.
- Same for single-line arrays, but no comma is allowed after the last array item.
- There should be no space between the comma and the end of the array item.
- There should be exactly one space between the comma and the start of the next array item for single-line items.

This sniff replaces the comma related checks within the `ArrayDeclaration` sniff which were buggy in a number of cases.
* The single-line array comma related checks in the `WordPress.Arrays.ArrayDeclaration` have been excluded via the ruleset.
*  The multi-line array comma related checks have been commented out in the `WordPress.Arrays.ArrayDeclaration` sniff as explained in more detail in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/998#issuecomment-310869580 .

Fixes #986
Fixes #998

/cc @pento