### PR TITLE
Update `.travis.yml` to use Ubuntu Trusty by default and Precise for PHP 5.2/5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 
+dist: trusty
+
 language:
     - php
 
 php:
-    - 5.2
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -38,6 +38,19 @@ matrix:
     # Test PHP 5.3 with short_open_tags set to On (is Off by default)
     - php: 5.3
       env: PHPCS_BRANCH=2.9 SHORT_OPEN_TAGS=true
+      dist: precise
+    - php: 5.3
+      env: PHPCS_BRANCH=2.9
+      dist: precise
+    - php: 5.3
+      env: PHPCS_BRANCH=2.9.0
+      dist: precise
+    - php: 5.2
+      env: PHPCS_BRANCH=2.9
+      dist: precise
+    - php: 5.2
+      env: PHPCS_BRANCH=2.9.0
+      dist: precise
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 
 dist: trusty
 
+cache:
+  apt: true
+     
 language:
     - php
 
@@ -24,6 +27,10 @@ matrix:
     # Run PHPCS against WPCS. I just picked to run it against 5.5.
     - php: 5.5
       env: PHPCS_BRANCH=2.9 SNIFF=1
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
     # Run against PHPCS 3.0. I just picked to run it against 5.6.
     - php: 5.6
       env: PHPCS_BRANCH=master


### PR DESCRIPTION
Via https://core.trac.wordpress.org/ticket/41292

Travis CI have announced they are going to switch to Trusty as the default distro come July 18th
> https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

----

The current availability of PHP 5.2 and 5.3 in the Travis CI build environment is the following:

1.  `dist: precise` with `sudo: false` 
2.    `dist: trusty` with `sudo: false`
3.    `dist: precise` with `sudo: false`
4.    `dist: precise` with `sudo: required`

• WPCS' current Travis CI config uses option `1` above

• Travis CI will override this configuration with option `2` come July 18th 2017

• The workaround for this issue for PHP 5.2 & 5.3 until September 2017 is to use option `3` for the PHP 5.2 and 5.3 Travis CI jobs

• Come September 2017 Travis CI will overwrite option `3` above with option `4`

WordPress Core have just committed the above change just now via [r41072](https://core.trac.wordpress.org/changeset/41072)

----

Travis CI doesn't play well when calculating the `php`/`env` build matrix that includes a `dist:` section, as such the PHP 5.2 and 5.3 jobs are moved to the `include` section of the `matrix` 🤖 