### PR TITLE
Make WPCS compatible with PHPCS 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 vendor
 composer.lock
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 cache:
   apt: true
-     
+
 language:
     - php
 
@@ -14,11 +14,12 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - nightly
 
 env:
-  # Branch for patches against 2.x. `master` is now 3.x which WPCS is not (yet) compatible with.
-  - PHPCS_BRANCH=2.9 LINT=1
-  # Tagged release
+  # `master` is now 3.x.
+  - PHPCS_BRANCH=master LINT=1
+  # Lowest tagged release in the 2.x series with which WPCS is compatible.
   - PHPCS_BRANCH=2.9.0
 
 matrix:
@@ -31,38 +32,27 @@ matrix:
         apt:
           packages:
             - libxml2-utils
-    # Run against PHPCS 3.0. I just picked to run it against 5.6.
-    - php: 5.6
-      env: PHPCS_BRANCH=master
+
     # Run against HHVM and PHP nightly.
     - php: hhvm
       sudo: required
-      dist: trusty 
+      dist: trusty
       group: edge
+      env: PHPCS_BRANCH=master LINT=1
+
+    # Test PHP 5.3 only against PHPCS 2.x as PHPCS 3.x has a minimum requirement of PHP 5.4.
+    - php: 5.3
       env: PHPCS_BRANCH=2.9 LINT=1
-    - php: nightly
-      env: PHPCS_BRANCH=2.9 LINT=1
+      dist: precise
     # Test PHP 5.3 with short_open_tags set to On (is Off by default)
     - php: 5.3
-      env: PHPCS_BRANCH=2.9 SHORT_OPEN_TAGS=true
+      env: PHPCS_BRANCH=2.9.0 SHORT_OPEN_TAGS=true
       dist: precise
-    - php: 5.3
-      env: PHPCS_BRANCH=2.9
-      dist: precise
-    - php: 5.3
-      env: PHPCS_BRANCH=2.9.0
-      dist: precise
-    - php: 5.2
-      env: PHPCS_BRANCH=2.9
-      dist: precise
-    - php: 5.2
-      env: PHPCS_BRANCH=2.9.0
-      dist: precise
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
     - php: hhvm
-    - env: PHPCS_BRANCH=master
 
 before_install:
     - export XMLLINT_INDENT="	"
@@ -82,8 +72,10 @@ script:
     # Lint the PHP files against parse errors.
     - if [[ "$LINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --filter WordPress /tmp/phpcs/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then phpunit --filter WordPress $(pwd)/Test/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --filter WordPress $(pwd)/Test/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar  --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,15 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 Sometimes, a sniff will flag code which upon further inspection by a human turns out to be OK.
 If the sniff you are writing is susceptible to this, please consider adding the ability to [whitelist lines of code](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors).
 
-To this end, the `WordPress_Sniff::has_whitelist_comment()` method was introduced.
+To this end, the `WordPress\Sniff::has_whitelist_comment()` method was introduced.
 
 Example usage:
 ```php
-class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
+namespace WordPress\Sniffs\CSRF;
+
+use WordPress\Sniff;
+
+class NonceVerificationSniff extends Sniff {
 
 	public function process_token( $stackPtr ) {
 
@@ -48,92 +52,140 @@ When you introduce a new whitelist comment, please don't forget to update the [w
 
 # Unit Testing
 
-TL;DR
+## Pre-requisites
+* WordPress-Coding-Standards
+* PHP CodeSniffer 2.9.x or 3.x
+* PHPUnit 4.x or 5.x
 
-If you have installed `phpcs` and the WordPress-Coding-Standards as [noted in the README](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use-this), then you can navigate to the directory where the `phpcs` repo is checked out and do:
+The WordPress Coding Standards use the PHP CodeSniffer native unit test suite for unit testing the sniffs.
 
-```sh
-composer install
-vendor/bin/phpunit --filter WordPress tests/AllTests.php
+Presuming you have installed PHP CodeSniffer and the WordPress-Coding-Standards as [noted in the README](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use-this), all you need now is `PHPUnit`.
+
+If you already have PHPUnit installed on your system: Congrats, you're all set.
+
+If not, you can navigate to the directory where the `PHP_CodeSniffer` repo is checked out and do `composer install` to install the `dev` dependencies.
+Alternatively, you can [install PHPUnit](https://phpunit.de/manual/5.7/en/installation.html) as a PHAR file.
+
+## Before running the unit tests
+
+N.B.: _If you used Composer to install the WordPress Coding Standards, you can skip this step._
+
+For the unit tests to work, you need to make sure PHPUnit can find your `PHP_CodeSniffer` install.
+
+The easiest way to do this is to add a `phpunit.xml` file to the root of your WPCS installation and set a `PHPCS_DIR` environment variable from within this file. Make sure to adjust the path to reflect your local setup.
+```xml
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+	backupGlobals="true">
+	<php>
+		<env name="PHPCS_DIR" value="/path/to/PHP_CodeSniffer/"/>
+	</php>
+</phpunit>
 ```
 
+## Running the unit tests
+
+The WordPress Coding Standards are compatible with both PHPCS 2.x as well as 3.x. This has some implications for running the unit tests.
+
+* Navigate to the directory in which you installed WPCS.
+* To run the unit tests with PHPCS 3.x:
+    ```sh
+    phpunit --bootstrap="./Test/phpcs3-bootstrap.php" --filter WordPress /path/to/PHP_CodeSniffer/tests/AllTests.php
+    ```
+* To run the unit tests with PHPCS 2.x:
+    ```sh
+    phpunit --bootstrap="./Test/phpcs2-bootstrap.php" --filter WordPress ./Test/AllTests.php
+    ```
+
 Expected output:
+```
+PHPUnit 4.8.19 by Sebastian Bergmann and contributors.
+
+Runtime:        PHP 7.1.3 with Xdebug 2.5.1
+Configuration:  /WordPressCS/phpunit.xml
+
+......................................................
+
+Tests generated 558 unique error codes; 48 were fixable (8.6%)
+
+Time: 12.25 seconds, Memory: 24.00Mb
+
+OK (54 tests, 0 assertions)
+```
 
 [![asciicast](https://asciinema.org/a/98078.png)](https://asciinema.org/a/98078)
 
-You can ignore any skipped tests as these are for `PHP_CodeSniffer` external tools.
-
-The reason why we need to checkout from `PHP_CodeSniffer` git repo to run the tests is because
-PEAR installation is intended for ready-to-use not for development. At some point `WordPress-Coding-Standards`
-might be submitted to `PHP_CodeSniffer` repo and using their existing convention for unit tests
-will eventually help them to test the code before merging in.
-
 ## Unit Testing conventions
 
-If you see inside the `WordPress/Tests`, the structure mimics the `WordPress/Sniffs`. For example,
-the `WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php` sniff has unit test class defined in
-`WordPress/Tests/Arrays/ArrayDeclarationUnitTest.php` that check `WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc`
-file. See the file naming convention? Lets take a look what inside `ArrayDeclarationUnitTest.php`:
+If you look inside the `WordPress/Tests` subdirectory, you'll see the structure mimics the `WordPress/Sniffs` subdirectory structure. For example, the `WordPress/Sniffs/PHP/POSIXFunctionsSniff.php` sniff has its unit test class defined in `WordPress/Tests/PHP/POSIXFunctionsUnitTest.php` which checks the `WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc` test case file. See the file naming convention?
+
+Lets take a look at what's inside `POSIXFunctionsUnitTest.php`:
 
 ```php
 ...
-class WordPress_Tests_Arrays_ArrayDeclarationUnitTest extends AbstractSniffUnitTest
-{
-    public function getErrorList()
-    {
-        return array(
-                3 => 1,
-                7 => 1,
-                9 => 1,
-                16 => 1,
-                31 => 2,
-               );
+namespace WordPress\Tests\PHP;
 
-    }//end getErrorList()
-}
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			13 => 1,
+			16 => 1,
+			18 => 1,
+			20 => 1,
+			22 => 1,
+			24 => 1,
+			26 => 1,
+		);
+
+	}
 ...
 ```
 
-Also note the class name convention. The method `getErrorList` MUST return an array of line numbers
-indicating errors (when running `phpcs`) found in `WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc`.
+Also note the class name convention. The method `getErrorList()` MUST return an array of line numbers indicating errors (when running `phpcs`) found in `WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc`.
 If you run:
 
 ```sh
 $ cd /path-to-cloned/phpcs
-$ ./scripts/phpcs --standard=Wordpress -s CodeSniffer/Standards/WordPress/Tests/Arrays/ArrayDeclarationUnitTest.inc
+$ ./bin/phpcs --standard=Wordpress -s /path/to/WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
 ...
 --------------------------------------------------------------------------------
-FOUND 8 ERROR(S) AND 2 WARNING(S) AFFECTING 6 LINE(S)
+FOUND 7 ERRORS AFFECTING 7 LINES
 --------------------------------------------------------------------------------
-  3 | ERROR   | Array keyword should be lower case; expected "array" but found
-    |         | "Array" (WordPress.Arrays.ArrayDeclaration)
-  7 | ERROR   | There must be no space between the Array keyword and the
-    |         | opening parenthesis (WordPress.Arrays.ArrayDeclaration)
-  9 | ERROR   | Empty array declaration must have no space between the
-    |         | parentheses (WordPress.Arrays.ArrayDeclaration)
- 12 | WARNING | No space after opening parenthesis of array is bad style
-    |         | (WordPress.Arrays.ArrayDeclaration)
- 12 | WARNING | No space before closing parenthesis of array is bad style
-    |         | (WordPress.Arrays.ArrayDeclaration)
- 16 | ERROR   | Each line in an array declaration must end in a comma
-    |         | (WordPress.Arrays.ArrayDeclaration)
- 31 | ERROR   | Expected 1 space between "'type'" and double arrow; 0 found
-    |         | (WordPress.Arrays.ArrayDeclaration)
- 31 | ERROR   | Expected 1 space between double arrow and "'post'"; 0 found
-    |         | (WordPress.Arrays.ArrayDeclaration)
- 31 | ERROR   | Expected 1 space before "=>"; 0 found
-    |         | (WordPress.WhiteSpace.OperatorSpacing)
- 31 | ERROR   | Expected 1 space after "=>"; 0 found
-    |         | (WordPress.WhiteSpace.OperatorSpacing)
+ 13 | ERROR | ereg() has been deprecated since PHP 5.3 and removed in PHP 7.0,
+    |       | please use preg_match() instead.
+    |       | (WordPress.PHP.POSIXFunctions.ereg_ereg)
+ 16 | ERROR | eregi() has been deprecated since PHP 5.3 and removed in PHP 7.0,
+    |       | please use preg_match() instead.
+    |       | (WordPress.PHP.POSIXFunctions.ereg_eregi)
+ 18 | ERROR | ereg_replace() has been deprecated since PHP 5.3 and removed in PHP
+    |       | 7.0, please use preg_replace() instead.
+    |       | (WordPress.PHP.POSIXFunctions.ereg_replace_ereg_replace)
+ 20 | ERROR | eregi_replace() has been deprecated since PHP 5.3 and removed in PHP
+    |       | 7.0, please use preg_replace() instead.
+    |       | (WordPress.PHP.POSIXFunctions.ereg_replace_eregi_replace)
+ 22 | ERROR | split() has been deprecated since PHP 5.3 and removed in PHP 7.0,
+    |       | please use explode(), str_split() or preg_split() instead.
+    |       | (WordPress.PHP.POSIXFunctions.split_split)
+ 24 | ERROR | spliti() has been deprecated since PHP 5.3 and removed in PHP 7.0,
+    |       | please use explode(), str_split() or preg_split() instead.
+    |       | (WordPress.PHP.POSIXFunctions.split_spliti)
+ 26 | ERROR | sql_regcase() has been deprecated since PHP 5.3 and removed in PHP
+    |       | 7.0, please use preg_match() instead.
+    |       | (WordPress.PHP.POSIXFunctions.ereg_sql_regcase)
 --------------------------------------------------------------------------------
 ....
 ```
+You'll see the line number and number of ERRORs we need to return in the `getErrorList()` method.
 
-You'll see the line number and number of ERRORs we need to return in `getErrorList` method.
-In line #31 there are two ERRORs belong to `WordPress.WhiteSpace.OperatorSpacing` sniff and
-it MUST not included in `ArrayDeclarationUnitTest` (that's why we only return 2 errros for line #31).
-Also there's `getWarningList` method in unit test class that returns an array of line numbers
-indicating WARNINGs.
+The `--sniffs=...` directive limits the output to the sniff you are testing.
 
 ## Sniff Code Standards
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.2 or higher and the [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.9.0** or higher.
-The WordPress Coding Standards are currently [not compatible with the upcoming PHPCS 3 release](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718).
+The WordPress Coding Standards require PHP 5.3 or higher and [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.9.0** or higher.
+As of version 0.13.0, the WordPress Coding Standards are compatible with PHPCS 3.0.2+. In that case, the minimum PHP requirement is PHP 5.4.
 
 ### Composer
 
@@ -58,7 +58,7 @@ Running this command will:
 3. Register WordPress standards in PHP_CodeSniffer configuration.
 4. Make `phpcs` command available from `wpcs/vendor/bin`.
 
-For the convenience of using `phpcs` as a global command, you may want to add the `wpcs/vendor/bin` path to a PATH environment in your operating system.
+For the convenience of using `phpcs` as a global command, you may want to add the path to the `wpcs/vendor/scripts` (PHPCS 2.x) and/or `wpcs/vendor/bin` (PHPCS 3.x) directories to a `PATH` environment variable for your operating system.
 
 #### Installing WPCS as a dependency
 
@@ -96,10 +96,13 @@ cd ~/projects
 git clone https://github.com/squizlabs/PHP_CodeSniffer.git phpcs
 git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
 cd phpcs
+#PHPCS 2.x
 ./scripts/phpcs --config-set installed_paths ../wpcs
+#PHPCS 3.x
+./bin/phpcs --config-set installed_paths ../wpcs
 ```
 
-And then add the `~/projects/phpcs/scripts` directory to your `PATH` environment variable via your `.bashrc`.
+And then add the `~/projects/phpcs/scripts` (PHPCS 2.x) or `~/projects/phpcs/bin` (PHPCS 3.x) directory to your `PATH` environment variable via your `.bashrc`.
 
 You should then see `WordPress-Core` et al listed when you run `phpcs -i`.
 
@@ -241,7 +244,7 @@ before_install:
   # Install WordPress Coding Standards.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
   # Set install path for WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
@@ -251,7 +254,7 @@ script:
   # for example: `--standard=wpcs.xml`.
   # You can use any of the normal PHPCS command line arguments in the command:
   # https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p . --standard=WordPress; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs -p . --standard=WordPress; fi
 ```
 
 

--- a/Test/AllTests.php
+++ b/Test/AllTests.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * A test class for running all PHP_CodeSniffer unit tests.
+ *
+ * PHP version 5
+ *
+ * {@internal WPCS: File copied from PHPCS 2.x to overload one method.}}
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/* Start of WPCS adjustment */
+namespace WordPressCS\Test;
+
+use WordPressCS\Test\AllSniffs;
+use PHP_CodeSniffer_AllTests;
+use PHP_CodeSniffer_TestSuite;
+/* End of WPCS adjustment */
+
+/**
+ * A test class for running all PHP_CodeSniffer unit tests.
+ *
+ * Usage: phpunit AllTests.php
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class AllTests extends PHP_CodeSniffer_AllTests {
+
+    /**
+     * Add all PHP_CodeSniffer test suites into a single test suite.
+     *
+     * @return PHPUnit_Framework_TestSuite
+     */
+    public static function suite()
+    {
+        $GLOBALS['PHP_CODESNIFFER_STANDARD_DIRS'] = array();
+
+        // Use a special PHP_CodeSniffer test suite so that we can
+        // unset our autoload function after the run.
+        $suite = new PHP_CodeSniffer_TestSuite('PHP CodeSniffer');
+
+        /* Start of WPCS adjustment */
+        // We need to point to the WPCS version of the referenced class
+        // and we may as well bypass the loading of the PHPCS core unit tests
+        // while we're at it too.
+        $suite->addTest(AllSniffs::suite());
+        /* End of WPCS adjustment */
+
+        // Unregister this here because the PEAR tester loads
+        // all package suites before running then, so our autoloader
+        // will cause problems for the packages included after us.
+        spl_autoload_unregister(array('PHP_CodeSniffer', 'autoload'));
+
+        return $suite;
+
+    }//end suite()
+
+
+}//end class

--- a/Test/Standards/AbstractSniffUnitTest.php
+++ b/Test/Standards/AbstractSniffUnitTest.php
@@ -1,0 +1,460 @@
+<?php
+/**
+ * An abstract class that all sniff unit tests must extend.
+ *
+ * PHP version 5
+ *
+ * {@internal WPCS: File copied from PHPCS 2.x to adjust one method.
+ * Unfortunately as the method is originally declared as `final`,
+ * we need the whole class.}}
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/* Start of WPCS adjustment */
+namespace WordPressCS\Test;
+
+use PHP_CodeSniffer;
+use PHP_CodeSniffer_File;
+use PHP_CodeSniffer_Exception;
+use PHPUnit_Framework_TestCase;
+use DirectoryIterator;
+/* End of WPCS adjustment */
+
+/**
+ * An abstract class that all sniff unit tests must extend.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings that are not found, or
+ * warnings and errors that are not expected, are considered test failures.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * Enable or disable the backup and restoration of the $GLOBALS array.
+     * Overwrite this attribute in a child class of TestCase.
+     * Setting this attribute in setUp() has no effect!
+     *
+     * @var boolean
+     */
+    protected $backupGlobals = false;
+
+    /**
+     * The PHP_CodeSniffer object used for testing.
+     *
+     * @var PHP_CodeSniffer
+     */
+    protected static $phpcs = null;
+
+    /**
+     * The path to the directory under which the sniff's standard lives.
+     *
+     * @var string
+     */
+    public $standardsDir = null;
+
+
+    /**
+     * Sets up this unit test.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        if (self::$phpcs === null) {
+            self::$phpcs = new PHP_CodeSniffer();
+        }
+
+        $class = get_class($this);
+        $this->standardsDir = $GLOBALS['PHP_CODESNIFFER_STANDARD_DIRS'][$class];
+
+    }//end setUp()
+
+
+    /**
+     * Get a list of all test files to check.
+     *
+     * These will have the same base as the sniff name but different extensions.
+     * We ignore the .php file as it is the class.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return string[]
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = array();
+
+        $dir = substr($testFileBase, 0, strrpos($testFileBase, DIRECTORY_SEPARATOR));
+        $di  = new DirectoryIterator($dir);
+
+        foreach ($di as $file) {
+            $path = $file->getPathname();
+            if (substr($path, 0, strlen($testFileBase)) === $testFileBase) {
+
+                /* Start of WPCS adjustment */
+                // If we're changing things anyway, we may as well exclude backup files
+                // from the test runs ;-)
+                if ($path !== $testFileBase.'php' && substr($path, -5) !== 'fixed'
+                    && substr($path, -3) !== 'bak' && substr($path, -4) !== 'orig'
+                ) {
+                    $testFiles[] = $path;
+                }
+                /* End of WPCS adjustment */
+            }
+        }
+
+        // Put them in order.
+        sort($testFiles);
+
+        return $testFiles;
+
+    }//end getTestFiles()
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Tests the extending classes Sniff class.
+     *
+     * @return void
+     * @throws PHPUnit_Framework_Error
+     */
+    public final function testSniff()
+    {
+        // Skip this test if we can't run in this environment.
+        if ($this->shouldSkipTest() === true) {
+            $this->markTestSkipped();
+        }
+
+        // The basis for determining file locations.
+        $basename = substr(get_class($this), 0, -8);
+
+        /* Start of WPCS adjustment */
+        // Support the use of PHP namespaces.
+        if (strpos($basename, '\\') !== false) {
+            $basename = str_replace('\\', '_', $basename);
+        }
+        /* End of WPCS adjustment */
+
+        // The name of the coding standard we are testing.
+        $standardName = substr($basename, 0, strpos($basename, '_'));
+
+        // The code of the sniff we are testing.
+        $parts     = explode('_', $basename);
+        $sniffCode = $parts[0].'.'.$parts[2].'.'.$parts[3];
+
+        $testFileBase = $this->standardsDir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $basename).'UnitTest.';
+
+        // Get a list of all test files to check.
+        $testFiles = $this->getTestFiles($testFileBase);
+
+        self::$phpcs->initStandard($standardName, array($sniffCode));
+        self::$phpcs->setIgnorePatterns(array());
+
+        $failureMessages = array();
+        foreach ($testFiles as $testFile) {
+            $filename = basename($testFile);
+
+            try {
+                $cliValues = $this->getCliValues($filename);
+                self::$phpcs->cli->setCommandLineValues($cliValues);
+                $phpcsFile = self::$phpcs->processFile($testFile);
+            } catch (Exception $e) {
+                $this->fail('An unexpected exception has been caught: '.$e->getMessage());
+            }
+
+            $failures        = $this->generateFailureMessages($phpcsFile);
+            $failureMessages = array_merge($failureMessages, $failures);
+
+            if ($phpcsFile->getFixableCount() > 0) {
+                // Attempt to fix the errors.
+                $phpcsFile->fixer->fixFile();
+                $fixable = $phpcsFile->getFixableCount();
+                if ($fixable > 0) {
+                    $failureMessages[] = "Failed to fix $fixable fixable violations in $filename";
+                }
+
+                // Check for a .fixed file to check for accuracy of fixes.
+                $fixedFile = $testFile.'.fixed';
+                if (file_exists($fixedFile) === true) {
+                    $diff = $phpcsFile->fixer->generateDiff($fixedFile);
+                    if (trim($diff) !== '') {
+                        $filename          = basename($testFile);
+                        $fixedFilename     = basename($fixedFile);
+                        $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
+                    }
+                }
+            }
+        }//end foreach
+
+        if (empty($failureMessages) === false) {
+            $this->fail(implode(PHP_EOL, $failureMessages));
+        }
+
+    }//end runTest()
+
+
+    /**
+     * Generate a list of test failures for a given sniffed file.
+     *
+     * @param PHP_CodeSniffer_File $file The file being tested.
+     *
+     * @return array
+     * @throws PHP_CodeSniffer_Exception
+     */
+    public function generateFailureMessages(PHP_CodeSniffer_File $file)
+    {
+        $testFile = $file->getFilename();
+
+        $foundErrors      = $file->getErrors();
+        $foundWarnings    = $file->getWarnings();
+        $expectedErrors   = $this->getErrorList(basename($testFile));
+        $expectedWarnings = $this->getWarningList(basename($testFile));
+
+        if (is_array($expectedErrors) === false) {
+            throw new PHP_CodeSniffer_Exception('getErrorList() must return an array');
+        }
+
+        if (is_array($expectedWarnings) === false) {
+            throw new PHP_CodeSniffer_Exception('getWarningList() must return an array');
+        }
+
+        /*
+            We merge errors and warnings together to make it easier
+            to iterate over them and produce the errors string. In this way,
+            we can report on errors and warnings in the same line even though
+            it's not really structured to allow that.
+        */
+
+        $allProblems     = array();
+        $failureMessages = array();
+
+        foreach ($foundErrors as $line => $lineErrors) {
+            foreach ($lineErrors as $column => $errors) {
+                if (isset($allProblems[$line]) === false) {
+                    $allProblems[$line] = array(
+                                           'expected_errors'   => 0,
+                                           'expected_warnings' => 0,
+                                           'found_errors'      => array(),
+                                           'found_warnings'    => array(),
+                                          );
+                }
+
+                $foundErrorsTemp = array();
+                foreach ($allProblems[$line]['found_errors'] as $foundError) {
+                    $foundErrorsTemp[] = $foundError;
+                }
+
+                $errorsTemp = array();
+                foreach ($errors as $foundError) {
+                    $errorsTemp[] = $foundError['message'].' ('.$foundError['source'].')';
+
+                    $source = $foundError['source'];
+                    if (in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']) === false) {
+                        $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'][] = $source;
+                    }
+
+                    if ($foundError['fixable'] === true
+                        && in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']) === false
+                    ) {
+                        $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'][] = $source;
+                    }
+                }
+
+                $allProblems[$line]['found_errors'] = array_merge($foundErrorsTemp, $errorsTemp);
+            }//end foreach
+
+            if (isset($expectedErrors[$line]) === true) {
+                $allProblems[$line]['expected_errors'] = $expectedErrors[$line];
+            } else {
+                $allProblems[$line]['expected_errors'] = 0;
+            }
+
+            unset($expectedErrors[$line]);
+        }//end foreach
+
+        foreach ($expectedErrors as $line => $numErrors) {
+            if (isset($allProblems[$line]) === false) {
+                $allProblems[$line] = array(
+                                       'expected_errors'   => 0,
+                                       'expected_warnings' => 0,
+                                       'found_errors'      => array(),
+                                       'found_warnings'    => array(),
+                                      );
+            }
+
+            $allProblems[$line]['expected_errors'] = $numErrors;
+        }
+
+        foreach ($foundWarnings as $line => $lineWarnings) {
+            foreach ($lineWarnings as $column => $warnings) {
+                if (isset($allProblems[$line]) === false) {
+                    $allProblems[$line] = array(
+                                           'expected_errors'   => 0,
+                                           'expected_warnings' => 0,
+                                           'found_errors'      => array(),
+                                           'found_warnings'    => array(),
+                                          );
+                }
+
+                $foundWarningsTemp = array();
+                foreach ($allProblems[$line]['found_warnings'] as $foundWarning) {
+                    $foundWarningsTemp[] = $foundWarning;
+                }
+
+                $warningsTemp = array();
+                foreach ($warnings as $warning) {
+                    $warningsTemp[] = $warning['message'].' ('.$warning['source'].')';
+                }
+
+                $allProblems[$line]['found_warnings'] = array_merge($foundWarningsTemp, $warningsTemp);
+            }//end foreach
+
+            if (isset($expectedWarnings[$line]) === true) {
+                $allProblems[$line]['expected_warnings'] = $expectedWarnings[$line];
+            } else {
+                $allProblems[$line]['expected_warnings'] = 0;
+            }
+
+            unset($expectedWarnings[$line]);
+        }//end foreach
+
+        foreach ($expectedWarnings as $line => $numWarnings) {
+            if (isset($allProblems[$line]) === false) {
+                $allProblems[$line] = array(
+                                       'expected_errors'   => 0,
+                                       'expected_warnings' => 0,
+                                       'found_errors'      => array(),
+                                       'found_warnings'    => array(),
+                                      );
+            }
+
+            $allProblems[$line]['expected_warnings'] = $numWarnings;
+        }
+
+        // Order the messages by line number.
+        ksort($allProblems);
+
+        foreach ($allProblems as $line => $problems) {
+            $numErrors        = count($problems['found_errors']);
+            $numWarnings      = count($problems['found_warnings']);
+            $expectedErrors   = $problems['expected_errors'];
+            $expectedWarnings = $problems['expected_warnings'];
+
+            $errors      = '';
+            $foundString = '';
+
+            if ($expectedErrors !== $numErrors || $expectedWarnings !== $numWarnings) {
+                $lineMessage     = "[LINE $line]";
+                $expectedMessage = 'Expected ';
+                $foundMessage    = 'in '.basename($testFile).' but found ';
+
+                if ($expectedErrors !== $numErrors) {
+                    $expectedMessage .= "$expectedErrors error(s)";
+                    $foundMessage    .= "$numErrors error(s)";
+                    if ($numErrors !== 0) {
+                        $foundString .= 'error(s)';
+                        $errors      .= implode(PHP_EOL.' -> ', $problems['found_errors']);
+                    }
+
+                    if ($expectedWarnings !== $numWarnings) {
+                        $expectedMessage .= ' and ';
+                        $foundMessage    .= ' and ';
+                        if ($numWarnings !== 0) {
+                            if ($foundString !== '') {
+                                $foundString .= ' and ';
+                            }
+                        }
+                    }
+                }
+
+                if ($expectedWarnings !== $numWarnings) {
+                    $expectedMessage .= "$expectedWarnings warning(s)";
+                    $foundMessage    .= "$numWarnings warning(s)";
+                    if ($numWarnings !== 0) {
+                        $foundString .= 'warning(s)';
+                        if (empty($errors) === false) {
+                            $errors .= PHP_EOL.' -> ';
+                        }
+
+                        $errors .= implode(PHP_EOL.' -> ', $problems['found_warnings']);
+                    }
+                }
+
+                $fullMessage = "$lineMessage $expectedMessage $foundMessage.";
+                if ($errors !== '') {
+                    $fullMessage .= " The $foundString found were:".PHP_EOL." -> $errors";
+                }
+
+                $failureMessages[] = $fullMessage;
+            }//end if
+        }//end foreach
+
+        return $failureMessages;
+
+    }//end generateFailureMessages()
+
+
+    /**
+     * Get a list of CLI values to set before the file is tested.
+     *
+     * @param string $filename The name of the file being tested.
+     *
+     * @return array
+     */
+    public function getCliValues($filename)
+    {
+        return array();
+
+    }//end getCliValues()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    protected abstract function getErrorList();
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    protected abstract function getWarningList();
+
+
+}//end class

--- a/Test/Standards/AllSniffs.php
+++ b/Test/Standards/AllSniffs.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * A test class for testing all sniffs for installed standards.
+ *
+ * PHP version 5
+ *
+ * {@internal WPCS: File copied from PHPCS 2.x to overload one method.}}
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/* Start of WPCS adjustment */
+namespace WordPressCS\Test;
+
+use PHP_CodeSniffer_Standards_AllSniffs;
+use PHP_CodeSniffer;
+use PHPUnit_Framework_TestSuite;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+/* End of WPCS adjustment */
+
+/**
+ * A test class for testing all sniffs for installed standards.
+ *
+ * Usage: phpunit AllSniffs.php
+ *
+ * This test class loads all unit tests for all installed standards into a
+ * single test suite and runs them. Errors are reported on the command line.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
+{
+
+    /**
+     * Add all sniff unit tests into a test suite.
+     *
+     * Sniff unit tests are found by recursing through the 'Tests' directory
+     * of each installed coding standard.
+     *
+     * @return PHPUnit_Framework_TestSuite
+     */
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('PHP CodeSniffer Standards');
+
+        /* Start of WPCS adjustment */
+        // Set the correct path to PHPCS.
+        $isInstalled = !is_file(PHPCS_DIR.'/CodeSniffer.php');
+        /* End of WPCS adjustment */
+
+        // Optionally allow for ignoring the tests for one or more standards.
+        $ignoreTestsForStandards = getenv('PHPCS_IGNORE_TESTS');
+        if ($ignoreTestsForStandards === false) {
+            $ignoreTestsForStandards = array();
+        } else {
+            $ignoreTestsForStandards = explode(',', $ignoreTestsForStandards);
+        }
+
+        $installedPaths = PHP_CodeSniffer::getInstalledStandardPaths();
+        foreach ($installedPaths as $path) {
+            $path      = realpath($path);
+            $origPath  = $path;
+            $standards = PHP_CodeSniffer::getInstalledStandards(true, $path);
+
+            // If the test is running PEAR installed, the built-in standards
+            // are split into different directories; one for the sniffs and
+            // a different file system location for tests.
+            if ($isInstalled === true
+                && is_dir($path.DIRECTORY_SEPARATOR.'Generic') === true
+            ) {
+                $path = dirname(__FILE__);
+            }
+
+            foreach ($standards as $standard) {
+                if (in_array($standard, $ignoreTestsForStandards, true)) {
+                    continue;
+                }
+
+                $testsDir = $path.DIRECTORY_SEPARATOR.$standard.DIRECTORY_SEPARATOR.'Tests'.DIRECTORY_SEPARATOR;
+
+                if (is_dir($testsDir) === false) {
+                    // No tests for this standard.
+                    continue;
+                }
+
+                $di = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($testsDir));
+
+                foreach ($di as $file) {
+                    // Skip hidden files.
+                    if (substr($file->getFilename(), 0, 1) === '.') {
+                        continue;
+                    }
+
+                    // Tests must have the extension 'php'.
+                    $parts = explode('.', $file);
+                    $ext   = array_pop($parts);
+                    if ($ext !== 'php') {
+                        continue;
+                    }
+
+                    $filePath  = $file->getPathname();
+                    $className = str_replace($path.DIRECTORY_SEPARATOR, '', $filePath);
+                    $className = substr($className, 0, -4);
+                    $className = str_replace(DIRECTORY_SEPARATOR, '_', $className);
+
+                    // Include the sniff here so tests can use it in their setup() methods.
+                    $parts = explode('_', $className);
+                    if (isset($parts[0],$parts[2],$parts[3]) === true) {
+                        $sniffPath = $origPath.DIRECTORY_SEPARATOR.$parts[0].DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR.$parts[2].DIRECTORY_SEPARATOR.$parts[3];
+                        $sniffPath = substr($sniffPath, 0, -8).'Sniff.php';
+
+                        if (file_exists($sniffPath) === true) {
+                            include_once $sniffPath;
+                            include_once $filePath;
+
+                            /* Start of WPCS adjustment */
+                            // Support the use of PHP namespaces. If the class name we included
+                            // contains namespace separators instead of underscores, use this as the
+                            // class name from now on.
+                            $classNameNS = str_replace('_', '\\', $className);
+                            if (class_exists($classNameNS, false) === true) {
+                                $className = $classNameNS;
+                            }
+                            /* End of WPCS adjustment */
+
+                            $GLOBALS['PHP_CODESNIFFER_STANDARD_DIRS'][$className] = $path;
+                            $suite->addTestSuite($className);
+                        } else {
+                            self::$orphanedTests[] = $filePath;
+                        }
+                    } else {
+                        self::$orphanedTests[] = $filePath;
+                    }
+                }//end foreach
+            }//end foreach
+        }//end foreach
+
+        return $suite;
+
+    }//end suite()
+
+
+}//end class

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Bootstrap file for tests.
+ *
+ * Load either the PHPCS 2.x or 3.x bootstrap file depending on an environment variable.
+ *
+ * This file is intended for use with Travis where the environment variable
+ * will be available.
+ *
+ * For running the unit tests manually, see the instructions below and in
+ * the CONTRIBUTING.MD document.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   0.13.0
+ */
+
+// Get the PHPCS BRANCH used from an environment variable.
+$phpcs_branch = getenv( 'PHPCS_BRANCH' );
+
+if ( false === $phpcs_branch ) {
+	echo 'To manually run the unit tests you need to use either of the following commands:
+	
+For running the unit tests with PHPCS 3.x:
+phpunit --bootstrap="./Test/phpcs3-bootstrap.php" --filter WordPress /path/to/PHP_CodeSniffer/tests/AllTests.php
+
+For running the unit tests with PHPCS 2.x:
+phpunit --bootstrap="./Test/phpcs2-bootstrap.php" --filter WordPress ./Test/AllTests.php
+
+Please read the contributors guidelines for more information:
+https://is.gd/WPCScontributing
+';
+
+	die( 1 );
+}
+
+if ( '2' !== $phpcs_branch[0] ) {
+	include __DIR__ . DIRECTORY_SEPARATOR . 'phpcs3-bootstrap.php';
+} else {
+	include __DIR__ . DIRECTORY_SEPARATOR . 'phpcs2-bootstrap.php';
+}

--- a/Test/phpcs2-bootstrap.php
+++ b/Test/phpcs2-bootstrap.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Bootstrap file for running the tests on PHPCS 2.x.
+ *
+ * Load the PHPCS test classes and the WPCS ones.
+ *
+ * {@internal The PHPCS 2.x test classes do not allow for namespaced unit
+ * test classes. Some small changes to the classes change that which
+ * is why we'll be using our own versions of some files.}}
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   0.13.0
+ */
+
+$ds = DIRECTORY_SEPARATOR;
+
+// Get the PHPCS dir from an environment variable.
+$phpcsDir = getenv( 'PHPCS_DIR' );
+
+if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer' ) ) {
+	$phpcsDir  = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+} else if ( false !== $phpcsDir ) {
+	$phpcsDir = realpath( $phpcsDir );
+}
+
+if ( false === $phpcsDir || ! is_dir( $phpcsDir . $ds . 'CodeSniffer' )
+	|| ! file_exists( $phpcsDir . $ds . 'tests' . $ds . 'AllTests.php' )
+) {
+	echo 'Uh oh... can\'t find PHPCS. Are you sure you are using PHPCS 2.x ?
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+
+Please read the contributors guidelines for more information:
+https://is.gd/WPCScontributing
+';
+
+	die( 1 );
+} else {
+	define( 'PHPCS_DIR', $phpcsDir );
+}
+
+// Load the PHPCS test classes and the WPCS versions where necessary.
+include_once PHPCS_DIR . $ds . 'tests' . $ds . 'AllTests.php';
+include_once __DIR__ . $ds . 'Standards' . $ds . 'AllSniffs.php';
+include_once __DIR__ . $ds . 'Standards' . $ds . 'AbstractSniffUnitTest.php';
+
+class_alias( 'WordPressCS\Test\AbstractSniffUnitTest', 'PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest' );
+
+unset( $ds, $phpcsDir );

--- a/Test/phpcs3-bootstrap.php
+++ b/Test/phpcs3-bootstrap.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bootstrap file for running the tests on PHPCS 3.x.
+ *
+ * Load the PHPCS autoloader and the WPCS PHPCS cross-version helpers.
+ *
+ * {@internal We need to load the PHPCS autoloader first, so as to allow their
+ * auto-loader to find the classes we want to alias for PHPCS 3.x.
+ * This aliasing has to be done before any of the test classes are loaded by the
+ * PHPCS native unit test suite to prevent fatal errors.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   0.13.0
+ */
+
+if ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+	define( 'PHP_CODESNIFFER_IN_TESTS', true );
+}
+
+$ds = DIRECTORY_SEPARATOR;
+
+// Get the PHPCS dir from an environment variable.
+$phpcsDir = getenv( 'PHPCS_DIR' );
+
+// This may be a Composer install.
+if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer' ) ) {
+	$phpcsDir  = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+} else if ( false !== $phpcsDir ) {
+	$phpcsDir = realpath( $phpcsDir );
+}
+
+// Try and load the PHPCS autoloader.
+if ( false !== $phpcsDir && file_exists( $phpcsDir . $ds . 'autoload.php' ) ) {
+	require_once $phpcsDir . $ds . 'autoload.php';
+} else {
+	echo 'Uh oh... can\'t find PHPCS. Are you sure you are using PHPCS 3.x ?
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+
+Please read the contributors guidelines for more information:
+https://is.gd/WPCScontributing
+';
+
+	die( 1 );
+}
+
+// Load our class aliases.
+include_once dirname( __DIR__ ) . $ds . 'WordPress' . $ds . 'PHPCSAliases.php';
+unset( $ds, $phpcsDir );
+
+/*
+ * Register our own autoloader for the WPCS abstract classes & the helper class.
+ *
+ * This can be removed once the minimum required version of WPCS for the
+ * PHPCS 3.x branch has gone up to 3.1.0 (unreleased as of yet).
+ *
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564
+ */
+spl_autoload_register( function ( $class ) {
+	// Only try & load our own classes.
+	if ( stripos( $class, 'WordPress' ) !== 0 ) {
+		return;
+	}
+
+	// PHPCS handles the Test and Sniff classes without problem.
+	if ( stripos( $class, '\Tests\\' ) !== false || stripos( $class, '\Sniffs\\' ) !== false ) {
+		return;
+	}
+
+	$file = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . strtr( $class, '\\', DIRECTORY_SEPARATOR ) . '.php';
+
+	if ( file_exists( $file ) ) {
+		include_once $file;
+	}
+} );

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -2,6 +2,8 @@
 <ruleset name="WordPress Core">
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
 	<!-- Treat all files as UTF-8. -->
 	<config name="encoding" value="utf-8"/>
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -2,6 +2,8 @@
 <ruleset name="WordPress Extra">
 	<description>Best practices beyond core WordPress Coding Standards</description>
 
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
 	<!-- Generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -2,6 +2,8 @@
 <ruleset name="WordPress VIP">
 	<description>WordPress VIP Coding Standards</description>
 
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
 	<rule ref="WordPress-Core"/>
 
 	<!-- Covers:

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
+use WordPress\Sniff;
+
 /**
  * Restricts array assignment of certain keys.
  *
@@ -18,7 +22,7 @@
  *                 `WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff` to
  *                 `WordPress_AbstractArrayAssignmentRestrictionsSniff`.
  */
-abstract class WordPress_AbstractArrayAssignmentRestrictionsSniff extends WordPress_Sniff {
+abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 	/**
 	 * Exclude groups.

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restricts usage of some classes.
  *
@@ -14,7 +18,7 @@
  *
  * @since   0.10.0
  */
-abstract class WordPress_AbstractClassRestrictionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Regex pattern with placeholder for the class names.

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Advises about parameters used in function calls.
  *
@@ -14,7 +18,7 @@
  *
  * @since   0.11.0
  */
-abstract class WordPress_AbstractFunctionParameterSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
+use WordPress\Sniff;
+
 /**
  * Restricts usage of some functions.
  *
@@ -19,7 +23,7 @@
  *                 `WordPress_AbstractFunctionRestrictionsSniff`.
  * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-abstract class WordPress_AbstractFunctionRestrictionsSniff extends WordPress_Sniff {
+abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 
 	/**
 	 * Exclude groups.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Restricts usage of some functions.
@@ -210,7 +211,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 
 		// Exclude function definitions, class methods, and namespaced calls.
 		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
-			$prev = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 			if ( false !== $prev ) {
 				// Skip sniffing if calling a same-named method, or on function definitions.
@@ -226,7 +227,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 
 				// Skip namespaced functions, ie: \foo\bar() not \bar().
 				if ( T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
-					$pprev = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $prev - 1 ), null, true );
+					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
 					if ( false !== $pprev && T_STRING === $this->tokens[ $pprev ]['code'] ) {
 						return false;
 					}

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
+use WordPress\Sniff;
+
 /**
  * Restricts usage of some variables.
  *
@@ -19,7 +23,7 @@
  *                 `WordPress_AbstractVariableRestrictionsSniff`.
  * @since   0.11.0 Extends the WordPress_Sniff class.
  */
-abstract class WordPress_AbstractVariableRestrictionsSniff extends WordPress_Sniff {
+abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 	/**
 	 * Exclude groups.

--- a/WordPress/PHPCSAliases.php
+++ b/WordPress/PHPCSAliases.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   0.13.0
+ */
+
+/*
+ * Alias a number of PHPCS 3.x classes to their PHPCS 2.x equivalents.
+ *
+ * This file is auto-loaded by PHPCS 3.x before any sniffs are loaded
+ * through the PHPCS 3.x `<autoload>` ruleset directive.
+ *
+ * {@internal The PHPCS files have been reorganized in PHPCS 3.x, quite
+ * a few "old" classes have been split and spread out over several "new"
+ * classes. In other words, this will only work for a limited number
+ * of classes.}}
+ *
+ * {@internal The `class_exists` wrappers are needed to play nice with other
+ * external PHPCS standards creating cross-version compatibility in the same
+ * manner.}}
+ */
+if ( ! defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
+	// PHPCS base classes/interface.
+	if ( ! interface_exists( '\PHP_CodeSniffer_File' ) ) {
+		class_alias( 'PHP_CodeSniffer\Files\File', '\PHP_CodeSniffer_File' );
+	}
+	if ( ! class_exists( '\PHP_CodeSniffer_Tokens' ) ) {
+		class_alias( 'PHP_CodeSniffer\Util\Tokens', '\PHP_CodeSniffer_Tokens' );
+	}
+	if ( ! class_exists( '\PHP_CodeSniffer_Sniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff' );
+	}
+
+	// PHPCS classes which are being extended by WPCS sniffs.
+	if ( ! class_exists( '\PHP_CodeSniffer_Standards_AbstractVariableSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Sniffs\AbstractVariableSniff', '\PHP_CodeSniffer_Standards_AbstractVariableSniff' );
+	}
+	if ( ! class_exists( '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff', '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff' );
+	}
+	if ( ! class_exists( '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff', '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' );
+	}
+
+	define( 'WPCS_PHPCS_ALIASES_SET', true );
+}

--- a/WordPress/PHPCSHelper.php
+++ b/WordPress/PHPCSHelper.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper class.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use PHP_CodeSniffer_File as File;
+
+/**
+ * PHPCSHelper
+ *
+ * PHPCS cross-version compatibility helper class.
+ *
+ * Deals with files which cannot be aliased 1-on-1 as the original
+ * class was split up into several classes.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.13.0
+ */
+class PHPCSHelper {
+
+	/**
+	 * Get the PHPCS version number.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return string
+	 */
+	public static function get_version() {
+		if ( defined( '\PHP_CodeSniffer\Config::VERSION' ) ) {
+			// PHPCS 3.x.
+			return \PHP_CodeSniffer\Config::VERSION;
+		} else {
+			// PHPCS 2.x.
+			return \PHP_CodeSniffer::VERSION;
+		}
+	}
+
+	/**
+	 * Pass config data to PHPCS.
+	 *
+	 * PHPCS cross-version compatibility helper.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param string      $key   The name of the config value.
+	 * @param string|null $value The value to set. If null, the config entry
+	 *                           is deleted, reverting it to the default value.
+	 * @param boolean     $temp  Set this config data temporarily for this script run.
+	 *                           This will not write the config data to the config file.
+	 */
+	public static function set_config_data( $key, $value, $temp = false ) {
+		if ( method_exists( '\PHP_CodeSniffer\Config', 'setConfigData' ) ) {
+			// PHPCS 3.x.
+			\PHP_CodeSniffer\Config::setConfigData( $key, $value, $temp );
+		} else {
+			// PHPCS 2.x.
+			\PHP_CodeSniffer::setConfigData( $key, $value, $temp );
+		}
+	}
+
+	/**
+	 * Get the value of a single PHPCS config key.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param string $key The name of the config value.
+	 *
+	 * @return string|null
+	 */
+	public static function get_config_data( $key ) {
+		if ( method_exists( '\PHP_CodeSniffer\Config', 'getConfigData' ) ) {
+			// PHPCS 3.x.
+			return \PHP_CodeSniffer\Config::getConfigData( $key );
+		} else {
+			// PHPCS 2.x.
+			return \PHP_CodeSniffer::getConfigData( $key );
+		}
+	}
+
+	/**
+	 * Get the tab width as passed to PHPCS from the command-line or the ruleset.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 *
+	 * @return int Tab width. Defaults to 4.
+	 */
+	public static function get_tab_width( File $phpcsFile ) {
+		$tab_width = 4;
+
+		if ( class_exists( '\PHP_CodeSniffer\Config' ) ) {
+			// PHPCS 3.x.
+			if ( isset( $phpcsFile->config->tabWidth ) && $phpcsFile->config->tabWidth > 0 ) {
+				$tab_width = $phpcsFile->config->tabWidth;
+			}
+		} else {
+			// PHPCS 2.x.
+			$cli_values = $phpcsFile->phpcs->cli->getCommandLineValues();
+			if ( isset( $cli_values['tabWidth'] ) && $cli_values['tabWidth'] > 0 ) {
+				$tab_width = $cli_values['tabWidth'];
+			}
+		}
+
+		return $tab_width;
+	}
+
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -7,6 +7,8 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress;
+
 /**
  * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
  *
@@ -26,7 +28,7 @@
  *            In the rare few cases where the array values *do* have meaning, this
  *            is documented in the property documentation.}}
  */
-abstract class WordPress_Sniff implements PHP_CodeSniffer_Sniff {
+abstract class Sniff implements PHP_CodeSniffer_Sniff {
 
 	/**
 	 * List of the functions which verify nonces.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -9,6 +9,10 @@
 
 namespace WordPress;
 
+use PHP_CodeSniffer_Sniff as PHPCS_Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
 /**
  * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
  *
@@ -28,7 +32,7 @@ namespace WordPress;
  *            In the rare few cases where the array values *do* have meaning, this
  *            is documented in the property documentation.}}
  */
-abstract class Sniff implements PHP_CodeSniffer_Sniff {
+abstract class Sniff implements PHPCS_Sniff {
 
 	/**
 	 * List of the functions which verify nonces.
@@ -798,7 +802,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @since 0.4.0
 	 *
-	 * @var PHP_CodeSniffer_File
+	 * @var \PHP_CodeSniffer\Files\File
 	 */
 	protected $phpcsFile;
 
@@ -816,14 +820,14 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @since 0.11.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token
-	 *                                        in the stack passed in $tokens.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$this->init( $phpcsFile );
 		return $this->process_token( $stackPtr );
 	}
@@ -848,9 +852,9 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file currently being processed.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file currently being processed.
 	 */
-	protected function init( PHP_CodeSniffer_File $phpcsFile ) {
+	protected function init( File $phpcsFile ) {
 		$this->phpcsFile = $phpcsFile;
 		$this->tokens    = $phpcsFile->getTokens();
 	}
@@ -1200,7 +1204,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		$next_non_empty = $this->phpcsFile->findNext(
-			PHP_CodeSniffer_Tokens::$emptyTokens
+			Tokens::$emptyTokens
 			, ( $stackPtr + 1 )
 			, null
 			, true
@@ -1214,7 +1218,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		// If the next token is an assignment, that's all we need to know.
-		if ( isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+		if ( isset( Tokens::$assignmentTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
 			return true;
 		}
 
@@ -1394,7 +1398,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 
 		// Get the last non-empty token.
 		$prev = $this->phpcsFile->findPrevious(
-			PHP_CodeSniffer_Tokens::$emptyTokens
+			Tokens::$emptyTokens
 			, ( $stackPtr - 1 )
 			, null
 			, true
@@ -1481,7 +1485,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 				 * to resolve the function name, do so.
 				 */
 				$first_non_empty = $this->phpcsFile->findNext(
-					PHP_CodeSniffer_Tokens::$emptyTokens,
+					Tokens::$emptyTokens,
 					$callback['start'],
 					( $callback['end'] + 1 ),
 					true
@@ -1538,7 +1542,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 
 		// Find the next non-empty token.
 		$open_bracket = $this->phpcsFile->findNext(
-			PHP_CodeSniffer_Tokens::$emptyTokens,
+			Tokens::$emptyTokens,
 			( $stackPtr + 1 ),
 			null,
 			true
@@ -1704,19 +1708,19 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 		// Find the previous non-empty token. We check before the var first because
 		// yoda conditions are usually expected.
 		$previous_token = $this->phpcsFile->findPrevious(
-			PHP_CodeSniffer_Tokens::$emptyTokens,
+			Tokens::$emptyTokens,
 			( $stackPtr - 1 ),
 			null,
 			true
 		);
 
-		if ( isset( PHP_CodeSniffer_Tokens::$comparisonTokens[ $this->tokens[ $previous_token ]['code'] ] ) ) {
+		if ( isset( Tokens::$comparisonTokens[ $this->tokens[ $previous_token ]['code'] ] ) ) {
 			return true;
 		}
 
 		// Maybe the comparison operator is after this.
 		$next_token = $this->phpcsFile->findNext(
-			PHP_CodeSniffer_Tokens::$emptyTokens,
+			Tokens::$emptyTokens,
 			( $stackPtr + 1 ),
 			null,
 			true
@@ -1726,14 +1730,14 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 		while ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_token ]['code'] ) {
 
 			$next_token = $this->phpcsFile->findNext(
-				PHP_CodeSniffer_Tokens::$emptyTokens,
+				Tokens::$emptyTokens,
 				( $this->tokens[ $next_token ]['bracket_closer'] + 1 ),
 				null,
 				true
 			);
 		}
 
-		if ( isset( PHP_CodeSniffer_Tokens::$comparisonTokens[ $this->tokens[ $next_token ]['code'] ] ) ) {
+		if ( isset( Tokens::$comparisonTokens[ $this->tokens[ $next_token ]['code'] ] ) ) {
 			return true;
 		}
 
@@ -1829,7 +1833,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 			return false;
 		}
 
-		$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 
 		// Deal with short array syntax.
 		if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $stackPtr ]['type'] ) {
@@ -1856,7 +1860,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 		}
 
 		$close_parenthesis   = $this->tokens[ $next_non_empty ]['parenthesis_closer'];
-		$next_next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), ( $close_parenthesis + 1 ), true );
+		$next_next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), ( $close_parenthesis + 1 ), true );
 
 		if ( $next_next_non_empty === $close_parenthesis ) {
 			// No parameters.
@@ -1932,7 +1936,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 
 			$nestedParenthesisCount = 0;
 		} else {
-			$opener = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+			$opener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 			$closer = $this->tokens[ $opener ]['parenthesis_closer'];
 
 			$nestedParenthesisCount = 1;
@@ -1982,7 +1986,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 			 * Prevents code like the following from setting a third parameter:
 			 * functionCall( $param1, $param2, );
 			 */
-			$has_next_param = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_comma + 1 ), $closer, true, null, true );
+			$has_next_param = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_comma + 1 ), $closer, true, null, true );
 			if ( false === $has_next_param ) {
 				break;
 			}
@@ -2154,7 +2158,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff {
 			return false;
 		}
 
-		$nextToken = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
 			// Declaration for global namespace when using multiple namespaces in a file.
 			// I.e.: `namespace {}`.

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -7,21 +7,27 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Restricts array assignment of certain keys.
  *
  * @package    WPCS\WordPressCodingStandards
  *
  * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
  * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
  *                    the WordPress_AbstractArrayAssignmentRestrictionsSniff class.
  *                    This class is left here to prevent backward-compatibility breaks for
  *                    custom sniffs extending the old class and references to this
  *                    sniff from custom phpcs.xml files.
  *                    This file is also still used to unit test the abstract class.
- * @see        WordPress_AbstractArrayAssignmentRestrictionsSniff
+ * @see        \WordPress\AbstractArrayAssignmentRestrictionsSniff
  */
-class WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
+class ArrayAssignmentRestrictionsSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -9,6 +9,8 @@
 
 namespace WordPress\Sniffs\Arrays;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * Enforces WordPress array format, based upon Squiz code.
  *
@@ -49,11 +51,11 @@ class ArrayDeclarationSniff {
 	 *
 	 * @deprecated 0.13.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile A PHP_CodeSniffer file.
-	 * @param int                  $stackPtr  The position of the token.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile A PHP_CodeSniffer file.
+	 * @param int                         $stackPtr  The position of the token.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {}
+	public function process( File $phpcsFile, $stackPtr ) {}
 
 } // End class.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -7,6 +7,8 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
 /**
  * Enforces WordPress array format, based upon Squiz code.
  *
@@ -19,6 +21,8 @@
  * @since      0.11.0 The additional single-line array checks have been moved to their own
  *                    sniff WordPress.Arrays.ArrayDeclarationSpacing.
  *                    This class now only contains a slimmed down version of the upstream sniff.
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
  * @deprecated 0.13.0 This sniff has now been deprecated. Most checks which were previously
  *                    contained herein had recently been excluded in favour of dedicated
  *                    sniffs with higher precision. The last remaining checks which were not
@@ -27,7 +31,7 @@
  *                    This class is left here to prevent breaking custom rulesets which refer
  *                    to this sniff.
  */
-class WordPress_Sniffs_Arrays_ArrayDeclarationSniff {
+class ArrayDeclarationSniff {
 
 	/**
 	 * Don't use.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Arrays;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces WordPress array spacing format.
@@ -219,7 +220,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 							 * interpreted as alignment whitespace.
 							 */
 							$first_non_empty = $this->phpcsFile->findNext(
-								PHP_CodeSniffer_Tokens::$emptyTokens,
+								Tokens::$emptyTokens,
 								$item['start'],
 								( $item['end'] + 1 ),
 								true

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
 /**
  * Enforces WordPress array spacing format.
  *
@@ -30,8 +34,9 @@
  * @since   0.13.0 Added the last remaining checks from the `ArrayDeclaration` sniff
  *                 which were not covered elsewhere. The `ArrayDeclaration` sniff has
  *                 now been deprecated.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Arrays_ArrayDeclarationSpacingSniff extends WordPress_Sniff {
+class ArrayDeclarationSpacingSniff extends Sniff {
 
 	/**
 	 * Token this sniff targets.

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
 /**
  * Enforces WordPress array indentation for multi-line arrays.
  *
@@ -15,11 +19,12 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * {@internal This sniff should eventually be pulled upstream as part of a solution
  * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}
  */
-class WordPress_Sniffs_Arrays_ArrayIndentationSniff extends WordPress_Sniff {
+class ArrayIndentationSniff extends Sniff {
 
 	/**
 	 * Should tabs be used for indenting?

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Arrays;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces WordPress array indentation for multi-line arrays.
@@ -69,7 +70,7 @@ class ArrayIndentationSniff extends Sniff {
 		 *
 		 * Existing heredoc, nowdoc and inline HTML indentation should be respected at all times.
 		 */
-		$this->ignore_tokens = PHP_CodeSniffer_Tokens::$heredocTokens;
+		$this->ignore_tokens = Tokens::$heredocTokens;
 		unset( $this->ignore_tokens[ T_START_HEREDOC ], $this->ignore_tokens[ T_START_NOWDOC ] );
 		$this->ignore_tokens[ T_INLINE_HTML ] = T_INLINE_HTML;
 

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Arrays;
 
 use WordPress\Sniff;
+use WordPress\PHPCSHelper;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -89,13 +90,7 @@ class ArrayIndentationSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( ! isset( $this->tab_width ) ) {
-			$cli_values = $this->phpcsFile->phpcs->cli->getCommandLineValues();
-			if ( ! isset( $cli_values['tabWidth'] ) || 0 === $cli_values['tabWidth'] ) {
-				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
-				$this->tab_width = 4;
-			} else {
-				$this->tab_width = $cli_values['tabWidth'];
-			}
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
 		}
 
 		/*

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
 /**
  * Check for proper spacing in array key references.
  *
@@ -17,8 +21,9 @@
  * @since   0.3.0
  * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
  * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Arrays_ArrayKeySpacingRestrictionsSniff extends WordPress_Sniff {
+class ArrayKeySpacingRestrictionsSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Arrays;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces a comma after each array item and the spacing around it.
@@ -114,7 +115,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 			}
 
 			$last_content = $this->phpcsFile->findPrevious(
-				PHP_CodeSniffer_Tokens::$emptyTokens,
+				Tokens::$emptyTokens,
 				$item['end'],
 				$item['start'],
 				true
@@ -155,7 +156,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 			if ( $last_content !== $item['end']
 				// Ignore whitespace at the end of a multi-line item if it is the end of a heredoc/nowdoc.
 				&& ( true === $single_line
-					|| ! isset( PHP_CodeSniffer_Tokens::$heredocTokens[ $this->tokens[ $last_content ]['code'] ] ) )
+					|| ! isset( Tokens::$heredocTokens[ $this->tokens[ $last_content ]['code'] ] ) )
 			) {
 				$newlines = 0;
 				$spaces   = 0;

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
 /**
  * Enforces a comma after each array item and the spacing around it.
  *
@@ -22,8 +26,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Arrays_CommaAfterArrayItemSniff extends WordPress_Sniff {
+class CommaAfterArrayItemSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\CSRF;
+
+use WordPress\Sniff;
+
 /**
  * Checks that nonce verification accompanies form processing.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.5.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_CSRF_NonceVerificationSniff extends WordPress_Sniff {
+class NonceVerificationSniff extends Sniff {
 
 	/**
 	 * Superglobals to notify about when not accompanied by an nonce check.

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -7,10 +7,13 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Classes;
+
+use WordPress\Sniff;
+
 /**
- * WordPress_Sniffs_Classes_ClassInstantiationSniff.
- *
  * Verifies object instantiation statements.
+ *
  * - Demand the use of parenthesis.
  * - Demand no space between the class name and the parenthesis.
  * - Forbid assigning new by reference.
@@ -21,8 +24,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Classes_ClassInstantiationSniff extends WordPress_Sniff {
+class ClassInstantiationSniff extends Sniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Classes;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Verifies object instantiation statements.
@@ -58,7 +59,7 @@ class ClassInstantiationSniff extends Sniff {
 		 *
 		 * Currently does not account for classnames passed as a variable variable.
 		 */
-		$this->classname_tokens                           = PHP_CodeSniffer_Tokens::$emptyTokens;
+		$this->classname_tokens                           = Tokens::$emptyTokens;
 		$this->classname_tokens[ T_NS_SEPARATOR ]         = T_NS_SEPARATOR;
 		$this->classname_tokens[ T_STRING ]               = T_STRING;
 		$this->classname_tokens[ T_SELF ]                 = T_SELF;
@@ -100,7 +101,7 @@ class ClassInstantiationSniff extends Sniff {
 		 */
 		if ( 'PHP' === $this->phpcsFile->tokenizerType ) {
 			$prev_non_empty = $this->phpcsFile->findPrevious(
-				PHP_CodeSniffer_Tokens::$emptyTokens,
+				Tokens::$emptyTokens,
 				($stackPtr - 1),
 				null,
 				true
@@ -139,7 +140,7 @@ class ClassInstantiationSniff extends Sniff {
 		// Walk back to the last part of the class name.
 		$has_comment = false;
 		for ( $classname_ptr = ( $next_non_empty_after_class_name - 1 ); $classname_ptr >= $stackPtr; $classname_ptr-- ) {
-			if ( ! isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $classname_ptr ]['code'] ] ) ) {
+			if ( ! isset( Tokens::$emptyTokens[ $this->tokens[ $classname_ptr ]['code'] ] ) ) {
 				// Prevent a false positive on variable variables, disregard them for now.
 				if ( $stackPtr === $classname_ptr ) {
 					return;

--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\CodeAnalysis;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Checks against empty statements.
@@ -57,7 +58,7 @@ class EmptyStatementSniff extends Sniff {
 			 */
 			case 'T_SEMICOLON':
 				$prevNonEmpty = $this->phpcsFile->findPrevious(
-					PHP_CodeSniffer_Tokens::$emptyTokens,
+					Tokens::$emptyTokens,
 					( $stackPtr - 1 ),
 					null,
 					true

--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\CodeAnalysis;
+
+use WordPress\Sniff;
+
 /**
  * Checks against empty statements.
  *
@@ -22,8 +26,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_CodeAnalysis_EmptyStatementSniff extends WordPress_Sniff {
+class EmptyStatementSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\DB;
+
+use WordPress\AbstractClassRestrictionsSniff;
+
 /**
  * Verifies that no database related PHP classes are used.
  *
@@ -20,8 +24,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_DB_RestrictedClassesSniff extends WordPress_AbstractClassRestrictionsSniff {
+class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
 
 	/**
 	 * Groups of classes to restrict.

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\DB;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Verifies that no database related PHP functions are used.
  *
@@ -20,8 +24,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_DB_RestrictedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -118,7 +118,7 @@ class FileNameSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		if ( defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+		if ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
 			$this->class_exceptions = array_merge( $this->class_exceptions, $this->unittest_class_exceptions );
 		}
 
@@ -195,8 +195,8 @@ class FileNameSniff extends Sniff {
 
 					if ( ( 'Template' === trim( $this->tokens[ $subpackage ]['content'] )
 						&& $this->tokens[ $subpackage_tag ]['line'] === $this->tokens[ $subpackage ]['line'] )
-						&& ( ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
-						|| ( defined( 'PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
+						&& ( ( ! defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
+						|| ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
 						&& false === $has_class
 					) {
 						$this->phpcsFile->addError(

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Files;
+
+use WordPress\Sniff;
+
 /**
  * Ensures filenames do not contain underscores.
  *
@@ -22,10 +26,11 @@
  *                 - This sniff will now allow for underscores in file names for certain theme
  *                   specific exceptions if the `$is_theme` property is set to `true`.
  * @since   0.12.0 - Now extends the `WordPress_Sniff` class.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    WordPress_Sniff::$custom_test_class_whitelist
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
  */
-class WordPress_Sniffs_Files_FileNameSniff extends WordPress_Sniff {
+class FileNameSniff extends Sniff {
 
 	/**
 	 * Regex for the theme specific exceptions.

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restricts the usage of extract().
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Functions_DontExtractSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Functions;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces no whitespace between the parenthesis of a function call without parameters.
@@ -29,7 +30,7 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return PHP_CodeSniffer_Tokens::$functionNameTokens;
+		return Tokens::$functionNameTokens;
 	}
 
 	/**
@@ -42,7 +43,7 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		// Find the next non-empty token.
-		$openParenthesis = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$openParenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openParenthesis ]['code'] ) {
 			// Not a function call.
@@ -55,7 +56,7 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 		}
 
 		// Find the previous non-empty token.
-		$search   = PHP_CodeSniffer_Tokens::$emptyTokens;
+		$search   = Tokens::$emptyTokens;
 		$search[] = T_BITWISE_AND;
 		$previous = $this->phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
 		if ( T_FUNCTION === $this->tokens[ $previous ]['code'] ) {

--- a/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\Sniff;
+
 /**
  * Enforces no whitespace between the parenthesis of a function call without parameters.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_Functions_FunctionCallSignatureNoParamsSniff extends WordPress_Sniff {
+class FunctionCallSignatureNoParamsSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -7,20 +7,26 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restricts usage of some functions.
  *
  * @package    WPCS\WordPressCodingStandards
  *
  * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
  * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
  *                    the WordPress_AbstractFunctionRestrictionsSniff class.
  *                    This class is left here to prevent backward-compatibility breaks for
  *                    custom sniffs extending the old class and references to this
  *                    sniff from custom phpcs.xml files.
- * @see        WordPress_AbstractFunctionRestrictionsSniff
+ * @see        \WordPress\AbstractFunctionRestrictionsSniff
  */
-class WordPress_Sniffs_Functions_FunctionRestrictionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class FunctionRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\NamingConventions;
 
 use WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
@@ -272,7 +273,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 						return;
 					}
 
-					$constant_name_ptr = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+					$constant_name_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 					if ( false === $constant_name_ptr ) {
 						// Live coding.
 						return;
@@ -329,7 +330,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		// Is this a variable variable ?
 		// Not concerned with nested ones as those will be recognized on their own token.
-		$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 		if ( false === $next_non_empty || ! isset( $indicators[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
 			return;
 		}
@@ -341,14 +342,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$next_non_empty = $this->tokens[ $next_non_empty ]['bracket_closer'];
 		}
 
-		$maybe_assignment = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
+		$maybe_assignment = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
 
 		while ( false !== $maybe_assignment
 			&& T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
 			&& isset( $this->tokens[ $maybe_assignment ]['bracket_closer'] )
 		) {
 			$maybe_assignment = $this->phpcsFile->findNext(
-				PHP_CodeSniffer_Tokens::$emptyTokens,
+				Tokens::$emptyTokens,
 				( $this->tokens[ $maybe_assignment ]['bracket_closer'] + 1 ),
 				null,
 				true,
@@ -361,7 +362,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( ! isset( PHP_CodeSniffer_Tokens::$assignmentTokens[ $this->tokens[ $maybe_assignment ]['code'] ] ) ) {
+		if ( ! isset( Tokens::$assignmentTokens[ $this->tokens[ $maybe_assignment ]['code'] ] ) ) {
 			// Not an assignment.
 			return;
 		}
@@ -435,13 +436,13 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( 'GLOBALS' === $variable_name ) {
-			$array_open = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+			$array_open = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 			if ( false === $array_open || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $array_open ]['code'] ) {
 				// Live coding or something very silly.
 				return;
 			}
 
-			$array_key = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $array_open + 1 ), null, true, null, true );
+			$array_key = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $array_open + 1 ), null, true, null, true );
 			if ( false === $array_key ) {
 				// No key found, nothing to do.
 				return;
@@ -451,7 +452,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$variable_name = $this->strip_quotes( $this->tokens[ $array_key ]['content'] );
 
 			// Check whether a prefix is needed.
-			if ( isset( PHP_CodeSniffer_Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] )
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] )
 				&& $this->variable_prefixed_or_whitelisted( $variable_name ) === true
 			) {
 				return;
@@ -470,7 +471,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					// If the first part was dynamic, throw a warning.
 					$is_error = false;
 				}
-			} elseif ( ! isset( PHP_CodeSniffer_Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] ) ) {
+			} elseif ( ! isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] ) ) {
 				// Dynamic array key, throw a warning.
 				$is_error = false;
 			}
@@ -580,7 +581,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		} else {
 			// This may be a dynamic hook/constant name.
 			$first_non_empty = $this->phpcsFile->findNext(
-				PHP_CodeSniffer_Tokens::$emptyTokens,
+				Tokens::$emptyTokens,
 				$parameters[1]['start'],
 				( $parameters[1]['end'] + 1 ),
 				true
@@ -593,7 +594,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$first_non_empty_content = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
 
 			// Try again with just the first token if it's a text string.
-			if ( isset( PHP_CodeSniffer_Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] )
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] )
 				&& $this->is_prefixed( $first_non_empty_content ) === true
 			) {
 				return;
@@ -612,7 +613,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					// Start of hook/constant name is dynamic, throw a warning.
 					$is_error = false;
 				}
-			} elseif ( ! isset( PHP_CodeSniffer_Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] ) ) {
+			} elseif ( ! isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] ) ) {
 				// Dynamic hook/constant name, throw a warning.
 				$is_error = false;
 			}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\NamingConventions;
 
 use WordPress\AbstractFunctionParameterSniff;
+use WordPress\PHPCSHelper;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -156,7 +157,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Allow overruling the prefixes set in a ruleset via the command line.
-		$cl_prefixes = trim( PHP_CodeSniffer::getConfigData( 'prefixes' ) );
+		$cl_prefixes = trim( PHPCSHelper::get_config_data( 'prefixes' ) );
 		if ( ! empty( $cl_prefixes ) ) {
 			$this->prefixes = $cl_prefixes;
 		}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -7,16 +7,21 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\NamingConventions;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    WordPress_Sniff::$custom_test_class_whitelist
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
  */
-class WordPress_Sniffs_NamingConventions_PrefixAllGlobalsSniff extends WordPress_AbstractFunctionParameterSniff {
+class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * Error message template.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -207,7 +207,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					}
 
 					$item_name = $this->phpcsFile->getDeclarationName( $stackPtr );
-					if ( function_exists( $item_name ) ) {
+					if ( function_exists( '\\' . $item_name ) ) {
 						// Backfill for PHP native function.
 						return;
 					}
@@ -234,14 +234,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 					switch ( $this->tokens[ $stackPtr ]['type'] ) {
 						case 'T_CLASS':
-							if ( class_exists( $item_name ) ) {
+							if ( class_exists( '\\' . $item_name ) ) {
 								// Backfill for PHP native class.
 								return;
 							}
 							break;
 
 						case 'T_INTERFACE':
-							if ( interface_exists( $item_name ) ) {
+							if ( interface_exists( '\\' . $item_name ) ) {
 								// Backfill for PHP native interface.
 								return;
 							}
@@ -251,7 +251,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							break;
 
 						case 'T_TRAIT':
-							if ( function_exists( 'trait_exists' ) && trait_exists( $item_name ) ) {
+							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name ) ) {
 								// Backfill for PHP native trait.
 								return;
 							}
@@ -280,7 +280,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					}
 
 					$item_name = $this->tokens[ $constant_name_ptr ]['content'];
-					if ( defined( $item_name ) ) {
+					if ( defined( '\\' . $item_name ) ) {
 						// Backfill for PHP native constant.
 						return;
 					}
@@ -620,7 +620,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( 'define' === $matched_content ) {
-			if ( defined( $raw_content ) ) {
+			if ( defined( '\\' . $raw_content ) ) {
 				// Backfill for PHP native constant.
 				return;
 			}

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -7,9 +7,9 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-if ( ! class_exists( 'PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', true ) ) {
-	throw new PHP_CodeSniffer_Exception( 'Class PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff not found' );
-}
+namespace WordPress\Sniffs\NamingConventions;
+
+use PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff as PHPCS_PEAR_ValidFunctionNameSniff;
 
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
@@ -27,7 +27,7 @@ if ( ! class_exists( 'PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', tru
  * {@internal While this class extends the PEAR parent, it does not actually use the checks
  * contained in the parent. It only uses the properties and the token registration from the parent.}}
  */
-class WordPress_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff {
+class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 
 	/**
 	 * Additional double underscore prefixed methods specific to certain PHP native extensions.

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\NamingConventions;
 
 use PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff as PHPCS_PEAR_ValidFunctionNameSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
@@ -55,13 +56,13 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 	/**
 	 * Processes the tokens outside the scope.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-	 * @param int                  $stackPtr  The position where this token was
-	 *                                        found.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 * @param int                         $stackPtr  The position where this token was
+	 *                                               found.
 	 *
 	 * @return void
 	 */
-	protected function processTokenOutsideScope( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+	protected function processTokenOutsideScope( File $phpcsFile, $stackPtr ) {
 		$functionName = $phpcsFile->getDeclarationName( $stackPtr );
 
 		if ( ! isset( $functionName ) ) {
@@ -101,14 +102,14 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 	/**
 	 * Processes the tokens within the scope.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-	 * @param int                  $stackPtr  The position where this token was
-	 *                                        found.
-	 * @param int                  $currScope The position of the current scope.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 * @param int                         $stackPtr  The position where this token was
+	 *                                               found.
+	 * @param int                         $currScope The position of the current scope.
 	 *
 	 * @return void
 	 */
-	protected function processTokenWithinScope( PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope ) {
+	protected function processTokenWithinScope( File $phpcsFile, $stackPtr, $currScope ) {
 		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
 
 		if ( ! isset( $methodName ) ) {

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -19,6 +19,7 @@ if ( ! class_exists( 'PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', tru
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.1.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * Last synced with parent class July 2016 up to commit 4fea2e651109e41066a81e22e004d851fb1287f6.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\NamingConventions;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Use lowercase letters in action and filter names. Separate words via underscores.
  *
@@ -21,8 +25,9 @@
  *
  * @since   0.10.0
  * @since   0.11.0 Extends the WordPress_AbstractFunctionParameterSniff class.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_NamingConventions_ValidHookNameSniff extends WordPress_AbstractFunctionParameterSniff {
+class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * Additional word separators.

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -7,9 +7,9 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-if ( ! class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) ) {
-	throw new PHP_CodeSniffer_Exception( 'Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found' );
-}
+namespace WordPress\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer_Standards_AbstractVariableSniff as PHPCS_AbstractVariableSniff;
 use WordPress\Sniff;
 
 /**
@@ -25,7 +25,7 @@ use WordPress\Sniff;
  * Last synced with base class July 2014 at commit ed257ca0e56ad86cd2a4d6fa38ce0b95141c824f.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  */
-class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff {
+class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 	/**
 	 * PHP Reserved Vars.

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -10,6 +10,7 @@
 if ( ! class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) ) {
 	throw new PHP_CodeSniffer_Exception( 'Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found' );
 }
+use WordPress\Sniff;
 
 /**
  * Checks the naming of variables and member variables.
@@ -19,6 +20,7 @@ if ( ! class_exists( 'PHP_CodeSniffer_Standards_AbstractVariableSniff', true ) )
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * Last synced with base class July 2014 at commit ed257ca0e56ad86cd2a4d6fa38ce0b95141c824f.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -301,10 +303,10 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 			|| $this->customVariablesWhitelist !== $this->addedCustomProperties['variables']
 		) {
 			// Fix property potentially passed as comma-delimited string.
-			$customProperties = WordPress_Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
+			$customProperties = Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
 
 			if ( ! empty( $this->customVariablesWhitelist ) ) {
-				$customProperties = WordPress_Sniff::merge_custom_array(
+				$customProperties = Sniff::merge_custom_array(
 					$this->customVariablesWhitelist,
 					$customProperties,
 					false
@@ -317,7 +319,7 @@ class WordPress_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_Code
 				);
 			}
 
-			$this->whitelisted_mixed_case_member_var_names = WordPress_Sniff::merge_custom_array(
+			$this->whitelisted_mixed_case_member_var_names = Sniff::merge_custom_array(
 				$customProperties,
 				$this->whitelisted_mixed_case_member_var_names
 			);

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer_Standards_AbstractVariableSniff as PHPCS_AbstractVariableSniff;
+use PHP_CodeSniffer_File as File;
 use WordPress\Sniff;
 
 /**
@@ -122,13 +123,13 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param int                  $stack_ptr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the current token in the
+	 *                                                stack passed in $tokens.
 	 *
 	 * @return void
 	 */
-	protected function processVariable( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+	protected function processVariable( File $phpcs_file, $stack_ptr ) {
 
 		$tokens   = $phpcs_file->getTokens();
 		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
@@ -208,13 +209,13 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	/**
 	 * Processes class member variables.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param int                  $stack_ptr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the current token in the
+	 *                                                stack passed in $tokens.
 	 *
 	 * @return void
 	 */
-	protected function processMemberVar( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+	protected function processMemberVar( File $phpcs_file, $stack_ptr ) {
 
 		$tokens = $phpcs_file->getTokens();
 
@@ -242,13 +243,13 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	/**
 	 * Processes the variable found within a double quoted string.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
-	 * @param int                  $stack_ptr  The position of the double quoted
-	 *                                         string.
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the double quoted
+	 *                                                string.
 	 *
 	 * @return void
 	 */
-	protected function processVariableInString( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+	protected function processVariableInString( File $phpcs_file, $stack_ptr ) {
 
 		$tokens = $phpcs_file->getTokens();
 
@@ -294,11 +295,11 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 *
 	 * @since 0.10.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcs_file The file being scanned.
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
 	 *
 	 * @return void
 	 */
-	protected function mergeWhiteList( $phpcs_file ) {
+	protected function mergeWhiteList( File $phpcs_file ) {
 		if ( $this->customPropertiesWhitelist !== $this->addedCustomProperties['properties']
 			|| $this->customVariablesWhitelist !== $this->addedCustomProperties['variables']
 		) {

--- a/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restrict the use of various development functions.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_PHP_DevelopmentFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -9,6 +9,8 @@
 
 namespace WordPress\Sniffs\PHP;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * Discourages the use of various native PHP functions and suggests alternatives.
  *
@@ -51,11 +53,11 @@ class DiscouragedFunctionsSniff {
 	 *
 	 * @deprecated 0.11.0
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile A PHP_CodeSniffer file.
-	 * @param int                  $stackPtr  The position of the token.
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile A PHP_CodeSniffer file.
+	 * @param int                         $stackPtr  The position of the token.
 	 *
 	 * @return void
 	 */
-	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {}
+	public function process( File $phpcsFile, $stackPtr ) {}
 
 }

--- a/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -7,6 +7,8 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
 /**
  * Discourages the use of various native PHP functions and suggests alternatives.
  *
@@ -15,6 +17,8 @@
  * @since      0.1.0
  * @since      0.10.0 The checks for the POSIX functions have been replaced by the stand-alone
  *                    sniff WordPress_Sniffs_PHP_POSIXFunctionsSniff.
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
  * @deprecated 0.11.0 The checks for the PHP development functions have been replaced by the
  *                    stand-alone sniff WordPress_Sniffs_PHP_DevelopmentFunctionsSniff.
  *                    The checks for the WP deprecated functions have been replaced by the
@@ -29,7 +33,7 @@
  *                    function. To check for `register_globals` ini directive use
  *                    PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff from wimg/PHPCompatibility.
  */
-class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff {
+class DiscouragedFunctionsSniff {
 
 	/**
 	 * Don't use.

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Discourages the use of various native PHP functions and suggests alternatives.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to discourage.

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Perl compatible regular expressions (PCRE, preg_ functions) should be used in preference
  * to their POSIX counterparts.
@@ -18,8 +22,9 @@
  *
  * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff
  *                 and the WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_PHP_POSIXFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -7,19 +7,24 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
 /**
  * Enforces Strict Comparison checks, based upon Squiz code.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.4.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * Last synced with base class ?[unknown date]? at commit ?[unknown commit]?.
  * It is currently unclear whether this sniff is actually based on Squiz code on whether the above
  * reference to it is a copy/paste oversight.
  * @link    Possibly: https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
  */
-class WordPress_Sniffs_PHP_StrictComparisonsSniff extends WordPress_Sniff {
+class StrictComparisonsSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Flag calling in_array(), array_search() and array_keys() without true as the third parameter.
  *
@@ -19,8 +23,9 @@
  *                 The sniff no longer needlessly extends the WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
  *                 which it didn't use.
  * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_PHP_StrictInArraySniff extends WordPress_AbstractFunctionParameterSniff {
+class StrictInArraySniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\PHP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces Yoda conditional statements.
@@ -40,8 +41,8 @@ class YodaConditionsSniff extends Sniff {
 	 */
 	public function register() {
 
-		$starters                       = PHP_CodeSniffer_Tokens::$booleanOperators;
-		$starters                      += PHP_CodeSniffer_Tokens::$assignmentTokens;
+		$starters                       = Tokens::$booleanOperators;
+		$starters                      += Tokens::$assignmentTokens;
 		$starters[ T_CASE ]             = T_CASE;
 		$starters[ T_RETURN ]           = T_RETURN;
 		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
@@ -75,7 +76,7 @@ class YodaConditionsSniff extends Sniff {
 		for ( $i = $stackPtr; $i > $start; $i-- ) {
 
 			// Ignore whitespace.
-			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
 
@@ -98,15 +99,15 @@ class YodaConditionsSniff extends Sniff {
 		}
 
 		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 ).
-		$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-		if ( isset( PHP_CodeSniffer_Tokens::$castTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
-			$next_non_empty = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
+		if ( isset( Tokens::$castTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+			$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
 		}
 
 		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
 			$next_non_empty = $this->phpcsFile->findNext(
-				array_merge( PHP_CodeSniffer_Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )
+				array_merge( Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )
 				, ( $next_non_empty + 1 )
 				, null
 				, true

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
 /**
  * Enforces Yoda conditional statements.
  *
@@ -16,8 +20,9 @@
  *
  * @since   0.3.0
  * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_PHP_YodaConditionsSniff extends WordPress_Sniff {
+class YodaConditionsSniff extends Sniff {
 
 	/**
 	 * The tokens that indicate the start of a condition.

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\VIP;
 
 use WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Discourages removal of the admin bar.
@@ -140,7 +141,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function register() {
 		// Set up all string targets.
-		$this->string_tokens = PHP_CodeSniffer_Tokens::$textStringTokens;
+		$this->string_tokens = Tokens::$textStringTokens;
 
 		$targets = $this->string_tokens;
 
@@ -361,7 +362,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$opener = $this->phpcsFile->findPrevious( T_OPEN_CURLY_BRACKET, $stackPtr );
 		if ( false !== $opener ) {
 			for ( $i = ( $opener - 1 ); $i >= 0; $i-- ) {
-				if ( isset( PHP_CodeSniffer_Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] )
+				if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] )
 					|| T_CLOSE_CURLY_BRACKET === $this->tokens[ $i ]['code']
 				) {
 					break;

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Discourages removal of the admin bar.
  *
@@ -18,8 +22,9 @@
  * @since   0.11.0 - Extends the WordPress_AbstractFunctionParameterSniff class.
  *                 - Added the $remove_only property.
  *                 - Now also sniffs for manipulation of the admin bar visibility through CSS.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_AdminBarRemovalSniff extends WordPress_AbstractFunctionParameterSniff {
+class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\VIP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Flag cron schedules less than 15 minutes.
@@ -78,7 +79,7 @@ class CronIntervalSniff extends Sniff {
 		}
 
 		// Detect callback function name.
-		$callbackArrayPtr = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, $callback['start'], ( $callback['end'] + 1 ), true );
+		$callbackArrayPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $callback['start'], ( $callback['end'] + 1 ), true );
 
 		// If callback is array, get second element.
 		if ( false !== $callbackArrayPtr

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
 /**
  * Flag cron schedules less than 15 minutes.
  *
@@ -17,8 +21,9 @@
  * @since   0.3.0
  * @since   0.11.0 - Extends the WordPress_Sniff class.
  *                 - Now deals correctly with WP time constants.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_CronIntervalSniff extends WordPress_Sniff {
+class CronIntervalSniff extends Sniff {
 
 	/**
 	 * Known WP Time constant names and their value.

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\VIP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Flag Database direct queries.
@@ -152,7 +153,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 
 		// Check for Database Schema Changes.
 		$_pos = $stackPtr;
-		while ( $_pos = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$textStringTokens, ( $_pos + 1 ), $endOfStatement, false, null, true ) ) {
+		while ( $_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, ( $_pos + 1 ), $endOfStatement, false, null, true ) ) {
 			if ( preg_match( '#\b(?:ALTER|CREATE|DROP)\b#i', $this->tokens[ $_pos ]['content'] ) > 0 ) {
 				$this->phpcsFile->addError( 'Attempting a database schema change is highly discouraged.', $_pos, 'SchemaChange' );
 			}

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
 /**
  * Flag Database direct queries.
  *
@@ -18,8 +22,9 @@
  * @since   0.3.0
  * @since   0.6.0  Removed the add_unique_message() function as it is no longer needed.
  * @since   0.11.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_DirectDatabaseQuerySniff extends WordPress_Sniff {
+class DirectDatabaseQuerySniff extends Sniff {
 
 	/**
 	 * List of custom cache get functions.

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Disallow Filesystem writes.
  *
@@ -17,8 +21,9 @@
  * @since   0.3.0
  * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
  *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class FileSystemWritesDisallowSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * If true, an error will be thrown; otherwise a warning.

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Flag using orderby => rand.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_OrderByRandSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
+class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Warn about __FILE__ for page registration.
  *
@@ -16,8 +20,9 @@
  *
  * @since   0.3.0
  * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_PluginMenuSlugSniff extends WordPress_AbstractFunctionParameterSniff {
+class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Flag returning high or infinite posts_per_page.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_PostsPerPageSniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
+class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restricts usage of some functions in VIP context.
  *
@@ -24,8 +28,9 @@
  *                 The check for `parse_url()` and `curl_*` have been moved to the stand-alone sniff
  *                 WordPress_Sniffs_WP_AlternativeFunctionsSniff.
  *                 The check for `eval()` now defers to the upstream Squiz.PHP.Eval sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_RestrictedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractVariableRestrictionsSniff;
+
 /**
  * Restricts usage of some variables in VIP context.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_RestrictedVariablesSniff extends WordPress_AbstractVariableRestrictionsSniff {
+class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Discourages the use of session functions.
  *
@@ -17,8 +21,9 @@
  * @since   0.3.0
  * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
  *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class SessionFunctionsUsageSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
 /**
  * Discourages the use of the session variable.
  * Creating a session writes a file to the server and is unreliable in a multi-server environment.
@@ -19,8 +23,9 @@
  * @since   0.10.0 The sniff no longer needlessly extends the Generic_Sniffs_PHP_ForbiddenFunctionsSniff
  *                 which it didn't use.
  * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_SessionVariableUsageSniff extends WordPress_Sniff {
+class SessionVariableUsageSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Flag potentially slow queries.
  *
@@ -18,8 +22,9 @@
  * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
  *                 comment, replacing the 'tax_query' whitelist comment which is now
  *                 deprecated.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_SlowDBQuerySniff extends WordPress_AbstractArrayAssignmentRestrictionsSniff {
+class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
 /**
  * Flag any usage of super global input var ( _GET / _POST / etc. ).
  *
@@ -15,9 +19,10 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.4.0 This class now extends WordPress_Sniff.
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_SuperGlobalInputUsageSniff extends WordPress_Sniff {
+class SuperGlobalInputUsageSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Disallow the changing of timezone.
  *
@@ -17,8 +21,9 @@
  * @since   0.3.0
  * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
  *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_TimezoneChangeSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
 /**
  * Flag any non-validated/sanitized input ( _GET / _POST / etc. ).
  *
@@ -15,10 +19,11 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.4.0 This class now extends WordPress_Sniff.
- * @since   0.5.0 Method getArrayIndexKey() has been moved to WordPress_Sniff.
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.5.0  Method getArrayIndexKey() has been moved to WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff {
+class ValidatedSanitizedInputSniff extends Sniff {
 
 	/**
 	 * Check for validation functions for a variable within its own parenthesis only.

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -7,9 +7,11 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Variables;
+
+use WordPress\Sniff;
+
 /**
- * WordPress_Sniffs_Variables_GlobalVariablesSniff.
- *
  * Warns about overwriting WordPress native global variables.
  *
  * @package WPCS\WordPressCodingStandards
@@ -17,10 +19,11 @@
  * @since   0.3.0
  * @since   0.4.0  This class now extends WordPress_Sniff.
  * @since   0.12.0 The $wp_globals property has been moved to the WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    WordPress_Sniff::$custom_test_class_whitelist
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
  */
-class WordPress_Sniffs_Variables_GlobalVariablesSniff extends WordPress_Sniff {
+class GlobalVariablesSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\Variables;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Warns about overwriting WordPress native global variables.
@@ -48,7 +49,7 @@ class GlobalVariablesSniff extends Sniff {
 		$token = $this->tokens[ $stackPtr ];
 
 		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
-			$bracketPtr = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			$bracketPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 			if ( false === $bracketPtr || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] || ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
 				return;
@@ -145,7 +146,7 @@ class GlobalVariablesSniff extends Sniff {
 					&& in_array( $this->tokens[ $ptr ]['content'], $search, true )
 				) {
 					// Don't throw false positives for static class properties.
-					$previous = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
+					$previous = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
 					if ( false !== $previous && T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {
 						continue;
 					}

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -7,21 +7,27 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\Variables;
+
+use WordPress\AbstractVariableRestrictionsSniff;
+
 /**
  * Restricts usage of some variables.
  *
  * @package    WPCS\WordPressCodingStandards
  *
  * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
  * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
  *                    the WordPress_AbstractVariableRestrictionsSniff class.
  *                    This class is left here to prevent backward-compatibility breaks for
  *                    custom sniffs extending the old class and references to this
  *                    sniff from custom phpcs.xml files.
  *                    This file is also still used to unit test the abstract class.
- * @see        WordPress_AbstractVariableRestrictionsSniff
+ * @see        \WordPress\AbstractVariableRestrictionsSniff
  */
-class WordPress_Sniffs_Variables_VariableRestrictionsSniff extends WordPress_AbstractVariableRestrictionsSniff {
+class VariableRestrictionsSniff extends AbstractVariableRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Discourages the use of various functions and suggests (WordPress) alternatives.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_AlternativeFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Capital P Dangit!
@@ -191,9 +192,9 @@ class CapitalPDangitSniff extends Sniff {
 
 		// Ignore any text strings which are array keys `$var['key']` as this is a false positive in 80% of all cases.
 		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
-			$prevToken = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+			$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
 			if ( false !== $prevToken && T_OPEN_SQUARE_BRACKET === $this->tokens[ $prevToken ]['code'] ) {
-				$nextToken = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+				$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 				if ( false !== $nextToken && T_CLOSE_SQUARE_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
 					return;
 				}

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+
 /**
  * Capital P Dangit!
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_CapitalPDangitSniff extends WordPress_Sniff {
+class CapitalPDangitSniff extends Sniff {
 
 	/**
 	 * Regex to match a large number or spelling variations of WordPress in text strings.

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractClassRestrictionsSniff;
+
 /**
  * Restricts the use of deprecated WordPress classes and suggests alternatives.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_DeprecatedClassesSniff extends WordPress_AbstractClassRestrictionsSniff {
+class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 
 	/**
 	 * Minimum WordPress version.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Restricts the use of various deprecated WordPress functions and suggests alternatives.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_DeprecatedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Minimum WordPress version.

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
 /**
  * Check for usage of deprecated parameters in WP functions and suggest alternative based on the parameter passed.
  *
@@ -19,8 +23,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_DeprecatedParametersSniff extends WordPress_AbstractFunctionParameterSniff {
+class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Discourages the use of various WordPress functions and suggests alternatives.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_DiscouragedFunctionsSniff extends WordPress_AbstractFunctionRestrictionsSniff {
+class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Makes sure scripts and styles are enqueued and not explicitly echo'd.
@@ -30,7 +31,7 @@ class EnqueuedResourcesSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return PHP_CodeSniffer_Tokens::$textStringTokens;
+		return Tokens::$textStringTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+
 /**
  * Makes sure scripts and styles are enqueued and not explicitly echo'd.
  *
@@ -16,8 +20,9 @@
  *
  * @since   0.3.0
  * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_EnqueuedResourcesSniff extends WordPress_Sniff {
+class EnqueuedResourcesSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+
 /**
  * Makes sure WP internationalization functions are used properly.
  *
@@ -20,8 +24,9 @@
  *                 - Now has the ability to handle text-domain set via the command-line
  *                   as a comma-delimited list.
  *                   `phpcs --runtime-set text_domain my-slug,default`
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_I18nSniff extends WordPress_Sniff {
+class I18nSniff extends Sniff {
 
 	/**
 	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Makes sure WP internationalization functions are used properly.
@@ -178,7 +179,7 @@ class I18nSniff extends Sniff {
 		for ( $i = ( $func_open_paren_token + 1 ); $i < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $i++ ) {
 			$this_token                = $this->tokens[ $i ];
 			$this_token['token_index'] = $i;
-			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this_token['code'] ] ) ) {
+			if ( isset( Tokens::$emptyTokens[ $this_token['code'] ] ) ) {
 				continue;
 			}
 			if ( T_COMMA === $this_token['code'] ) {
@@ -188,7 +189,7 @@ class I18nSniff extends Sniff {
 			}
 
 			// Merge consecutive single or double quoted strings (when they span multiple lines).
-			if ( isset( PHP_CodeSniffer_Tokens::$textStringTokens[ $this_token['code'] ] ) ) {
+			if ( isset( Tokens::$textStringTokens[ $this_token['code'] ] ) ) {
 				for ( $j = ( $i + 1 ); $j < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
 					if ( $this_token['code'] === $this->tokens[ $j ]['code'] ) {
 						$this_token['content'] .= $this->tokens[ $j ]['content'];
@@ -526,7 +527,7 @@ class I18nSniff extends Sniff {
 					continue;
 				}
 
-				$previous_comment = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+				$previous_comment = $this->phpcsFile->findPrevious( Tokens::$commentTokens, ( $stack_ptr - 1 ) );
 
 				if ( false !== $previous_comment ) {
 					/*

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WP;
 
 use WordPress\Sniff;
+use WordPress\PHPCSHelper;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -146,7 +147,7 @@ class I18nSniff extends Sniff {
 		$token = $this->tokens[ $stack_ptr ];
 
 		// Allow overruling the text_domain set in a ruleset via the command line.
-		$cl_text_domain = trim( PHP_CodeSniffer::getConfigData( 'text_domain' ) );
+		$cl_text_domain = trim( PHPCSHelper::get_config_data( 'text_domain' ) );
 		if ( ! empty( $cl_text_domain ) ) {
 			$this->text_domain = $cl_text_domain;
 		}

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+
 /**
  * Sniff for prepared SQL.
  *
@@ -17,8 +21,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.8.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WP_PreparedSQLSniff extends WordPress_Sniff {
+class PreparedSQLSniff extends Sniff {
 
 	/**
 	 * The lists of $wpdb methods.

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WhiteSpace;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Ensure cast statements don't contain whitespace, but *are* surrounded by whitespace, based upon Squiz code.
@@ -32,7 +33,7 @@ class CastStructureSpacingSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return PHP_CodeSniffer_Tokens::$castTokens;
+		return Tokens::$castTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+
 /**
  * Ensure cast statements don't contain whitespace, but *are* surrounded by whitespace, based upon Squiz code.
  *
@@ -18,8 +22,9 @@
  * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
  * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
  * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WhiteSpace_CastStructureSpacingSniff extends WordPress_Sniff {
+class CastStructureSpacingSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+
 /**
  * Enforces spacing around logical operators and assignments, based upon Squiz code.
  *
@@ -16,13 +20,14 @@
  * @since   2013-06-11 This sniff no longer supports JS.
  * @since   0.3.0      This sniff now has the ability to fix most errors it flags.
  * @since   0.7.0      This class now extends WordPress_Sniff.
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  *
  * Last synced with base class 2017-01-15 at commit b024ad84656c37ef5733c6998ebc1e60957b2277.
  * Note: This class has diverged quite far from the original. All the same, checking occassionally
  * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
-class WordPress_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends WordPress_Sniff {
+class ControlStructureSpacingSniff extends Sniff {
 
 	/**
 	 * Check for blank lines on start/end of control structures.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WhiteSpace;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Enforces spacing around logical operators and assignments, based upon Squiz code.
@@ -165,7 +166,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			}
 		}
 
-		$parenthesisOpener = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$parenthesisOpener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If this is a function declaration.
 		if ( T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
@@ -178,7 +179,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 				// This function returns by reference (function &function_name() {}).
 				$parenthesisOpener = $this->phpcsFile->findNext(
-					PHP_CodeSniffer_Tokens::$emptyTokens,
+					Tokens::$emptyTokens,
 					( $parenthesisOpener + 1 ),
 					null,
 					true
@@ -188,7 +189,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 			if ( isset( $function_name_ptr ) ) {
 				$parenthesisOpener = $this->phpcsFile->findNext(
-					PHP_CodeSniffer_Tokens::$emptyTokens,
+					Tokens::$emptyTokens,
 					( $parenthesisOpener + 1 ),
 					null,
 					true
@@ -216,7 +217,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
 
 				$usePtr = $this->phpcsFile->findNext(
-					PHP_CodeSniffer_Tokens::$emptyTokens,
+					Tokens::$emptyTokens,
 					( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
 					null,
 					true,
@@ -330,7 +331,7 @@ class ControlStructureSpacingSniff extends Sniff {
 						$this->phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
 					}
 				} elseif ( ' ' !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['content'] ) {
-					$prevNonEmpty = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $parenthesisCloser - 1 ), null, true );
+					$prevNonEmpty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $parenthesisCloser - 1 ), null, true );
 					if ( $this->tokens[ ( $parenthesisCloser ) ]['line'] === $this->tokens[ ( $prevNonEmpty + 1 ) ]['line'] ) {
 						$error = 'Expected exactly one space before closing parenthesis; "%s" found.';
 						$fix   = $this->phpcsFile->addFixableError(
@@ -435,7 +436,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			if ( $firstContent !== $scopeCloser ) {
 				$lastContent = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
 
-				$lastNonEmptyContent = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
+				$lastNonEmptyContent = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
 
 				$checkToken = $lastContent;
 				if ( isset( $this->tokens[ $lastNonEmptyContent ]['scope_condition'] ) ) {
@@ -485,7 +486,7 @@ class ControlStructureSpacingSniff extends Sniff {
 		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
 			// Special exception for code where the comment about
 			// an ELSE or ELSEIF is written between the control structures.
-			$nextCode = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
+			$nextCode = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
 
 			if ( T_ELSE === $this->tokens[ $nextCode ]['code'] || T_ELSEIF === $this->tokens[ $nextCode ]['code'] ) {
 				$trailingContent = $nextCode;

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+
 /**
  * Enforces using spaces for mid-line alignment.
  *
@@ -15,8 +19,9 @@
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_WhiteSpace_DisallowInlineTabsSniff extends WordPress_Sniff {
+class DisallowInlineTabsSniff extends Sniff {
 
 	/**
 	 * The --tab-width CLI value that is being used.

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WhiteSpace;
 
 use WordPress\Sniff;
+use WordPress\PHPCSHelper;
 
 /**
  * Enforces using spaces for mid-line alignment.
@@ -50,13 +51,7 @@ class DisallowInlineTabsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( ! isset( $this->tab_width ) ) {
-			$cli_values = $this->phpcsFile->phpcs->cli->getCommandLineValues();
-			if ( ! isset( $cli_values['tabWidth'] ) || 0 === $cli_values['tabWidth'] ) {
-				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
-				$this->tab_width = 4;
-			} else {
-				$this->tab_width = $cli_values['tabWidth'];
-			}
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
 		}
 
 		$check_tokens = array(

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -7,9 +7,9 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true ) ) {
-	throw new PHP_CodeSniffer_Exception( 'Class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff not found' );
-}
+namespace WordPress\Sniffs\WhiteSpace;
+
+use Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff as PHPCS_Squiz_OperatorSpacingSniff;
 
 /**
  * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the `!` (boolean not) operator.
@@ -33,7 +33,7 @@ if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true ) ) {
  * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
-class WordPress_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff {
+class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 
 	/**
 	 * Allow newlines instead of spaces.

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WhiteSpace;
 
 use Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff as PHPCS_Squiz_OperatorSpacingSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the `!` (boolean not) operator.
@@ -53,7 +54,7 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 	public function register() {
 		$tokens                  = parent::register();
 		$tokens[ T_BOOLEAN_NOT ] = T_BOOLEAN_NOT;
-		$logical_operators       = PHP_CodeSniffer_Tokens::$booleanOperators;
+		$logical_operators       = Tokens::$booleanOperators;
 
 		// Using array union to auto-dedup.
 		return $tokens + $logical_operators;

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true ) ) {
  *                 T_BOOLEAN_NOT and the logical operators (`&&` and the like) - via the
  *                 registration method and changing the value of the customizable
  *                 $ignoreNewlines property.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\XSS;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Verifies that all outputted strings are escaped.
@@ -198,7 +199,7 @@ class EscapeOutputSniff extends Sniff {
 		$function = $this->tokens[ $stackPtr ]['content'];
 
 		// Find the opening parenthesis (if present; T_ECHO might not have it).
-		$open_paren = $this->phpcsFile->findNext( PHP_CodeSniffer_Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$open_paren = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If function, not T_ECHO nor T_PRINT.
 		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
@@ -260,7 +261,7 @@ class EscapeOutputSniff extends Sniff {
 		if ( ! isset( $end_of_statement ) ) {
 
 			$end_of_statement = $this->phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
-			$last_token       = $this->phpcsFile->findPrevious( PHP_CodeSniffer_Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
+			$last_token       = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
 
 			// Check for the ternary operator. We only need to do this here if this
 			// echo is lacking parenthesis. Otherwise it will be handled below.
@@ -286,7 +287,7 @@ class EscapeOutputSniff extends Sniff {
 		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
 
 			// Ignore whitespaces and comments.
-			if ( isset( PHP_CodeSniffer_Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
 
@@ -388,7 +389,7 @@ class EscapeOutputSniff extends Sniff {
 
 						// Get the first parameter (name of function being used on the array).
 						$mapped_function = $this->phpcsFile->findNext(
-							PHP_CodeSniffer_Tokens::$emptyTokens,
+							Tokens::$emptyTokens,
 							( $function_opener + 1 ),
 							$this->tokens[ $function_opener ]['parenthesis_closer'],
 							true

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -7,6 +7,10 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Sniffs\XSS;
+
+use WordPress\Sniff;
+
 /**
  * Verifies that all outputted strings are escaped.
  *
@@ -20,8 +24,9 @@
  *                 have been moved to the WordPress_Sniff parent class.
  * @since   0.12.0 This sniff will now also check for output escaping when using shorthand
  *                 echo tags `<?=`.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
+class EscapeOutputSniff extends Sniff {
 
 	/**
 	 * Custom list of functions which escape values for output.
@@ -46,7 +51,7 @@ class WordPress_Sniffs_XSS_EscapeOutputSniff extends WordPress_Sniff {
 	 *
 	 * @since      0.3.0
 	 * @deprecated 0.5.0 Use $customEscapingFunctions instead.
-	 * @see        WordPress_Sniffs_XSS_EscapeOutputSniff::$customEscapingFunctions
+	 * @see        \WordPress\Sniffs\XSS\EscapeOutputSniff::$customEscapingFunctions
 	 *
 	 * @var string|string[]
 	 */

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -7,13 +7,20 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
 /**
  * Unit test class for the ArrayAssignmentRestrictions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest {
+class ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Fill in the $groups property to test the abstract class.
@@ -21,7 +28,7 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 	protected function setUp() {
 		parent::setUp();
 
-		WordPress_AbstractArrayAssignmentRestrictionsSniff::$groups = array(
+		AbstractArrayAssignmentRestrictionsSniff::$groups = array(
 			'foobar' => array(
 				'type'    => 'error',
 				'message' => 'Found assignment value of %s to be %s',
@@ -37,7 +44,7 @@ class WordPress_Tests_Arrays_ArrayAssignmentRestrictionsUnitTest extends Abstrac
 	 * Reset the $groups property.
 	 */
 	protected function tearDown() {
-		WordPress_AbstractArrayAssignmentRestrictionsSniff::$groups = array();
+		AbstractArrayAssignmentRestrictionsSniff::$groups = array();
 		parent::tearDown();
 	}
 

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ArrayDeclarationSpacing sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Arrays_ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
+class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ArrayIndentation sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Arrays_ArrayIndentationUnitTest extends AbstractSniffUnitTest {
+class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Get a list of CLI values to set before the file is tested.

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -22,7 +22,16 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 
 	/**
+	 * The tab width to use during testing.
+	 *
+	 * @var int
+	 */
+	private $tab_width = 4;
+
+	/**
 	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * Used by PHPCS 2.x.
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
@@ -31,11 +40,31 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 	public function getCliValues( $testFile ) {
 		// Tab width setting is only needed for the tabbed file.
 		if ( 'ArrayIndentationUnitTest.1.inc' === $testFile ) {
-			return array( '--tab-width=4' );
+			return array( '--tab-width=' . $this->tab_width );
 		}
 
 		return array();
 	}
+
+	/**
+	 * Set CLI values before the file is tested.
+	 *
+	 * Used by PHPCS 3.x.
+	 *
+	 * @param string                  $testFile The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $testFile, $config ) {
+		// Tab width setting is only needed for the tabbed file.
+		if ( 'ArrayIndentationUnitTest.1.inc' === $testFile ) {
+			$config->tabWidth = $this->tab_width;
+		} else {
+			$config->tabWidth = 0;
+		}
+	}
+
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ArrayKeySpacingRestrictions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Arrays_ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
+class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the Arrays.CommaAfterArrayItem sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Arrays_CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
+class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\CSRF;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the NonceVerification sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.5.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_CSRF_NonceVerificationUnitTest extends AbstractSniffUnitTest {
+class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ClassInstantiation sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Classes_ClassInstantiationUnitTest extends AbstractSniffUnitTest {
+class ClassInstantiationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Get a list of all test files to check.

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the EmptyStatement sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_CodeAnalysis_EmptyStatementUnitTest extends AbstractSniffUnitTest {
+class EmptyStatementUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -7,13 +7,20 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\DB;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use WordPress\AbstractFunctionRestrictionsSniff;
+
 /**
  * Unit test class for the DB_RestrictedClasses sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest {
+class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Add a number of extra restricted classes to unit test the abstract
@@ -25,7 +32,7 @@ class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest
 	protected function setUp() {
 		parent::setUp();
 
-		WordPress_AbstractFunctionRestrictionsSniff::$unittest_groups = array(
+		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
 			'test' => array(
 				'type'      => 'error',
 				'message'   => 'Detected usage of %s.',
@@ -41,7 +48,7 @@ class WordPress_Tests_DB_RestrictedClassesUnitTest extends AbstractSniffUnitTest
 	 * Reset the $groups property.
 	 */
 	protected function tearDown() {
-		WordPress_AbstractFunctionRestrictionsSniff::$unittest_groups = array();
+		AbstractFunctionRestrictionsSniff::$unittest_groups = array();
 		parent::tearDown();
 	}
 

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\DB;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the DB_RestrictedFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_DB_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -7,14 +7,20 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Files;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the FileName sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   2013-06-11
  * @since   0.11.0     Actually added tests ;-)
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Files_FileNameUnitTest extends AbstractSniffUnitTest {
+class FileNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Error files with the expected nr of errors.

--- a/WordPress/Tests/Functions/DontExtractUnitTest.php
+++ b/WordPress/Tests/Functions/DontExtractUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the DontExtract sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Functions_DontExtractUnitTest extends AbstractSniffUnitTest {
+class DontExtractUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
+++ b/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the FunctionCallSignatureNoParams sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Functions_FunctionCallSignatureNoParamsUnitTest extends AbstractSniffUnitTest {
+class FunctionCallSignatureNoParamsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PrefixAllGlobals sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_NamingConventions_PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
+class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -53,10 +53,10 @@ class WordPress_Tests_NamingConventions_PrefixAllGlobalsUnitTest extends Abstrac
 					154 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
 					155 => ( PHP_VERSION_ID >= 50300 ) ? 0 : 1, // PHPCS on PHP 5.2 does not recognize namespaces.
 					// Backfills.
-					225 => ( function_exists( 'mb_strpos' ) ) ? 0 : 1,
-					230 => ( function_exists( 'array_column' ) ) ? 0 : 1,
-					234 => ( defined( 'E_DEPRECATED' ) ) ? 0 : 1,
-					238 => ( class_exists( 'IntlTimeZone' ) ) ? 0 : 1,
+					225 => ( function_exists( '\mb_strpos' ) ) ? 0 : 1,
+					230 => ( function_exists( '\array_column' ) ) ? 0 : 1,
+					234 => ( defined( '\E_DEPRECATED' ) ) ? 0 : 1,
+					238 => ( class_exists( '\IntlTimeZone' ) ) ? 0 : 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.1.inc':

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ValidFunctionName sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   2013-06-11
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_NamingConventions_ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
+class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ValidHookName sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_NamingConventions_ValidHookNameUnitTest extends AbstractSniffUnitTest {
+class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ValidVariableName sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_NamingConventions_ValidVariableNameUnitTest extends AbstractSniffUnitTest {
+class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PHP_DevelopmentFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
+class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PHP_DiscouragedPHPFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
+class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the POSIXFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
+class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the StrictComparisons sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.4.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_StrictComparisonsUnitTest extends AbstractSniffUnitTest {
+class StrictComparisonsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the StrictInArray sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_StrictInArrayUnitTest extends AbstractSniffUnitTest {
+class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the YodaConditions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_PHP_YodaConditionsUnitTest extends AbstractSniffUnitTest {
+class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the AdminBarRemoval sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
+class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the CronInterval sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_CronIntervalUnitTest extends AbstractSniffUnitTest {
+class CronIntervalUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the DirectDatabaseQuery sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
+class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the FileSystemWritesDisallow sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
+class FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/OrderByRandUnitTest.php
+++ b/WordPress/Tests/VIP/OrderByRandUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the OrderByRand sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_OrderByRandUnitTest extends AbstractSniffUnitTest {
+class OrderByRandUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PluginMenuSlug sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
+class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PostsPerPage sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_PostsPerPageUnitTest extends AbstractSniffUnitTest {
+class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the VIP_RestrictedFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the VIP_RestrictedVariables sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
+class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the SessionFunctionsUsage sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest {
+class SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the SessionVariableUsage sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
+class SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the SlowDBQuery sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_SlowDBQueryUnitTest extends AbstractSniffUnitTest {
+class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the SuperGlobalInputUsage sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
+class SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the TimezoneChange sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_TimezoneChangeUnitTest extends AbstractSniffUnitTest {
+class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\VIP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ValidatedSanitizedInput sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
+class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Variables;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the GlobalVariables sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Variables_GlobalVariablesUnitTest extends AbstractSniffUnitTest {
+class GlobalVariablesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -7,13 +7,20 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\Variables;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use WordPress\AbstractVariableRestrictionsSniff;
+
 /**
  * Unit test class for the VariableRestrictions sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
+class VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Fill in the $groups property to test the abstract class.
@@ -21,7 +28,7 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 	protected function setUp() {
 		parent::setUp();
 
-		WordPress_AbstractVariableRestrictionsSniff::$groups = array(
+		AbstractVariableRestrictionsSniff::$groups = array(
 			'test' => array(
 				'type'          => 'error',
 				'message'       => 'Detected usage of %s',
@@ -61,7 +68,7 @@ class WordPress_Tests_Variables_VariableRestrictionsUnitTest extends AbstractSni
 	 * Reset the $groups property.
 	 */
 	protected function tearDown() {
-		WordPress_AbstractVariableRestrictionsSniff::$groups = array();
+		AbstractVariableRestrictionsSniff::$groups = array();
 		parent::tearDown();
 	}
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the WP_AlternativeFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
+class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the CapitalPDangit sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_CapitalPDangitUnitTest extends AbstractSniffUnitTest {
+class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the WP_DeprecatedClasses sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
+class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the WP_DeprecatedFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
+class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the DeprecatedParameters sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
+class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -7,14 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the WP_DiscouragedFunctions sniff.
  *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
+class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the EnqueuedResources sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
+class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -7,15 +7,20 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use WordPress\PHPCSHelper;
 
 /**
  * Unit test class for the I18n sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
+class I18nUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Fill in the $text_domain property to test domain check functionality.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -7,6 +7,8 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+use WordPress\PHPCSHelper;
+
 /**
  * Unit test class for the I18n sniff.
  *
@@ -20,14 +22,14 @@ class WordPress_Tests_WP_I18nUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function setUp() {
 		parent::setUp();
-		PHP_CodeSniffer::setConfigData( 'text_domain', 'my-slug,default', true );
+		PHPCSHelper::set_config_data( 'text_domain', 'my-slug,default', true );
 	}
 
 	/**
 	 * Reset the $groups property.
 	 */
 	protected function tearDown() {
-		PHP_CodeSniffer::setConfigData( 'text_domain', null, true );
+		PHPCSHelper::set_config_data( 'text_domain', null, true );
 		parent::tearDown();
 	}
 

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the PreparedSQL sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.8.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WP_PreparedSQLUnitTest extends AbstractSniffUnitTest {
+class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the CastStructureSpacing sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WhiteSpace_CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
+class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ControlStructureSpacing sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   2013-06-11
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WhiteSpace_ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
+class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Skip this test on PHP 5.2.

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the DisallowInlineTabs sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WhiteSpace_DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
+class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Get a list of CLI values to set before the file is tested.

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -22,14 +22,37 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
 
 	/**
+	 * The tab width to use during testing.
+	 *
+	 * @var int
+	 */
+	private $tab_width = 4;
+
+	/**
 	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * Used by PHPCS 2.x.
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
 	 * @return array
 	 */
 	public function getCliValues( $testFile ) {
-		return array( '--tab-width=4' );
+		return array( '--tab-width=' . $this->tab_width );
+	}
+
+	/**
+	 * Set CLI values before the file is tested.
+	 *
+	 * Used by PHPCS 3.x.
+	 *
+	 * @param string                  $testFile The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $testFile, $config ) {
+		$config->tabWidth = $this->tab_width;
 	}
 
 	/**

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -7,15 +7,21 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the OperatorSpacing sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   2013-06-11
  * @since   0.12.0     Now only tests the WPCS specific addition of T_BOOLEAN_NOT.
  *                     The rest of the sniff is unit tested upstream.
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUnitTest {
+class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -7,13 +7,19 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
+namespace WordPress\Tests\XSS;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the EscapeOutput sniff.
  *
  * @package WPCS\WordPressCodingStandards
+ *
  * @since   2013-06-11
+ * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class WordPress_Tests_XSS_EscapeOutputUnitTest extends AbstractSniffUnitTest {
+class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress">
+<ruleset name="WordPress" namespace="WordPress">
 	<description>WordPress Coding Standards</description>
+
+	<autoload>./PHPCSAliases.php</autoload>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -2,6 +2,10 @@
 <ruleset name="WordPress Coding Standards">
 	<description>The Coding standard for the WordPress Coding Standards itself.</description>
 
+	<!-- Exclude the code in the PHPCS 2.x test files copied in from PHPCS. -->
+	<exclude-pattern>/Test/AllTests.php</exclude-pattern>
+	<exclude-pattern>/Test/Standards/*.php</exclude-pattern>
+
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName" />

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -13,4 +13,7 @@
 
 	<rule ref="WordPress-Docs" />
 
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 		}
 	],
 	"require"    : {
-		"squizlabs/php_codesniffer": "^2.9.0"
+		"php" : ">=5.3",
+		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"suggest" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "*"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+	backupGlobals="true"
+	bootstrap="./Test/bootstrap.php"
+	colors="true">
+</phpunit>


### PR DESCRIPTION
This PR provides cross-version compatibility for WPCS with PHPCS 2.x as well as 3.x.

The minimum PHPCS 3.x requirement will be PHPCS 3.0.2 due to various bugs in earlier versions of the PHPCS 3.x autoloader.

Please see the individual commits for more detailed information. The commits have been set up to facilitate easier code review.

For end users, this PR will allow them to upgrade to PHPCS 3.x. Aside from the path to the `phpcs` command changing in PHPCS 3.x (upstream change), there is no backward-compatibility break for them.

For sniff developers who contribute to WPCS, the way to run the unit tests changes and - unfortunately - will be different for running these in combination with PHPCS 2.x vs 3.x.
The information regarding running the unit tests in the `CONTRIBUTING.md` file has been updated to reflect this change.

The PR has been set up with eventually dropping PHPCS 2.x support in mind. Where possible I've made choices which will make the update to WPCS to drop PHPCS 2.x support easier and less involved.
I will open a separate issue documenting how to drop PHPCS 2.x support.

Fixes #718