### PR TITLE
PHPCS 3.x prep: work round a function which will no longer exist

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -48,11 +48,25 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	protected $excluded_groups = array();
 
 	/**
+	 * Cache for the group information.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @var array
+	 */
+	protected $groups_cache = array();
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
 	public function register() {
+		// Retrieve the groups only once and don't set up a listener if there are no groups.
+		if ( false === $this->setup_groups() ) {
+			return array();
+		}
+
 		return array(
 			T_DOUBLE_ARROW,
 			T_CLOSE_SQUARE_BRACKET,
@@ -81,6 +95,28 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	abstract public function getGroups();
 
 	/**
+	 * Cache the groups.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return bool True if the groups were setup. False if not.
+	 */
+	protected function setup_groups() {
+		$this->groups_cache = $this->getGroups();
+
+		if ( empty( $this->groups_cache ) && empty( self::$groups ) ) {
+			return false;
+		}
+
+		// Allow for adding extra unit tests.
+		if ( ! empty( self::$groups ) ) {
+			$this->groups_cache = array_merge( $this->groups_cache, self::$groups );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
@@ -89,15 +125,8 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 	 */
 	public function process_token( $stackPtr ) {
 
-		$groups = $this->getGroups();
-
-		if ( empty( $groups ) ) {
-			$this->phpcsFile->removeTokenListener( $this, $this->register() );
-			return;
-		}
-
 		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
-		if ( array_diff_key( $groups, $this->excluded_groups ) === array() ) {
+		if ( array_diff_key( $this->groups_cache, $this->excluded_groups ) === array() ) {
 			// All groups have been excluded.
 			// Don't remove the listener as the exclude property can be changed inline.
 			return;
@@ -149,7 +178,7 @@ abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPr
 			return;
 		}
 
-		foreach ( $groups as $groupName => $group ) {
+		foreach ( $this->groups_cache as $groupName => $group ) {
 
 			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
 				continue;

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -49,11 +49,25 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	protected $excluded_groups = array();
 
 	/**
+	 * Cache for the group information.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @var array
+	 */
+	protected $groups_cache = array();
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
 	 */
 	public function register() {
+		// Retrieve the groups only once and don't set up a listener if there are no groups.
+		if ( false === $this->setup_groups() ) {
+			return array();
+		}
+
 		return array(
 			T_VARIABLE,
 			T_OBJECT_OPERATOR,
@@ -85,6 +99,28 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	abstract public function getGroups();
 
 	/**
+	 * Cache the groups.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return bool True if the groups were setup. False if not.
+	 */
+	protected function setup_groups() {
+		$this->groups_cache = $this->getGroups();
+
+		if ( empty( $this->groups_cache ) && empty( self::$groups ) ) {
+			return false;
+		}
+
+		// Allow for adding extra unit tests.
+		if ( ! empty( self::$groups ) ) {
+			$this->groups_cache = array_merge( $this->groups_cache, self::$groups );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
@@ -94,16 +130,10 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 	 */
 	public function process_token( $stackPtr ) {
 
-		$token  = $this->tokens[ $stackPtr ];
-		$groups = $this->getGroups();
-
-		if ( empty( $groups ) ) {
-			$this->phpcsFile->removeTokenListener( $this, $this->register() );
-			return;
-		}
+		$token = $this->tokens[ $stackPtr ];
 
 		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
-		if ( array_diff_key( $groups, $this->excluded_groups ) === array() ) {
+		if ( array_diff_key( $this->groups_cache, $this->excluded_groups ) === array() ) {
 			// All groups have been excluded.
 			// Don't remove the listener as the exclude property can be changed inline.
 			return;
@@ -118,7 +148,7 @@ abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sni
 			}
 		}
 
-		foreach ( $groups as $groupName => $group ) {
+		foreach ( $this->groups_cache as $groupName => $group ) {
 
 			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
 				continue;

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -38,7 +38,7 @@ class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress
 	 * @return array
 	 */
 	public function getGroups() {
-		return parent::$groups;
+		return array();
 	}
 
 	/**

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -39,7 +39,7 @@ class WordPress_Sniffs_Variables_VariableRestrictionsSniff extends WordPress_Abs
 	 * @return array
 	 */
 	public function getGroups() {
-		return parent::$groups;
+		return array();
 	}
 
 } // End class.


### PR DESCRIPTION
This PR is part of the preparation for PHPCS 3.x compatibility.

The `removeTokenListener()` method was used to prevent the sniffs using these abstracts from being called for further files, however, this method will no longer exist in PHPCS 3.x with no alternative.

The `AbstractFunctionRestrictionSniff` also uses a `getGroups()` method, but calls it earlier and prevents the child sniffs from being run without groups by just not registering any token listeners if no groups are found.

This same methodology has now been implemented in the two abstracts which used the `removeTokenListener()` method, effectively making these sniffs more efficient and preventing the removal of the method from becoming a problem.