### PR TITLE
Add new `CodeAnalysis.AssignmentInCondition` sniff to `Extra`

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -24,6 +24,10 @@
 	</rule>
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
+	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 -->
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
+
 	<!-- More generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
 	<rule ref="Squiz.PHP.NonExecutableCode"/>

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -169,7 +169,7 @@ class AssignmentInConditionSniff extends Sniff {
 
 			if ( true === $hasVariable ) {
 				$this->phpcsFile->addWarning(
-					'Variable assignment found within a condition. Did you mean to do a comparison ?',
+					'Variable assignment found within a condition. Did you mean to do a comparison?',
 					$hasAssignment,
 					'Found'
 				);
@@ -181,4 +181,4 @@ class AssignmentInConditionSniff extends Sniff {
 
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\CodeAnalysis;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Detects variable assignments being made within conditions.
+ *
+ * This is a typical code smell and more often than not a comparison was intended.
+ *
+ * Note: this sniff does not detect variable assignments in the conditional part of ternaries!
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of the same sniff as pulled upstream.
+ * Once the upstream sniff has been merged and the minimum WPCS PHPCS requirement has gone up to
+ * the version in which the sniff was merged, this version can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594} }}
+ */
+class AssignmentInConditionSniff extends Sniff {
+
+	/**
+	 * Assignment tokens to trigger on.
+	 *
+	 * Set in the register() method.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $assignment_tokens = array();
+
+	/**
+	 * The tokens that indicate the start of a condition.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $condition_start_tokens = array();
+
+	/**
+	 * Registers the tokens that this sniff wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$this->assignment_tokens = Tokens::$assignmentTokens;
+		unset( $this->assignment_tokens[ T_DOUBLE_ARROW ] );
+
+		$starters                       = Tokens::$booleanOperators;
+		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
+		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+
+		$this->condition_start_tokens = $starters;
+
+		return array(
+			T_IF,
+			T_ELSEIF,
+			T_FOR,
+			T_SWITCH,
+			T_CASE,
+			T_WHILE,
+		);
+
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$token = $this->tokens[ $stackPtr ];
+
+		// Find the condition opener/closer.
+		if ( T_FOR === $token['code'] ) {
+			if ( isset( $token['parenthesis_opener'], $token['parenthesis_closer'] ) === false ) {
+				return;
+			}
+
+			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $token['parenthesis_opener'] + 1 ), $token['parenthesis_closer'] );
+			if ( false === $semicolon ) {
+				return;
+			}
+
+			$opener    = $semicolon;
+			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $opener + 1 ), $token['parenthesis_closer'] );
+			if ( false === $semicolon ) {
+				return;
+			}
+
+			$closer = $semicolon;
+			unset( $semicolon );
+
+		} elseif ( T_CASE === $token['code'] ) {
+			if ( isset( $token['scope_opener'] ) === false ) {
+				return;
+			}
+
+			$opener = $stackPtr;
+			$closer = $token['scope_opener'];
+
+		} else {
+			if ( isset( $token['parenthesis_opener'], $token['parenthesis_closer'] ) === false ) {
+				return;
+			}
+
+			$opener = $token['parenthesis_opener'];
+			$closer = $token['parenthesis_closer'];
+		}
+
+		$startPos = $opener;
+
+		do {
+			$hasAssignment = $this->phpcsFile->findNext( $this->assignment_tokens, ( $startPos + 1 ), $closer );
+			if ( false === $hasAssignment ) {
+				return;
+			}
+
+			// Examine whether the left side is a variable.
+			$hasVariable       = false;
+			$conditionStart    = $startPos;
+			$altConditionStart = $this->phpcsFile->findPrevious(
+				$this->condition_start_tokens,
+				( $hasAssignment - 1 ),
+				$startPos
+			);
+			if ( false !== $altConditionStart ) {
+				$conditionStart = $altConditionStart;
+			}
+
+			for ( $i = $hasAssignment; $i > $conditionStart; $i-- ) {
+				if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+					continue;
+				}
+
+				// If this is a variable or array, we've seen all we need to see.
+				if ( T_VARIABLE === $this->tokens[ $i ]['code']
+					|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+				) {
+					$hasVariable = true;
+					break;
+				}
+
+				// If this is a function call or something, we are OK.
+				if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+					break;
+				}
+			}
+
+			if ( true === $hasVariable ) {
+				$this->phpcsFile->addWarning(
+					'Variable assignment found within a condition. Did you mean to do a comparison ?',
+					$hasAssignment,
+					'Found'
+				);
+			}
+
+			$startPos = $hasAssignment;
+
+		} while ( $startPos < $closer );
+
+	}
+
+} // End class.

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -152,8 +152,12 @@ class DirectDatabaseQuerySniff extends Sniff {
 		}
 
 		// Check for Database Schema Changes.
-		$_pos = $stackPtr;
-		while ( $_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, ( $_pos + 1 ), $endOfStatement, false, null, true ) ) {
+		for ( $_pos = ( $stackPtr + 1 ); $_pos < $endOfStatement; $_pos++ ) {
+			$_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, $_pos, $endOfStatement, false, null, true );
+			if ( false === $_pos ) {
+				break;
+			}
+
 			if ( preg_match( '#\b(?:ALTER|CREATE|DROP)\b#i', $this->tokens[ $_pos ]['content'] ) > 0 ) {
 				$this->phpcsFile->addError( 'Attempting a database schema change is highly discouraged.', $_pos, 'SchemaChange' );
 			}

--- a/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
@@ -1,0 +1,94 @@
+<?php
+
+// OK.
+if ($a === 123) {
+} elseif ($a == 123) {
+} elseif ($a !== 123) {
+} elseif ($a != 123) {}
+
+function abc( $a = 'default' ) {}
+if (in_array( $a, array( 1 => 'a', 2 => 'b' ) ) ) {}
+
+switch ( $a === $b ) {}
+switch ( true ) {
+	case $sample == 'something':
+		break;
+}
+
+for ( $i = 0; $i == 100; $i++ ) {}
+for ( $i = 0; $i >= 100; $i++ ) {}
+for ( $i = 0; ; $i++ ) {}
+for (;;) {}
+
+do {
+} while ( $sample == false );
+
+while ( $sample === false ) {}
+while (list($field_name, $file_names) = each($formfiles)) {}
+
+ // Silly, but not an assignment.
+if (123 = $a) {}
+if (strtolower($b) = $b) {}
+if (array( 1 => 'a', 2 => 'b' ) = $b) {}
+
+if (SOME_CONSTANT = 123) {
+} else if(self::SOME_CONSTANT -= 10) {}
+
+if ( $a() = 123 ) {
+} else if ( $b->something() = 123 ) {
+} elseif ( $c::something() = 123 ) {}
+
+switch ( true ) {
+	case 'something' = $sample:
+		break;
+}
+
+// Assignments in condition.
+if ($a = 123) {
+} elseif ($a = 'abc') {
+} else if( $a += 10 ) {
+} else if($a -= 10) {
+} else if($a *= 10) {
+} else if($a **= 10) {
+} else if($a /= 10) {
+} else if($a .= strtolower($b)) {
+} else if($a %= SOME_CONSTANT) {
+} else if($a &= 2) {
+} else if($a |= 2) {
+} else if($a ^= 2) {
+} else if($a <<= 2) {
+} else if($a >>= 2) {
+} else if($a ??= $b) {
+} elseif( $a = 'abc' && $b = 'def' ) {
+} elseif(
+    $a = 'abc'
+	&& $a .= 'def'
+) {}
+
+if ($a[] = 123) {
+} elseif ($a['something'] = 123) {
+} elseif (self::$a = 123) {
+} elseif (parent::$a *= 123) {
+} elseif (static::$a = 123) {
+} elseif (MyClass::$a .= 'abc') {
+} else if( $this->something += 10 ) {}
+
+switch ( $a = $b ) {}
+switch ( true ) {
+	case $sample = 'something':
+		break;
+
+	case $sample = 'something' && $a = $b:
+		break;
+}
+
+for ( $i = 0; $i = 100; $i++ ) {}
+for ( $i = 0; $i = 100 && $b = false; $i++ ) {}
+
+do {
+} while ( $sample = false );
+
+while ( $sample = false ) {}
+
+if ($a = 123) :
+endif;

--- a/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the AssignmentInCondition sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class AssignmentInConditionUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			47 => 1,
+			48 => 1,
+			49 => 1,
+			50 => 1,
+			51 => 1,
+			52 => 1,
+			53 => 1,
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
+			58 => 1,
+			59 => 1,
+			60 => 1,
+			61 => 1,
+			62 => 2,
+			64 => 1,
+			65 => 1,
+			68 => 1,
+			69 => 1,
+			70 => 1,
+			71 => 1,
+			72 => 1,
+			73 => 1,
+			74 => 1,
+			76 => 1,
+			78 => 1,
+			81 => 2,
+			85 => 1,
+			86 => 2,
+			89 => 1,
+			91 => 1,
+			93 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
Most of the time variable assignments being made in conditions are unintentional and are in actual fact typos which were intended as a comparison.
In those cases when it isn't a typo, this is a typical code smell which is a prime candidate for refactoring.

This sniff will warn when any such a variable assignment is found in a condition.

Note: the sniff does currently **not** detect variable assignments in the conditional part of ternaries.

Includes extensive unit tests.

Inspired by [this twitter thread](https://twitter.com/jrf_nl/status/893891839903838209), or rather: the responses I received to my tweet.

Note: the fact that WP uses Yoda conditions does **not** invalidate the need for this sniff.
The Yoda conditions sniff only checks comparison operators, not assignment operators.

I've run this sniff over WP Core to:
a) test the sniff and
b) see what it would turn up

And found 1004 cases in 847 files and visual verification of a sample of theses results showed no false positives.

AFAICS the cases found in WP Core are intentional assignments within conditions, however, as said above, that is an indicator that the code in question is due for some refactoring as this is definitely a code smell.

This sniff is a duplicate of the same which I've pulled upstream: squizlabs/PHP_CodeSniffer/pull/1594
The upstream sniff has been merged (rather quickly) and is due to be included in PHPCS 3.1.0. Once the minimum PHPCS requirement for WPCS has gone up beyond that version (i.e. after PHPCS 2.x support has been dropped), we can safely remove the WPCS version of the sniff.