### PR TITLE
PHPCS 3.x compat: Update the pre-commit hook code

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -11,4 +11,4 @@ fi
 
 find . \( -name '*.php' \) -exec php -lf {} \;
 
-phpunit --filter WordPress "$phpcs_root/tests/AllTests.php"
+phpunit --bootstrap="./../Test/phpcs3-bootstrap.php" --filter WordPress "$phpcs_root/tests/AllTests.php"

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -11,4 +11,4 @@ fi
 
 find . \( -name '*.php' \) -exec php -lf {} \;
 
-phpunit --bootstrap="./../Test/phpcs3-bootstrap.php" --filter WordPress "$phpcs_root/tests/AllTests.php"
+PHPCS_DIR=$phpcs_root phpunit --bootstrap="./Test/phpcs3-bootstrap.php" --filter WordPress "$phpcs_root/tests/AllTests.php"


### PR DESCRIPTION
This update presumes that devs using this pre-commit hook will be using PHPCS 3.x.

N.B. Can someone who actually uses the pre-commit hook test this ? I'm on Windows and AFAIK this won't work there. /cc @westonruter 