### PR TITLE
Update Travis CI example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ matrix:
       env: SNIFF=1
 
 before_install:
-  - if [[ "$SNIFF" == "1" ]]; export PHPCS_DIR=/tmp/phpcs; fi
-  - if [[ "$SNIFF" == "1" ]]; export SNIFFS_DIR=/tmp/sniffs; fi
+  - if [[ "$SNIFF" == "1" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
+  - if [[ "$SNIFF" == "1" ]]; then export SNIFFS_DIR=/tmp/sniffs; fi
   # Install PHP CodeSniffer.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.


### PR DESCRIPTION
When using the [Travis CI example](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#travis-ci) verbatim, the build seems to choke on:
```
- if [[ "$SNIFF" == "1" ]]; export PHPCS_DIR=/tmp/phpcs; fi
- if [[ "$SNIFF" == "1" ]]; export SNIFFS_DIR=/tmp/sniffs; fi
```
Adding `then` resolves that issue.

(In the current example the master branch of PHP_Codesniffer is used, which does not work with the current WPCS version. I guess this will be fixed via #1047.)