### PR TITLE
PrefixAllGlobals: Improve recognition of namespaced constants using `define()`

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -626,6 +626,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				return;
 			}
 
+			if ( strpos( $raw_content, '\\' ) !== false ) {
+				// Namespaced or unreachable constant.
+				return;
+			}
+
 			$data       = array( 'Global constants defined' );
 			$error_code = 'NonPrefixedConstantFound';
 		} else {

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -13,3 +13,6 @@ const SOME_CONSTANT = 'value';
 class Example {}
 interface I_Example {}
 trait T_Example {}
+
+// Issue #1056.
+define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -306,3 +306,15 @@ do_action( 'acronym-action' ); // OK.
 apply_filters( 'acronym/filter', $var ); // OK.
 do_action( "acronym-action-{$acronym_filter_var}" ); // OK.
 apply_filters( 'acronym/filter-' . $acronym_filter_var ); // OK.
+
+// Issue #1056.
+define( 'SomeNameSpace\PLUGIN_FILE', __FILE__ ); // OK.
+define( '\OtherNameSpace\PLUGIN_FILE', __FILE__ ); // OK.
+// OK: unreachable constants.
+define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
+define( '\PLUGIN_FILE', __FILE__ );
+
+namespace Testing {
+	define( 'MY' . __NAMESPACE__, __FILE__ ); // Error, not actually namespaced.
+	define( 'MY\\' . __NAMESPACE__, __FILE__ ); // OK, even though strangely setup, the constant is in a namespace.
+}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -57,6 +57,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					230 => ( function_exists( '\array_column' ) ) ? 0 : 1,
 					234 => ( defined( '\E_DEPRECATED' ) ) ? 0 : 1,
 					238 => ( class_exists( '\IntlTimeZone' ) ) ? 0 : 1,
+					318  => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.1.inc':


### PR DESCRIPTION
Notes:
* Checking for the existence of a namespace separator should be enough here.
* Using `__NAMESPACE__` outside of a namespace will result in an empty string, however, the `\` in the string following it will be part of the namespace name, making the constant effectively unreachable (which is not our concern).

Fixes #1056