### PR TITLE
Unit tests: Prevent bleed through between unit tests.

### DIFF
--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -34,6 +34,14 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 	}
 
 	/**
+	 * Reset the $groups property.
+	 */
+	protected function tearDown() {
+		WordPress_AbstractArrayAssignmentRestrictionsSniff::$groups = array();
+		parent::tearDown();
+	}
+
+	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @return array <int line number> => <int number of errors>

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -38,6 +38,14 @@ class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest
 	}
 
 	/**
+	 * Reset the $groups property.
+	 */
+	protected function tearDown() {
+		WordPress_AbstractFunctionRestrictionsSniff::$unittest_groups = array();
+		parent::tearDown();
+	}
+
+	/**
 	 * Skip this test on PHP 5.2 as otherwise testing the namespace resolving would fail.
 	 *
 	 * @return bool Whether to skip this test.

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -58,6 +58,14 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 	}
 
 	/**
+	 * Reset the $groups property.
+	 */
+	protected function tearDown() {
+		WordPress_AbstractVariableRestrictionsSniff::$groups = array();
+		parent::tearDown();
+	}
+
+	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @return array <int line number> => <int number of errors>

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -24,6 +24,14 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 	}
 
 	/**
+	 * Reset the $groups property.
+	 */
+	protected function tearDown() {
+		PHP_CodeSniffer::setConfigData( 'text_domain', null, true );
+		parent::tearDown();
+	}
+
+	/**
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.


### PR DESCRIPTION
Unit tests which have a `setUp()` method and use this to set the value of properties or command line parameters, should always have a `tearDown()` method in which they clean up after themselves.

This PR is part of the preparation for PHPCS 3.x compatibility.