### PR TITLE
Build: improve our own codestyle checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ env:
 matrix:
   fast_finish: true
   include:
-    # Run PHPCS against WPCS. I just picked to run it against 5.5.
-    - php: 5.5
-      env: PHPCS_BRANCH=2.9 SNIFF=1
+    # Run PHPCS against WPCS. I just picked to run it against 7.0.
+    - php: 7.0
+      env: PHPCS_BRANCH=master SNIFF=1
       addons:
         apt:
           packages:
@@ -85,7 +85,7 @@ script:
     # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
     # --standard: Use WordPress as the standard.
     # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -n . --standard=./bin/phpcs.xml --extensions=php; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN . --standard=./bin/phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./*/ruleset.xml; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,6 @@ You'll see the line number and number of ERRORs we need to return in the `getErr
 
 The `--sniffs=...` directive limits the output to the sniff you are testing.
 
-## Sniff Code Standards
+## Code Standards for this project
 
-The sniffs for WPCS should be written such that they pass the `WordPress-Core` code standards.
-
+The sniffs and test files - not test _case_ files! - for WPCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/bin/phpcs.xml`.

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -2,9 +2,15 @@
 <ruleset name="WordPress Coding Standards">
 	<description>The Coding standard for the WordPress Coding Standards itself.</description>
 
+	<arg value="sp"/>
+	<arg name="extensions" value="php"/>
+
 	<!-- Exclude the code in the PHPCS 2.x test files copied in from PHPCS. -->
 	<exclude-pattern>/Test/AllTests.php</exclude-pattern>
 	<exclude-pattern>/Test/Standards/*.php</exclude-pattern>
+
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName" />


### PR DESCRIPTION
* Run the sniffs using a higher PHP and PHPCS version.
* Minor simplification in the command to call phpcs.
* Show warnings, but do not break the build for it. Previously warnings wouldn't be shown at all.
* Move a number of command line options to the ruleset.
* Exclude the Composer `vendor` directory if it exists.
* Update the section in the `Contributing.md` regarding code style