### PR TITLE
PHPCS 3.x compat: Implement recognition of the `--ignore-annotations` setting

### DIFF
--- a/WordPress/PHPCSHelper.php
+++ b/WordPress/PHPCSHelper.php
@@ -112,4 +112,30 @@ class PHPCSHelper {
 		return $tab_width;
 	}
 
+	/**
+	 * Check whether the `--ignore-annotations` option has been used.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile Optional. The current file being processed.
+	 *
+	 * @return bool True if annotations should be ignored, false otherwise.
+	 */
+	public static function ignore_annotations( File $phpcsFile = null ) {
+		if ( class_exists( '\PHP_CodeSniffer\Config' ) ) {
+			// PHPCS 3.x.
+			if ( isset( $phpcsFile, $phpcsFile->config->annotations ) ) {
+				return ! $phpcsFile->config->annotations;
+			} else {
+				$annotations = \PHP_CodeSniffer\Config::getConfigData( 'annotations' );
+				if ( isset( $annotations ) ) {
+					return ! $annotations;
+				}
+			}
+		}
+
+		// PHPCS 2.x does not support `--ignore-annotations`.
+		return false;
+	}
+
 }

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1066,6 +1066,11 @@ abstract class Sniff implements PHPCS_Sniff {
 	 */
 	protected function has_whitelist_comment( $comment, $stackPtr ) {
 
+		// Respect the PHPCS 3.x --ignore-annotations setting.
+		if ( true === PHPCSHelper::ignore_annotations( $this->phpcsFile ) ) {
+			return false;
+		}
+
 		$lastPtr     = $this->get_last_ptr_on_line( $stackPtr );
 		$end_of_line = $lastPtr;
 


### PR DESCRIPTION
This PR is part of the PHPCS 3.x compatibility PR series.

PHPCS 3.x introduces a `--ignore-annotations` command line option to ignore any and all inline file ignore / line ignore / coding standard setting changes etc.

This PR ensures that the WPCS specific whitelist comments will also be ignored if the `--ignore-annotations` command line option is passed.

Fixes #862