### PR TITLE
Add `PSR2.ControlStructures.SwitchDeclaration` to the `WordPress-Core` ruleset

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -67,6 +67,7 @@
 		<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.NotLower"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine"/>
 	</rule>
 
 	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
@@ -211,17 +212,6 @@
 
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Blank Lines.
-	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#blank-lines
-	#############################################################################
-	-->
-	<!-- Rule: The first line of a new code block should not be blank.
-	           This includes classes, functions, and all flow control blocks. -->
-	<!-- Covered by several different sniffs, but largely covered. -->
 
 
 	<!--

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -61,6 +61,14 @@
 		 Also covers various single-line array whitespace issues. -->
 	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
 
+	<!-- Covers rule: For switch structures case should indent one tab from the
+	     switch statement and break one tab from the case statement. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration">
+		<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.NotLower"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+	</rule>
+
 	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
 	<rule ref="WordPress.WhiteSpace.DisallowInlineTabs"/>
 
@@ -207,6 +215,17 @@
 
 	<!--
 	#############################################################################
+	Handbook: PHP - Blank Lines.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#blank-lines
+	#############################################################################
+	-->
+	<!-- Rule: The first line of a new code block should not be blank.
+	           This includes classes, functions, and all flow control blocks. -->
+	<!-- Covered by several different sniffs, but largely covered. -->
+
+
+	<!--
+	#############################################################################
 	Handbook: PHP - Formatting SQL statements.
 	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#formatting-sql-statements
 	#############################################################################
@@ -323,6 +342,10 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
 	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+	<!-- Rule: In a switch statement... If a case contains a block, then falls through
+	     to the next block, this must be explicitly commented. -->
+	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
 
 
 	<!--


### PR DESCRIPTION
As proposed in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/982#issuecomment-312607024

Also adds the newly added ~~section +~~ rules from the handbook which came out of the discussion in #982.

Partially fixes #982.