### PR TITLE
ArrayIndentation sniff: fix bug with multi-line strings as array value

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -224,9 +224,11 @@ class ArrayIndentationSniff extends Sniff {
 
 			// Find first token on second line of the array item.
 			// If the second line is a heredoc/nowdoc, continue on until we find a line with a different token.
+			// Same for the second line of a multi-line text string.
 			for ( $ptr = ( $first_content + 1 ); $ptr <= $item['end']; $ptr++ ) {
 				if ( $this->tokens[ $first_content ]['line'] !== $this->tokens[ $ptr ]['line']
-					&& ! isset( $this->ignore_tokens[ $this->tokens[ $ptr ]['code'] ] )
+					&& 1 === $this->tokens[ $ptr ]['column']
+					&& false === $this->ignore_token( $ptr )
 				) {
 					break;
 				}
@@ -323,8 +325,8 @@ class ArrayIndentationSniff extends Sniff {
 							break;
 						}
 
-						// Ignore lines with heredoc and nowdoc tokens.
-						if ( isset( $this->ignore_tokens[ $this->tokens[ $first_content_on_line ]['code'] ] ) ) {
+						// Ignore lines with heredoc and nowdoc tokens and subsequent lines in multi-line strings.
+						if ( true === $this->ignore_token( $first_content_on_line ) ) {
 							$i = $first_content_on_line;
 							continue;
 						}
@@ -378,6 +380,35 @@ class ArrayIndentationSniff extends Sniff {
 
 	} // End process_token().
 
+
+	/**
+	 * Should the token be ignored ?
+	 *
+	 * This method is only intended to be used with the first token on a line
+	 * for subsequent lines in an multi-line array item.
+	 *
+	 * @param int $ptr Stack pointer to the first token on a line.
+	 *
+	 * @return bool
+	 */
+	protected function ignore_token( $ptr ) {
+		$token_code = $this->tokens[ $ptr ]['code'];
+
+		if ( isset( $this->ignore_tokens[ $token_code ] ) ) {
+			return true;
+		}
+
+		// If it's a subsequent line of a multi-line sting, it will not start with a quote character.
+		if ( ( T_CONSTANT_ENCAPSED_STRING === $token_code
+			|| T_DOUBLE_QUOTED_STRING === $token_code )
+			&& "'" !== $this->tokens[ $ptr ]['content'][0]
+			&& '"' !== $this->tokens[ $ptr ]['content'][0]
+		) {
+			return true;
+		}
+
+		return false;
+	}
 
 	/**
 	 * Determine the line indentation whitespace.

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -334,3 +334,60 @@ $my_array = [
 			 */
 			apply_filters( '...', true ),
 ];
+
+/*
+ * Test multi-line strings as the value for an array item.
+ */
+$test => array(
+	'notes1'         => '<p>
+			Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+		</p>',
+
+	'notes1'         =>
+'<p>
+	Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>' . // The sniff should check & fix the next line as it is a new token.
+'<p>
+	This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+	Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>',
+
+	'notes1'         => // Same, but now using double quotes.
+"<p>
+	Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>" . // The sniff should check & fix the next line as it is a new token.
+"<p>
+	This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+	Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>",
+
+	// Now using double quotes with a variable to force T_DOUBLE_QUOTED_STRING token.
+	'notes1'         => array(
+		"<p>
+			Whether to use $abc or $def depends on what you want to know:
+		</p>" . // The sniff should check & fix the next line as it is a new token.
+	"<p>
+		This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+		Also note that $abc is faster than $def, but as said above, will return false if no value has been assigned.
+	</p>",
+	),
+
+	'notes2'         => array(
+		'<p><strong>Important</strong>: Integers between -128 and 255 are interpreted as the ASCII value pointing to a character (negative values have 256 added in order to allow characters in the Extended ASCII range).<br />
+		In any other case, integers are interpreted as a string containing the decimal digits of the integer.</p>',
+	),
+
+	'tooltip' => '
+if( ! is_array( $x ) ) {
+	filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+}
+else {
+	filter_var_array( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ); // = Simplified... see note
+}
+	',
+	'notes3'         => array(
+		'<p>Please note: On some PHP versions <code>filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE )</code> where <code>$x = false</code> will incorrectly return <code>null</code>.<br />
+		Also: with the same parameters filter_var() will return <code>false</code> instead of <code>null</code> for most objects.</p>',
+		'<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
+	),
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -334,3 +334,60 @@ $my_array = [
 		 */
 		apply_filters( '...', true ),
 ];
+
+/*
+ * Test multi-line strings as the value for an array item.
+ */
+$test => array(
+	'notes1'         => '<p>
+			Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+		</p>',
+
+	'notes1'         =>
+	'<p>
+	Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>' . // The sniff should check & fix the next line as it is a new token.
+	'<p>
+	This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+	Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>',
+
+	'notes1'         => // Same, but now using double quotes.
+	"<p>
+	Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>" . // The sniff should check & fix the next line as it is a new token.
+	"<p>
+	This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+	Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>",
+
+	// Now using double quotes with a variable to force T_DOUBLE_QUOTED_STRING token.
+	'notes1'         => array(
+		"<p>
+			Whether to use $abc or $def depends on what you want to know:
+		</p>" . // The sniff should check & fix the next line as it is a new token.
+		"<p>
+		This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+		Also note that $abc is faster than $def, but as said above, will return false if no value has been assigned.
+	</p>",
+	),
+
+	'notes2'         => array(
+		'<p><strong>Important</strong>: Integers between -128 and 255 are interpreted as the ASCII value pointing to a character (negative values have 256 added in order to allow characters in the Extended ASCII range).<br />
+		In any other case, integers are interpreted as a string containing the decimal digits of the integer.</p>',
+	),
+
+	'tooltip' => '
+if( ! is_array( $x ) ) {
+	filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+}
+else {
+	filter_var_array( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ); // = Simplified... see note
+}
+	',
+	'notes3'         => array(
+		'<p>Please note: On some PHP versions <code>filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE )</code> where <code>$x = false</code> will incorrectly return <code>null</code>.<br />
+		Also: with the same parameters filter_var() will return <code>false</code> instead of <code>null</code> for most objects.</p>',
+		'<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
+	),
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -181,7 +181,7 @@ EOD
 
 // Should report the second line and fix the second line + the comma on the last line.
 get_current_screen()->add_help_tab( array(
-    'id'		=>
+    'id'        =>
 <<<EOD
 Here comes some text.
 And some more text.
@@ -334,5 +334,62 @@ $my_array = [
              */
             apply_filters( '...', true ),
 ];
+
+/*
+ * Test multi-line strings as the value for an array item.
+ */
+$test => array(
+    'notes1'         => '<p>
+            Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+        </p>',
+
+    'notes1'         =>
+'<p>
+    Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>' . // The sniff should check & fix the next line as it is a new token.
+'<p>
+    This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+    Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>',
+
+    'notes1'         => // Same, but now using double quotes.
+"<p>
+    Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>" . // The sniff should check & fix the next line as it is a new token.
+"<p>
+    This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+    Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>",
+
+    // Now using double quotes with a variable to force T_DOUBLE_QUOTED_STRING token.
+    'notes1'         => array(
+        "<p>
+            Whether to use $abc or $def depends on what you want to know:
+        </p>" . // The sniff should check & fix the next line as it is a new token.
+    "<p>
+        This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+        Also note that $abc is faster than $def, but as said above, will return false if no value has been assigned.
+    </p>",
+    ),
+
+    'notes2'         => array(
+        '<p><strong>Important</strong>: Integers between -128 and 255 are interpreted as the ASCII value pointing to a character (negative values have 256 added in order to allow characters in the Extended ASCII range).<br />
+        In any other case, integers are interpreted as a string containing the decimal digits of the integer.</p>',
+    ),
+
+    'tooltip' => '
+if( ! is_array( $x ) ) {
+    filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+}
+else {
+    filter_var_array( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ); // = Simplified... see note
+}
+    ',
+    'notes3'         => array(
+        '<p>Please note: On some PHP versions <code>filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE )</code> where <code>$x = false</code> will incorrectly return <code>null</code>.<br />
+        Also: with the same parameters filter_var() will return <code>false</code> instead of <code>null</code> for most objects.</p>',
+        '<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
+    ),
+);
 
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -181,7 +181,7 @@ EOD
 
 // Should report the second line and fix the second line + the comma on the last line.
 get_current_screen()->add_help_tab( array(
-    'id'		=>
+    'id'        =>
     <<<EOD
 Here comes some text.
 And some more text.
@@ -334,5 +334,62 @@ $my_array = [
          */
         apply_filters( '...', true ),
 ];
+
+/*
+ * Test multi-line strings as the value for an array item.
+ */
+$test => array(
+    'notes1'         => '<p>
+            Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+        </p>',
+
+    'notes1'         =>
+    '<p>
+    Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>' . // The sniff should check & fix the next line as it is a new token.
+    '<p>
+    This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+    Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>',
+
+    'notes1'         => // Same, but now using double quotes.
+    "<p>
+    Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
+</p>" . // The sniff should check & fix the next line as it is a new token.
+    "<p>
+    This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+    Also note that <code>isset()</code> is faster than <code>array_key_exists()</code>, but as said above, will return false if no value has been assigned.
+</p>",
+
+    // Now using double quotes with a variable to force T_DOUBLE_QUOTED_STRING token.
+    'notes1'         => array(
+        "<p>
+            Whether to use $abc or $def depends on what you want to know:
+        </p>" . // The sniff should check & fix the next line as it is a new token.
+        "<p>
+        This said, we can concluded that to avoid warnings and undesired results you will always have to use an <code>is_array()</code> first.<br />
+        Also note that $abc is faster than $def, but as said above, will return false if no value has been assigned.
+    </p>",
+    ),
+
+    'notes2'         => array(
+        '<p><strong>Important</strong>: Integers between -128 and 255 are interpreted as the ASCII value pointing to a character (negative values have 256 added in order to allow characters in the Extended ASCII range).<br />
+        In any other case, integers are interpreted as a string containing the decimal digits of the integer.</p>',
+    ),
+
+    'tooltip' => '
+if( ! is_array( $x ) ) {
+    filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+}
+else {
+    filter_var_array( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ); // = Simplified... see note
+}
+    ',
+    'notes3'         => array(
+        '<p>Please note: On some PHP versions <code>filter_var( $x, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE )</code> where <code>$x = false</code> will incorrectly return <code>null</code>.<br />
+        Also: with the same parameters filter_var() will return <code>false</code> instead of <code>null</code> for most objects.</p>',
+        '<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
+    ),
+);
 
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -159,6 +159,9 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 			324 => 1,
 			331 => 1,
 			332 => 1,
+			347 => 1,
+			356 => 1,
+			369 => 1,
 		);
 	}
 


### PR DESCRIPTION
Subsequent lines in a multi-line text string should be ignored as the chosen indentation should be presumed intentional, like for HTML snippets.

Includes additional unit tests.

Fixes #1064