### PR TITLE
Move `Squiz.PHP.EmbeddedPhp` from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -105,6 +105,22 @@
 
 	<!--
 	#############################################################################
+	Handbook: PHP - Opening and Closing PHP Tags.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#opening-and-closing-php-tags
+	#############################################################################
+	-->
+	<!-- Covers rule: When embedding multi-line PHP snippets within a HTML block, the
+	     PHP open and close tags must be on a line by themselves. -->
+	<rule ref="Squiz.PHP.EmbeddedPhp">
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	Handbook: PHP - No Shorthand PHP Tags.
 	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#no-shorthand-php-tags
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -33,15 +33,6 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
-	<!-- Another generic PHP best practice sniff - inspect embedded PHP.
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/465 -->
-	<rule ref="Squiz.PHP.EmbeddedPhp">
-		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
-	</rule>
-
 	<!-- This sniff is not refined enough for general use -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
 	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->


### PR DESCRIPTION
As the handbook has now been adjusted, this sniff can now be legitimately placed in the Core ruleset.
Thanks @ntwb for sorting that out, including the adjustments.

Fixes #1000