### PR TITLE
XSS.EscapeOutput sniff: Fix issue #933 - namespace separators.

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -291,6 +291,11 @@ class EscapeOutputSniff extends Sniff {
 				continue;
 			}
 
+			// Ignore namespace separators.
+			if ( T_NS_SEPARATOR === $this->tokens[ $i ]['code'] ) {
+				continue;
+			}
+
 			if ( T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 
 				if ( ! isset( $this->tokens[ $i ]['parenthesis_closer'] ) ) {

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -225,3 +225,15 @@ echo 8 * 1.2; // Ok.
 <?= $var['foo']; ?><!-- Bad. -->
 <?= $var->foo ?><!-- Bad. -->
 <?php
+
+// Issue #933. OK.
+function do_footer_nav() {
+	echo \wp_kses_post(
+		\genesis_get_nav_menu(
+			[
+				'menu_class'     => 'menu genesis-nav-menu menu-footer',
+				'theme_location' => 'footer',
+			]
+		)
+	);
+}


### PR DESCRIPTION
This simple change means that namespace separators will be be ignored completely by the check for output escaping which fixes the immediate issue.

For a more thorough fix, the logic of the function would need to be refactored to take namespaced functions into account as well, but that's for another day.

Fixes #933