### PR TITLE
Add `is_class_property()` utility method and implement use of this and the other two new utility methods

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1777,7 +1777,12 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// USE keywords for traits.
-		if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_CLASS, T_ANON_CLASS, T_TRAIT ) ) ) {
+		$valid_scopes = array(
+			'T_CLASS'      => true,
+			'T_ANON_CLASS' => true,
+			'T_TRAIT'      => true,
+		);
+		if ( true === $this->valid_direct_scope( $stackPtr, $valid_scopes ) ) {
 			return 'trait';
 		}
 
@@ -2242,6 +2247,35 @@ abstract class Sniff implements PHPCS_Sniff {
 		);
 
 		return $this->valid_direct_scope( $stackPtr, $valid_scopes );
+	}
+
+	/**
+	 * Check whether a T_VARIABLE token is a class property declaration.
+	 *
+	 * @param int $stackPtr  The position in the stack of the T_VARIABLE token to verify.
+	 *
+	 * @return bool
+	 */
+	public function is_class_property( $stackPtr ) {
+		if ( ! isset( $this->tokens[ $stackPtr ] ) || T_VARIABLE !== $this->tokens[ $stackPtr ]['code'] ) {
+			return false;
+		}
+
+		// Note: interfaces can not declare properties.
+		$valid_scopes = array(
+			'T_CLASS'      => true,
+			'T_ANON_CLASS' => true,
+			'T_TRAIT'      => true,
+		);
+
+		if ( $this->valid_direct_scope( $stackPtr, $valid_scopes ) ) {
+			// Make sure it's not a method parameter.
+			if ( empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -270,7 +270,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 				case 'T_CONST':
 					// Constants in a class do not need to be prefixed.
-					if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ) ) === true ) {
+					if ( true === $this->is_class_constant( $stackPtr ) ) {
 						return;
 					}
 
@@ -488,11 +488,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 
 			// Properties in a class do not need to be prefixed.
-			$conditions = array_keys( $this->tokens[ $stackPtr ]['conditions'] );
-			$ptr        = array_pop( $conditions );
-			if ( isset( $this->tokens[ $ptr ] )
-				&& in_array( $this->tokens[ $ptr ]['code'], array( T_CLASS, T_ANON_CLASS, T_TRAIT ), true )
-			) {
+			if ( true === $this->is_class_property( $stackPtr ) ) {
 				return;
 			}
 


### PR DESCRIPTION
PR #1089 introduced two new utility methods to the `WordPress\Sniff` class: `is_class_constant()` and `valid_direct_scope()`.

This PR introduces one additional utility method `is_class_property()` and implements the use of this and the other two methods in other places in the code where appropriate (other than where they were originally introduced for).

These utility methods improve the accuracy of the scope detection.