### PR TITLE
Explicitly recommend v0.4.1+ of the DealerDirect Composer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For the convenience of using `phpcs` as a global command, you may want to add th
 When installing the WordPress Coding Standards as a dependency in a larger project, the above mentioned step 3 will not be executed automatically.
 
 There are two actively maintained Composer plugins which can handle the registration of standards with PHP_CodeSniffer for you:
-* [composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
+* [composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin):"^0.4.1"
 * [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer)
 
 It is strongly suggested to `require` one of these plugins in your project to handle the registration of external standards with PHPCS for you.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "*"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
Version 0.4.0 of the DealerDirect Composer plugin registers each standard individually as if they were root-directory standards, not a collection of standards, which exposes a bug in PHPCS 3.x.

Refs:
* squizlabs/PHP_CodeSniffer/pull/1581
* DealerDirect/phpcodesniffer-composer-installer/issues/33