### PR TITLE
Fix fixer conflict between PEAR.FunctionCallSignature and WP.ArrayDeclarationSpacing

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -186,10 +186,10 @@
 		</properties>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-		<severity>0</severity>
+		<severity phpcs-only="true">0</severity>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-		<severity>0</severity>
+		<severity phpcs-only="true">0</severity>
 	</rule>
 	<!-- Related to issue #970 / https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 -->
 	<rule ref="WordPress.Functions.FunctionCallSignatureNoParams"/>


### PR DESCRIPTION
Single-line function calls which contain an associative array as a parameter should - according to the handbook - have each item in the associative array on a new line.
```php
my_function( true, array( 'a' => 'b' ) );
```
This causes the function call to effectively become multi-line, while not complying with the PEAR "parameters in a multi-line function call should start on a new line" expectation.
```php
my_function( true, array(
	'a' => 'b'
) );
```
As the rules for that part of the PEAR sniff were disabled, this caused a fixer conflict, resulting in the file not being fixed at all, 

By allowing the PEAR fixer to apply those rules anyway, the fixer conflict is removed.
```php
my_function(
	true, array(
		'a' => 'b',
	)
);
```

The currently chosen solution has been discussed in depth in #968.

Fixes #968