### PR TITLE
Allow for setting the minimum supported WP version from the command line

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -14,34 +14,23 @@ use WordPress\AbstractClassRestrictionsSniff;
 /**
  * Restricts the use of deprecated WordPress classes and suggests alternatives.
  *
+ * This sniff will throw an error when usage of a deprecated class is detected
+ * if the class was deprecated before the minimum supported WP version;
+ * a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
-
-	/**
-	 * Minimum WordPress version.
-	 *
-	 * This sniff will throw an error when usage of a deprecated class is
-	 * detected if the class was deprecated before the minimum supported
-	 * WP version; a warning otherwise.
-	 * By default, it is set to presume that a project will support the current
-	 * WP version and up to three releases before.
-	 * This variable allows changing the minimum supported WP version used by
-	 * this sniff by setting a property in a custom phpcs.xml ruleset.
-	 *
-	 * Example usage:
-	 * <rule ref="WordPress.WP.DeprecatedClasses">
-	 *  <properties>
-	 *   <property name="minimum_supported_version" value="4.3"/>
-	 *  </properties>
-	 * </rule>
-	 *
-	 * @var string WordPress versions.
-	 */
-	public $minimum_supported_version = '4.5';
 
 	/**
 	 * List of deprecated classes with alternative when available.
@@ -92,6 +81,9 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 * @return void
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$this->get_wp_version_from_cl();
+
 		$class_name = ltrim( strtolower( $matched_content ), '\\' );
 
 		$message = 'The %s class has been deprecated since WordPress version %s.';

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -14,34 +14,23 @@ use WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Restricts the use of various deprecated WordPress functions and suggests alternatives.
  *
+ * This sniff will throw an error when usage of deprecated functions is detected
+ * if the function was deprecated before the minimum supported WP version;
+ * a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
-
-	/**
-	 * Minimum WordPress version.
-	 *
-	 * This sniff will throw an error when usage of deprecated functions is
-	 * detected if the function was deprecated before the minimum supported
-	 * WP version; a warning otherwise.
-	 * By default, it is set to presume that a project will support the current
-	 * WP version and up to three releases before.
-	 * This variable allows changing the minimum supported WP version used by
-	 * this sniff by setting a property in a custom phpcs.xml ruleset.
-	 *
-	 * Example usage:
-	 * <rule ref="WordPress.WP.DeprecatedFunctions">
-	 *  <properties>
-	 *   <property name="minimum_supported_version" value="4.3"/>
-	 *  </properties>
-	 * </rule>
-	 *
-	 * @var string WordPress versions.
-	 */
-	public $minimum_supported_version = '4.5';
 
 	/**
 	 * List of deprecated functions with alternative when available.
@@ -1341,6 +1330,9 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 * @return void
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$this->get_wp_version_from_cl();
+
 		$function_name = strtolower( $matched_content );
 
 		$message = '%s() has been deprecated since WordPress version %s.';

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -24,6 +24,11 @@ use WordPress\AbstractFunctionParameterSniff;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 
@@ -35,25 +40,6 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 * @var string
 	 */
 	protected $group_name = 'wp_deprecated_parameters';
-
-	/**
-	 * Minimum WordPress version.
-	 *
-	 * This variable allows changing the minimum supported WP version used by
-	 * this sniff by setting a property in a custom ruleset XML file.
-	 *
-	 * Example usage:
-	 * <rule ref="WordPress.WP.DeprecatedParameters">
-	 *  <properties>
-	 *   <property name="minimum_supported_version" value="4.5"/>
-	 *  </properties>
-	 * </rule>
-	 *
-	 * @since 0.12.0
-	 *
-	 * @var string WordPress version.
-	 */
-	public $minimum_supported_version = 4.5;
 
 	/**
 	 * Array of function, argument, and default value for deprecated argument.
@@ -293,6 +279,9 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+
+		$this->get_wp_version_from_cl();
+
 		$paramCount = count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 


### PR DESCRIPTION
This PR addresses the comments made here: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/826#discussion_r127965474

This change allows for setting the `minimum_supported_version` property for all three `WP.Deprecated...` sniffs in one go, either via the command-line or by setting a config variable in a custom ruleset.

As this config variable is no longer directly related to a sniff, I've chosen to make the name slightly more specific/descriptive: `minimum_supported_wp_version` <= note the `_wp_`.

Usage:
```bash
phpcs . --standard=WordPress --runtime-set minimum_supported_wp_version 4.5
```

or in a ruleset:
```xml
<config name="minimum_supported_wp_version" value="4.5"/>
```

The above one liner can replace the custom property which would otherwise need to be set for all three sniffs individually.

Overrule order:
1. Value passed via the command line
2. `<config>` property in the ruleset
3. Individual sniff `<property>`'s set via the ruleset
4. Default value

Simplest way to test this is by running PHPCS over the `WP.DeprecatedParameter` sniff unit tests:
```bash
phpcs -p -s ./WordPress/Tests/DeprecatedParametersUnitTest.inc --standard=WordPress --sniffs=WordPress.WP.DeprecatedParameters

phpcs -p -s ./WordPress/Tests/DeprecatedParametersUnitTest.inc --standard=WordPress --sniffs=WordPress.WP.DeprecatedParameters --runtime-set minimum_supported_wp_version 4.8

phpcs -p -s ./WordPress/Tests/DeprecatedParametersUnitTest.inc --standard=WordPress --sniffs=WordPress.WP.DeprecatedParameters --runtime-set minimum_supported_wp_version 3.8
```

Additional notes:
* I've moved the `$custom_test_class_whitelist` property up in the `WordPress\Sniff` class, so both `public` properties are now at the top of the file.

-----
 To do once this PR is merged:
- [ ] Update the customizable properties wiki page with information about this feature