### PR TITLE
Improve detection of condition beginning in Yoda conditions sniff

### DIFF
--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -35,12 +35,14 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 	 */
 	public function register() {
 
-		$this->condition_start_tokens  = PHP_CodeSniffer_Tokens::$booleanOperators;
-		$this->condition_start_tokens += PHP_CodeSniffer_Tokens::$assignmentTokens;
-		$this->condition_start_tokens[ T_CASE ] = T_CASE;
-		$this->condition_start_tokens[ T_RETURN ] = T_RETURN;
-		$this->condition_start_tokens[ T_SEMICOLON ] = T_SEMICOLON;
-		$this->condition_start_tokens[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+		$starters                       = PHP_CodeSniffer_Tokens::$booleanOperators;
+		$starters                      += PHP_CodeSniffer_Tokens::$assignmentTokens;
+		$starters[ T_CASE ]             = T_CASE;
+		$starters[ T_RETURN ]           = T_RETURN;
+		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
+		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+
+		$this->condition_start_tokens = $starters;
 
 		return array(
 			T_IS_EQUAL,

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -46,6 +46,8 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 		$beginners   = PHP_CodeSniffer_Tokens::$booleanOperators;
 		$beginners[] = T_IF;
 		$beginners[] = T_ELSEIF;
+		$beginners[] = T_RETURN;
+		$beginners = array_merge( $beginners, PHP_CodeSniffer_Tokens::$assignmentTokens );
 
 		$beginning = $this->phpcsFile->findPrevious( $beginners, $stackPtr, null, false, null, true );
 
@@ -68,7 +70,7 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_CLOSE_PARENTHESIS, T_OPEN_PARENTHESIS, T_RETURN ), true ) ) {
+			if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 				return;
 			}
 		}

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -37,9 +37,10 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 
 		$this->condition_start_tokens  = PHP_CodeSniffer_Tokens::$booleanOperators;
 		$this->condition_start_tokens += PHP_CodeSniffer_Tokens::$assignmentTokens;
-		$this->condition_start_tokens[ T_IF ] = T_IF;
-		$this->condition_start_tokens[ T_ELSEIF ] = T_ELSEIF;
+		$this->condition_start_tokens[ T_CASE ] = T_CASE;
 		$this->condition_start_tokens[ T_RETURN ] = T_RETURN;
+		$this->condition_start_tokens[ T_SEMICOLON ] = T_SEMICOLON;
+		$this->condition_start_tokens[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
 
 		return array(
 			T_IS_EQUAL,

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -20,11 +20,27 @@
 class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 
 	/**
+	 * The tokens that indicate the start of a condition.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	protected $condition_start_tokens;
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
 	public function register() {
+
+		$this->condition_start_tokens  = PHP_CodeSniffer_Tokens::$booleanOperators;
+		$this->condition_start_tokens += PHP_CodeSniffer_Tokens::$assignmentTokens;
+		$this->condition_start_tokens[ T_IF ] = T_IF;
+		$this->condition_start_tokens[ T_ELSEIF ] = T_ELSEIF;
+		$this->condition_start_tokens[ T_RETURN ] = T_RETURN;
+
 		return array(
 			T_IS_EQUAL,
 			T_IS_NOT_EQUAL,
@@ -43,18 +59,12 @@ class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		$beginners   = PHP_CodeSniffer_Tokens::$booleanOperators;
-		$beginners[] = T_IF;
-		$beginners[] = T_ELSEIF;
-		$beginners[] = T_RETURN;
-		$beginners = array_merge( $beginners, PHP_CodeSniffer_Tokens::$assignmentTokens );
-
-		$beginning = $this->phpcsFile->findPrevious( $beginners, $stackPtr, null, false, null, true );
+		$start = $this->phpcsFile->findPrevious( $this->condition_start_tokens, $stackPtr, null, false, null, true );
 
 		$needs_yoda = false;
 
 		// Note: going backwards!
-		for ( $i = $stackPtr; $i > $beginning; $i-- ) {
+		for ( $i = $stackPtr; $i > $start; $i-- ) {
 
 			// Ignore whitespace.
 			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -90,3 +90,9 @@ if ( $GLOBALS['wpdb']->num_rows === 0 ) {} // Bad.
 if ( $true == strtolower( $check ) ) {} // Bad.
 
 $update = 'yes' === strtolower( $this->from_post( 'update' ) ); // Ok.
+$sample = false !== strpos( $link, '%pagename%' ); // Ok.
+$sample = true !== strpos( $link, '%pagename%' ); // Ok.
+$sample = null !== strpos( $link, '%pagename%' ); // Ok.
+$sample = SOME_CONSTANT !== strpos( $link, '%pagename%' ); // Ok.
+$sample = foo() !== strpos( $link, '%pagename%' ); // Ok.
+$sample = foo( $var ) !== strpos( $link, '%pagename%' ); // Ok.

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -96,3 +96,33 @@ $sample = null !== strpos( $link, '%pagename%' ); // Ok.
 $sample = SOME_CONSTANT !== strpos( $link, '%pagename%' ); // Ok.
 $sample = foo() !== strpos( $link, '%pagename%' ); // Ok.
 $sample = foo( $var ) !== strpos( $link, '%pagename%' ); // Ok.
+
+if ( $sample = false !== strpos( $link, '%pagename%' ) ) {} // Ok.
+if ( $sample = ( false !== strpos( $link, '%pagename%' ) ) ) {} // Ok.
+if ( ( $sample = false ) !== strpos( $link, '%pagename%' ) ) {} // Ok.
+
+switch ( true ) {
+	case $sample === 'something': // Bad.
+		// Do something.
+	break;
+
+	case 'something' === $sample: // OK.
+		// Do something.
+	break;
+}
+
+for ( $i = 0; $i !== 100; $i++ ) {} // Bad.
+for ( $i = 0; 100 != $i; $i++ ) {} // OK.
+
+do {
+	// Something.
+} while ( $sample === false ); // Bad.
+
+do {
+	// Something.
+} while ( CONSTANT_A === $sample ); // OK.
+
+while ( $sample === false ) {} // Bad.
+while ( false != $sample ) {} // OK.
+
+$a = ( $sample ) === 'yes'; // OK.

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -35,6 +35,10 @@ class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest {
 			84 => 1,
 			88 => 1,
 			90 => 1,
+			105 => 1,
+			114 => 1,
+			119 => 1,
+			125 => 1,
 		);
 
 	}


### PR DESCRIPTION
This sniff is supposed to loop over the left-hand side of the condition,
checking for variables. If the left-hand side of the condition is not a
variable, then it should not give an error about it.

However, there were some issues with how we were detecting the beginning
of the left-hand side of the condition. Take the following example code:

```php
$sample = false !== strpos( $link, '%pagename%' ); // Ok.
```

This should not cause an issue, because the left-hand side of the
condition is just `false`. However, we weren't detecting the beginning
of the condition correctly; we'd end up checking right through the `=`
assignment operator and seeing the `$sample` variable. As a result, an
error would be given for this snippet.

To correct this, we just need to take assignment operators into account
when detecting the beginning of the condition.

With this correction, we can also simplify some other code that was
checking for a function call (or certain other tokens) within the
condition, that would indicate it didn't need to be checked:

- The `T_RETURN` token is actually an indicator of the beginning of the
condition, so it should be moved to that check instead.
- The `T_CONSTANT_ENCAPSED_STRING` token is no longer needed to be checked
at all, because it was added to circumvent the bug that is now fixed by
better detection of the beginning of the condition.
- The `T_OPEN_PARENTHESIS` really shouldn't be needed, because the closing
parenthesis will be detected first anyway (we are looping backward
here).

The `T_CLOSE_PARENTHESIS` is the only one that needs to stay, because of
cases like this:

```php
$sample = foo( $var ) !== strpos( $link, '%pagename%' ); // Ok.
```

Without the check for the closing parenthesis token, the `$var`
parameter in the call to the `foo()` function would cause the condition
to be flagged as needing to be a Yoda condition.

Fixes #1036