### PR TITLE
DisallowInlineTabs sniff: improve & add more unit tests.

### DIFF
--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc
@@ -25,3 +25,15 @@
 				$expected_value => 'data',
 				$found			=> 'more_data', // Bad.
 			);
+
+/*
+ * Test that the tab replacements do not negatively influence the existing mid-line alignments.
+ */
+$a		  = true;
+$aa		  = true;
+$aaa	  = true;
+$aaaa	  = true;
+$aaaaa	  = true;
+$aaaaaa	  = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.inc.fixed
@@ -14,14 +14,26 @@
 			);
 
 /**
- * @param int     $var     Description - Bad: alignment using tabs.
+ * @param int    $var    Description - Bad: alignment using tabs.
  * @param string $string Another description.
  */
 
 			$expected = ( $column - 1 );
-			$found      = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
-			$error      = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
-			$data      = array( // Bad.
+			$found    = ( $this->tokens[ $closer ]['column'] - 1 ); // Bad.
+			$error    = 'Array closer not aligned correctly; expected %s space(s) but found %s'; // Bad.
+			$data     = array( // Bad.
 				$expected_value => 'data',
-				$found            => 'more_data', // Bad.
+				$found          => 'more_data', // Bad.
 			);
+
+/*
+ * Test that the tab replacements do not negatively influence the existing mid-line alignments.
+ */
+$a        = true;
+$aa       = true;
+$aaa      = true;
+$aaaa     = true;
+$aaaaa    = true;
+$aaaaaa   = true;
+$aaaaaaa  = true;
+$aaaaaaaa = true;

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -16,6 +16,17 @@
 class WordPress_Tests_WhiteSpace_DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
 
 	/**
+	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array
+	 */
+	public function getCliValues( $testFile ) {
+		return array( '--tab-width=4' );
+	}
+
+	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @return array <int line number> => <int number of errors>
@@ -27,6 +38,12 @@ class WordPress_Tests_WhiteSpace_DisallowInlineTabsUnitTest extends AbstractSnif
 			23 => 1,
 			24 => 1,
 			26 => 1,
+			32 => 1,
+			33 => 1,
+			34 => 1,
+			35 => 1,
+			36 => 1,
+			37 => 1,
 		);
 	}
 


### PR DESCRIPTION
Set the `tabWidth` for the unit test file and see the fixes we would expect to happen.

N.B.: I realize that the new unit tests look like they are not all aligned in the code view for the unfixed file, but this is due to the GH tab size setting. With a tab size setting of `4`, there are actually aligned.