### PR TITLE
Example project.ruleset.xml: improve exclusion pattern suggestions

### DIFF
--- a/project.ruleset.xml.example
+++ b/project.ruleset.xml.example
@@ -2,17 +2,22 @@
 <ruleset name="Example Project">
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
-	<!-- Exclude select folders and files from being checked. -->
+	<!-- Exclude WP Core folders and files from being checked. -->
 	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-*.php</exclude-pattern>
 	<exclude-pattern>/docroot/index.php</exclude-pattern>
 	<exclude-pattern>/docroot/xmlrpc.php</exclude-pattern>
 	<exclude-pattern>/docroot/wp-content/plugins/*</exclude-pattern>
-	<exclude-pattern>*.twig</exclude-pattern>
 
 	<!-- Exclude the Composer Vendor directory. -->
 	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Exclude the Node Modules directory. -->
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<!-- Exclude minified Javascript files. -->
+	<exclude-pattern>*.min.js</exclude-pattern>
 
 	<!-- Include the WordPress-Extra standard. -->
 	<rule ref="WordPress-Extra">


### PR DESCRIPTION
P.S.: it would be nice if WP-core would actually comply with the `.min.js` naming conventions for minified JS ...

Some examples of files which are minified without the `.min.js` extensions:
* `html5.js` as shipped with most default themes
* `wp-includes/js/jquery/jquery.js`
* `wp-includes/js/jquery/jquery.query.js`
* `wp-includes/js/jquery/jquery.ui.touch-punch.js`
* `wp-includes/js/swfobject.js`

---- 

PR has been updated and now covers:
* Add exclusion of minified JS files.
* Add exclusion of Node modules directory
* Remove exclusion of `*.twig` files as that's not an extension that is included by PHPCS by default, so would need to be added via `--extensions=...` for those files to be picked up in the first place.
