### PR TITLE
PrefixAllGlobalsSniff: allow "prefix + non-word char" for improved support of hook names

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -643,10 +643,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Check if a function/class/constant/variable name is prefixed with one of the expected prefixes.
 	 *
 	 * @since 0.12.0
+	 * @since 0.14.0 Allows for other non-word characters as well as underscores to better support hook names.
 	 *
 	 * @param string $name Name to check for a prefix.
 	 *
-	 * @return bool True when the name is the prefix or starts with the prefix + an underscore.
+	 * @return bool True when the name is the prefix or starts with the prefix + a separator.
 	 *              False otherwise.
 	 */
 	private function is_prefixed( $name ) {
@@ -660,7 +661,12 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				$prefix_found = stripos( $name, $prefix . '_' );
 
 				if ( 0 === $prefix_found ) {
-					// Ok, prefix found as start of hook/constant name.
+					// Ok, prefix found at start of hook/constant name.
+					return true;
+				}
+
+				if ( preg_match( '`^' . preg_quote( $prefix, '`' ) . '\W`i', $name ) === 1 ) {
+					// Ok, prefix with other non-word character found at start of hook/constant name.
 					return true;
 				}
 			}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -299,3 +299,10 @@ class Acronym_Dynamic_Hooks {
 		do_action( $this->parent_property ); // Warning.
 	}
 }
+
+// Dashes and other non-word characters are ok as a hook name separator after the prefix.
+// The rule that these should be underscores is handled by another sniff.
+do_action( 'acronym-action' ); // OK.
+apply_filters( 'acronym/filter', $var ); // OK.
+do_action( "acronym-action-{$acronym_filter_var}" ); // OK.
+apply_filters( 'acronym/filter-' . $acronym_filter_var ); // OK.


### PR DESCRIPTION
Words in hook names by default should be separated by underscores, however, this is checked by another sniff and not the concern of this sniff.
As that sniff `ValidHookName` also allows for passing other separator characters, this sniff should allow for an arbitrary word separator.