### PR TITLE
New `ClassInstantiation` sniff to `WordPress-Extra`.

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -109,4 +109,8 @@
 	<!-- Verify that everything in the global namespace is prefixed. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
 
+	<!-- Check that object instantiations always have braces & are not assigned by reference.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/919 -->
+	<rule ref="WordPress.Classes.ClassInstantiation"/>
+
 </ruleset>

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * WordPress_Sniffs_Classes_ClassInstantiationSniff.
+ *
+ * Verifies object instantiation statements.
+ * - Demand the use of parenthesis.
+ * - Demand no space between the class name and the parenthesis.
+ * - Forbid assigning new by reference.
+ *
+ * {@internal Note: This sniff currently does not examine the parenthesis of new object
+ * instantiations where the class name is held in a variable variable.}}
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ */
+class WordPress_Sniffs_Classes_ClassInstantiationSniff extends WordPress_Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+	);
+
+	/**
+	 * Tokens which can be part of a "classname".
+	 *
+	 * Set from within the register() method.
+	 *
+	 * @var array
+	 */
+	protected $classname_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		/*
+		 * Set the $classname_tokens property.
+		 *
+		 * Currently does not account for classnames passed as a variable variable.
+		 */
+		$this->classname_tokens                           = PHP_CodeSniffer_Tokens::$emptyTokens;
+		$this->classname_tokens[ T_NS_SEPARATOR ]         = T_NS_SEPARATOR;
+		$this->classname_tokens[ T_STRING ]               = T_STRING;
+		$this->classname_tokens[ T_SELF ]                 = T_SELF;
+		$this->classname_tokens[ T_STATIC ]               = T_STATIC;
+		$this->classname_tokens[ T_PARENT ]               = T_PARENT;
+		$this->classname_tokens[ T_ANON_CLASS ]           = T_ANON_CLASS;
+		// Classname in a variable.
+		$this->classname_tokens[ T_VARIABLE ]             = T_VARIABLE;
+		$this->classname_tokens[ T_DOUBLE_COLON ]         = T_DOUBLE_COLON;
+		$this->classname_tokens[ T_OBJECT_OPERATOR ]      = T_OBJECT_OPERATOR;
+		$this->classname_tokens[ T_OPEN_SQUARE_BRACKET ]  = T_OPEN_SQUARE_BRACKET;
+		$this->classname_tokens[ T_CLOSE_SQUARE_BRACKET ] = T_CLOSE_SQUARE_BRACKET;
+
+		return array(
+			T_NEW,
+			T_STRING, // JS.
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		// Make sure we have the right token, JS vs PHP.
+		if ( ( 'PHP' === $this->phpcsFile->tokenizerType && T_NEW !== $this->tokens[ $stackPtr ]['code'] )
+			|| ( 'JS' === $this->phpcsFile->tokenizerType
+				&& ( T_STRING !== $this->tokens[ $stackPtr ]['code']
+				|| 'new' !== strtolower( $this->tokens[ $stackPtr ]['content'] ) ) )
+		) {
+			return;
+		}
+
+		/*
+		 * Check for new by reference used in PHP files.
+		 */
+		if ( 'PHP' === $this->phpcsFile->tokenizerType ) {
+			$prev_non_empty = $this->phpcsFile->findPrevious(
+				PHP_CodeSniffer_Tokens::$emptyTokens,
+				($stackPtr - 1),
+				null,
+				true
+			);
+
+			if ( false !== $prev_non_empty && 'T_BITWISE_AND' === $this->tokens[ $prev_non_empty ]['type'] ) {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Assigning new by reference', 'yes' );
+
+				$this->phpcsFile->addError(
+					'Assigning the return value of new by reference is no longer supported by PHP.',
+					$stackPtr,
+					'NewByReferenceFound'
+				);
+			} else {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Assigning new by reference', 'no' );
+			}
+		}
+
+		/*
+		 * Check for parenthesis & correct placement thereof.
+		 */
+		$next_non_empty_after_class_name = $this->phpcsFile->findNext(
+			$this->classname_tokens,
+			($stackPtr + 1),
+			null,
+			true,
+			null,
+			true
+		);
+
+		if ( false === $next_non_empty_after_class_name ) {
+			// Live coding.
+			return;
+		}
+
+		// Walk back to the last part of the class name.
+		$has_comment = false;
+		for ( $classname_ptr = ( $next_non_empty_after_class_name - 1 ); $classname_ptr >= $stackPtr; $classname_ptr-- ) {
+			if ( ! isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $classname_ptr ]['code'] ] ) ) {
+				// Prevent a false positive on variable variables, disregard them for now.
+				if ( $stackPtr === $classname_ptr ) {
+					return;
+				}
+
+				break;
+			}
+
+			if ( T_WHITESPACE !== $this->tokens[ $classname_ptr ]['code'] ) {
+				$has_comment = true;
+			}
+		}
+
+		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty_after_class_name ]['code'] ) {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Object instantiation with parenthesis', 'no' );
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Parenthesis should always be used when instantiating a new object.',
+				$classname_ptr,
+				'MissingParenthesis'
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContent( $classname_ptr, '()' );
+			}
+		} else {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Object instantiation with parenthesis', 'yes' );
+
+			if ( ( $next_non_empty_after_class_name - 1 ) !== $classname_ptr ) {
+				$this->phpcsFile->recordMetric(
+					$stackPtr,
+					'Space between classname and parenthesis',
+					( $next_non_empty_after_class_name - $classname_ptr )
+				);
+
+				$error      = 'There must be no spaces between the class name and the open parenthesis when instantiating a new object.';
+				$error_code = 'SpaceBeforeParenthesis';
+
+				if ( false === $has_comment ) {
+					$fix = $this->phpcsFile->addFixableError( $error, $next_non_empty_after_class_name, $error_code );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $next_non_empty_after_class_name - 1 ); $i > $classname_ptr; $i-- ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$fix = $this->phpcsFile->addError( $error, $next_non_empty_after_class_name, $error_code );
+				}
+			} else {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Space between classname and parenthesis', 0 );
+			}
+		}
+	} // End process_token().
+
+} // End class.

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.1.inc
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.1.inc
@@ -1,0 +1,90 @@
+<?php
+/*
+ * All OK.
+ */
+$a = new MyClass();
+$a = new MyClass( $something );
+$a = new $varHoldingClassName();
+$a = new self::$transport[$cap_string]();
+$renderer = new $this->inline_diff_renderer();
+$b = ( new MyClass() )->my_function();
+$b = ( new MyClass() )::$property;
+
+class ClassA {
+	public static function get_instance() {
+		return new self();
+	}
+
+	public static function get_other_instance() {
+		return new static();
+	}
+}
+
+class ClassB extends ClassA {
+	public function get_parent_instance() {
+		return new parent();
+	}
+}
+
+// PHP 7: Anonymous classes.
+$util->setLogger( new class() {} );
+$b = new class( 10 ) extends SomeClass implements SomeInterface {};
+
+
+/*
+ * Bad.
+ */
+$a = new MyClass;
+$a = new $varHoldingClassName;
+$a = new self::$transport[$cap_string];
+$renderer = new $this->inline_diff_renderer;
+$b = ( new MyClass )->my_function();
+$b = ( new MyClass )::$property;
+
+class ClassA {
+	public static function get_instance() {
+		return new self;
+	}
+
+	public static function get_other_instance() {
+		return new static;
+	}
+}
+
+class ClassB extends ClassA {
+	public function get_parent_instance() {
+		return new parent;
+	}
+}
+
+// PHP 7: Anonymous classes.
+$util->setLogger( new class {} );
+$b = new class extends SomeClass implements SomeInterface {};
+
+
+// Test some non-typical spacing.
+$renderer = new $this->
+					inline_diff_renderer  ();
+$renderer = new $this-> // There can be a comment here.
+					inline_diff_renderer  ();
+$renderer = new $this->
+					inline_diff_renderer /* or here */ ();
+$a = new self :: $transport [ $cap_string ] ();
+
+$renderer = new $this->
+					inline_diff_renderer;
+$renderer = new $this-> // There can be a comment here.
+					inline_diff_renderer;
+$renderer = new $this->
+					inline_diff_renderer /* or here */ ;
+$a = new self :: $transport [ $cap_string ];
+
+
+// Assigning new by reference.
+$b = &new Foobar();
+$b = & new Foobar();
+
+
+// Currently not accounted for by the sniff, i.e. false negatives.
+$a = new $$varHoldingClassName;
+$a = new ${$varHoldingClassName};

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.1.inc.fixed
@@ -1,0 +1,90 @@
+<?php
+/*
+ * All OK.
+ */
+$a = new MyClass();
+$a = new MyClass( $something );
+$a = new $varHoldingClassName();
+$a = new self::$transport[$cap_string]();
+$renderer = new $this->inline_diff_renderer();
+$b = ( new MyClass() )->my_function();
+$b = ( new MyClass() )::$property;
+
+class ClassA {
+	public static function get_instance() {
+		return new self();
+	}
+
+	public static function get_other_instance() {
+		return new static();
+	}
+}
+
+class ClassB extends ClassA {
+	public function get_parent_instance() {
+		return new parent();
+	}
+}
+
+// PHP 7: Anonymous classes.
+$util->setLogger( new class() {} );
+$b = new class( 10 ) extends SomeClass implements SomeInterface {};
+
+
+/*
+ * Bad.
+ */
+$a = new MyClass();
+$a = new $varHoldingClassName();
+$a = new self::$transport[$cap_string]();
+$renderer = new $this->inline_diff_renderer();
+$b = ( new MyClass() )->my_function();
+$b = ( new MyClass() )::$property;
+
+class ClassA {
+	public static function get_instance() {
+		return new self();
+	}
+
+	public static function get_other_instance() {
+		return new static();
+	}
+}
+
+class ClassB extends ClassA {
+	public function get_parent_instance() {
+		return new parent();
+	}
+}
+
+// PHP 7: Anonymous classes.
+$util->setLogger( new class() {} );
+$b = new class() extends SomeClass implements SomeInterface {};
+
+
+// Test some non-typical spacing.
+$renderer = new $this->
+					inline_diff_renderer();
+$renderer = new $this-> // There can be a comment here.
+					inline_diff_renderer();
+$renderer = new $this->
+					inline_diff_renderer /* or here */ ();
+$a = new self :: $transport [ $cap_string ]();
+
+$renderer = new $this->
+					inline_diff_renderer();
+$renderer = new $this-> // There can be a comment here.
+					inline_diff_renderer();
+$renderer = new $this->
+					inline_diff_renderer() /* or here */ ;
+$a = new self :: $transport [ $cap_string ]();
+
+
+// Assigning new by reference.
+$b = &new Foobar();
+$b = & new Foobar();
+
+
+// Currently not accounted for by the sniff, i.e. false negatives.
+$a = new $$varHoldingClassName;
+$a = new ${$varHoldingClassName};

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.2.inc
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.2.inc
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Test cases which can't be tested on PHP 5.2.
+ */
+
+/*
+ * All OK.
+ */
+$a = new \MyClass();
+$a = new \MyNamespace\MyClass();
+
+
+/*
+ * Bad.
+ */
+$a = new \MyClass;
+$a = new \MyNamespace\MyClass;

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.2.inc.fixed
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Test cases which can't be tested on PHP 5.2.
+ */
+
+/*
+ * All OK.
+ */
+$a = new \MyClass();
+$a = new \MyNamespace\MyClass();
+
+
+/*
+ * Bad.
+ */
+$a = new \MyClass();
+$a = new \MyNamespace\MyClass();

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.js
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.js
@@ -1,0 +1,4 @@
+var firstBook  = new Book(); // OK.
+var secondBook = new Book; // Bad.
+var thirdBook  = new Book    (); // Bad.
+var fourthBook = new Book    ( 'title' ); // Bad.

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.js.fixed
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.js.fixed
@@ -1,0 +1,4 @@
+var firstBook  = new Book(); // OK.
+var secondBook = new Book(); // Bad.
+var thirdBook  = new Book(); // Bad.
+var fourthBook = new Book( 'title' ); // Bad.

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the ClassInstantiation sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.12.0
+ */
+class WordPress_Tests_Classes_ClassInstantiationUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Get a list of all test files to check.
+	 *
+	 * @param string $testFileBase The base path that the unit tests files will have.
+	 *
+	 * @return string[]
+	 */
+	protected function getTestFiles( $testFileBase ) {
+		$testFiles = parent::getTestFiles( $testFileBase );
+
+		if ( PHP_VERSION_ID < 50300 ) {
+			$testFiles = array_diff( $testFiles, array( $testFileBase . '2.inc' ) );
+		}
+
+		return $testFiles;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+
+		switch ( $testFile ) {
+			case 'ClassInstantiationUnitTest.1.inc':
+				return array(
+					37 => 1,
+					38 => 1,
+					39 => 1,
+					40 => 1,
+					41 => 1,
+					42 => 1,
+					46 => 1,
+					50 => 1,
+					56 => 1,
+					61 => 1,
+					62 => 1,
+					67 => 1,
+					69 => 1,
+					71 => 1,
+					72 => 1,
+					75 => 1,
+					77 => 1,
+					79 => 1,
+					80 => 1,
+					84 => 1,
+					85 => 1,
+				);
+
+			case 'ClassInstantiationUnitTest.2.inc':
+				return array(
+					16 => 1,
+					17 => 1,
+				);
+
+			case 'ClassInstantiationUnitTest.js':
+				return array(
+					2 => 1,
+					3 => 1,
+					4 => 1,
+				);
+
+			default:
+				return array();
+
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
New sniff to verify that objects being instantiated comply with some basic rules:
* Always use parenthesis.
* Don't have spaces (or comments) between the class name and the parenthesis.
* Don't assign new by reference (PHP only).

Sniffs both PHP as well as JS code.

Auto-fixes _missing parentheses_ and _space between class name and parentheses_.

Includes unit tests.

Currently doesn't handle cases of object instantiations where the class name is held in a variable variable.

Fixes #919