### PR TITLE
New `WhiteSpace.PrecisionAlignment` sniff for `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -46,6 +46,7 @@
 
 	<!-- Covers rule: Use real tabs and not spaces. -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+	<rule ref="WordPress.WhiteSpace.PrecisionAlignment"/>
 
 	<!-- Generic array layout check. -->
 	<!-- Covers rule: For associative arrays, values should start on a new line.

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use WordPress\PHPCSHelper;
+
+/**
+ * Warn on line indentation ending with spaces for precision alignment.
+ *
+ * WP demands tabs for indentation. In rare cases, spaces for precision alignment can be
+ * intentional and acceptable, but more often than not, this is a typo.
+ *
+ * The `Generic.WhiteSpace.DisallowSpaceIndent` sniff already checks for space indentation
+ * and auto-fixes to tabs.
+ *
+ * This sniff only checks for precision alignments which can not be corrected by the
+ * `Generic.WhiteSpace.DisallowSpaceIndent` sniff.
+ *
+ * As this may be intentional, this sniff explicitly does *NOT* contain a fixer.
+ *
+ * @link    https://make.wordpress.org/core/handbook/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class PrecisionAlignmentSniff extends Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+		'CSS',
+	);
+
+	/**
+	 * Allow for providing a list of tokens for which (preceding) precision alignment should be ignored.
+	 *
+	 * <rule ref="WordPress.WhiteSpace.PrecisionAlignment">
+	 *    <properties>
+	 *        <property name="ignoreAlignmentTokens" type="array"
+	 *             value="T_COMMENT,T_INLINE_HTML"/>
+	 *    </properties>
+	 * </rule>
+	 *
+	 * @var array
+	 */
+	public $ignoreAlignmentTokens = array();
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
+		}
+
+		// Handle any custom ignore tokens received from a ruleset.
+		$this->ignoreAlignmentTokens = $this->merge_custom_array( $this->ignoreAlignmentTokens );
+
+		$check_tokens = array(
+			T_WHITESPACE             => true,
+			T_INLINE_HTML            => true,
+			T_DOC_COMMENT_WHITESPACE => true,
+			T_COMMENT                => true,
+		);
+
+		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+			if ( ! isset( $this->tokens[ ( $i + 1 ) ] ) ) {
+				break;
+			}
+
+			if ( 1 !== $this->tokens[ $i ]['column'] ) {
+				continue;
+			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) === false
+				|| T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code']
+				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar
+				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
+				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] )
+			) {
+				continue;
+			}
+
+			$spaces = 0;
+			switch ( $this->tokens[ $i ]['type'] ) {
+				case 'T_WHITESPACE':
+					$spaces = ( $this->tokens[ $i ]['length'] % $this->tab_width );
+					break;
+
+				case 'T_DOC_COMMENT_WHITESPACE':
+					$length = $this->tokens[ $i ]['length'];
+					if ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
+						|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code']
+					) {
+						// One alignment space expected before the *.
+						$length--;
+					}
+
+					$spaces = ( $length % $this->tab_width );
+					break;
+
+				case 'T_COMMENT':
+					/*
+					 * Indentation whitespace for subsequent lines of multi-line comments
+					 * are tokenized as part of the comment.
+					 */
+					$comment    = ltrim( $this->tokens[ $i ]['content'] );
+					$whitespace = str_replace( $comment, '', $this->tokens[ $i ]['content'] );
+					$length     = strlen( $whitespace );
+					if ( '*' === $comment[0] ) {
+						$length--;
+					}
+
+					$spaces = ( $length % $this->tab_width );
+					break;
+
+				case 'T_INLINE_HTML':
+					if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
+						$spaces = 0;
+					} else {
+						/*
+						 * Indentation whitespace for inline HTML is part of the T_INLINE_HTML token.
+						 */
+						$content    = ltrim( $this->tokens[ $i ]['content'] );
+						$whitespace = str_replace( $content, '', $this->tokens[ $i ]['content'] );
+						$length     = strlen( $whitespace );
+						$spaces     = ( strlen( $whitespace ) % $this->tab_width );
+					}
+					break;
+			}
+
+			if ( $spaces > 0 && ! $this->has_whitelist_comment( 'precision alignment', $i ) ) {
+				$this->phpcsFile->addWarning(
+					'Found precision alignment of %s spaces.',
+					$i,
+					'Found',
+					array( $spaces )
+				);
+			}
+		}
+
+		// Ignore the rest of the file.
+		return ( $this->phpcsFile->numTokens + 1 );
+
+	} // End process().
+
+} // End class.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -1,0 +1,42 @@
+<?php
+
+	function exampleFunction() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space].
+ * The four spaces will be replaced by a tab by the upstream sniff.
+ */
+	    function exampleFunction() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab].
+ * The space replacement here will be handled by the upstream sniff.
+ */
+	  	 	function exampleFunction() {}
+
+	/**
+	 * OK: Doc comments are indented with tabs and one space.
+	 *
+	  * @var string  <= Bad.
+	 * @access private
+	 */
+
+	/*
+	 * OK: Multi-line comments are indented with tabs and one space.
+	 *
+	   * <= Bad.
+	 */
+
+	 function exampleFunction() {} // Bad: [tab][space].
+	  function exampleFunction() {} // Bad: [tab][space][space].
+	   function exampleFunction() {} // Bad: [tab][space][space][space].
+
+	 function exampleFunction() {} // WPCS: precision alignment ok.
+
+?>
+
+	<p>
+	  Bad: Some text with precision alignment.
+	</p>
+
+<?php

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -1,0 +1,44 @@
+@codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_COMMENT,T_DOC_COMMENT_WHITESPACE,T_INLINE_HTML,T_FUNCTION
+
+<?php
+
+	function exampleFunction() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space].
+ * The four spaces will be replaced by a tab by the upstream sniff.
+ */
+	    function exampleFunction() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab].
+ * The space replacement here will be handled by the upstream sniff.
+ */
+	  	 	function exampleFunction() {}
+
+	/**
+	 * OK: Doc comments are indented with tabs and one space.
+	 *
+	  * @var string  <= Bad.
+	 * @access private
+	 */
+
+	/*
+	 * OK: Multi-line comments are indented with tabs and one space.
+	 *
+	   * <= Bad.
+	 */
+
+	 function exampleFunction() {} // Bad: [tab][space].
+	  function exampleFunction() {} // Bad: [tab][space][space].
+	   function exampleFunction() {} // Bad: [tab][space][space][space].
+
+?>
+
+	<p>
+	  Bad: Some text with precision alignment.
+	</p>
+
+<?php
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_NONE

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.3.inc
@@ -1,0 +1,14 @@
+<?php
+/*
+Plugin Name: Hello Dolly
+Plugin URI: http://wordpress.org/#
+Description: This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.
+Author: Matt Mullenweg
+Version: 1.5.1
+Author URI: http://ma.tt/
+Text Domain: hello-dolly
+
+*/
+
+// Test for 
+?>

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.css
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.css
@@ -1,0 +1,5 @@
+#login-container {
+    margin-left: -225px;
+	width: 450px;
+	 height: 450px; /* Bad. */
+}

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.js
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.js
@@ -1,0 +1,7 @@
+var x = {
+	abc: 1,
+    zyz: 2,
+	 mno: {
+	   abc: 4
+	 },
+}

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PrecisionAlignment sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * The tab width to use during testing.
+	 *
+	 * @var int
+	 */
+	private $tab_width = 4;
+
+	/**
+	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * Used by PHPCS 2.x.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array
+	 */
+	public function getCliValues( $testFile ) {
+		return array( '--tab-width=' . $this->tab_width );
+	}
+
+	/**
+	 * Set CLI values before the file is tested.
+	 *
+	 * Used by PHPCS 3.x.
+	 *
+	 * @param string                  $testFile The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $testFile, $config ) {
+		$config->tabWidth = $this->tab_width;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'PrecisionAlignmentUnitTest.1.inc':
+				return array(
+					20 => 1,
+					27 => 1,
+					30 => 1,
+					31 => 1,
+					32 => 1,
+					39 => 1,
+				);
+
+			case 'PrecisionAlignmentUnitTest.css':
+				return array(
+					4 => 1,
+				);
+
+			case 'PrecisionAlignmentUnitTest.js':
+				return array(
+					4 => 1,
+					5 => 1,
+					6 => 1,
+				);
+
+			case 'PrecisionAlignmentUnitTest.2.inc':
+			case 'PrecisionAlignmentUnitTest.3.inc':
+			default:
+				return array();
+		}
+	}
+
+} // End class.


### PR DESCRIPTION
This sniff complements the upstream `Generic.WhiteSpace.DisallowSpaceIndent` sniff.

The `Generic.WhiteSpace.DisallowSpaceIndent` sniff makes sure that tabs are used for indentation instead of spaces.
However, the sniff allows for precision alignment of `# spaces < tab_width`.

In WP it is not customary to use precision alignment, though there are a few exceptions where it is used intentionally.

This means that precision alignment can not be auto-fixed.

We can, however, throw a warning when precision alignment is detected which is what this sniff implements.

Notes:
* This sniff will detect precision alignment in PHP, JS as well as CSS files.
* The sniff adds a new `precision alignment` whitelist comment.
* The sniff will handle the "space before star"precision alignment for comments without issue.
* The sniff adds a new custom property which allows users to pass an array of tokens to ignore for the purposes of this sniff. By default nothing is ignored.

Includes unit tests.

I've added the sniff to the `Core` ruleset as this is one of the issues which came out of the initial review of auto-fixed core files.

A run of the sniff over the `/src/` directory of core (using the current `phpcs.xml.5.dist` basis) results in 281 infractions in 68 files. See the attachment for details: 
[20170809-precision-alignment.txt](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/files/1210448/20170809-precision-alignment.txt)

A visual inspection shows no false positives and that nearly all of the infractions found should be corrected. There are only very few, where by the looks of it, the precision alignment was actually intended as such.

/cc @pento 

Fixes #983

-----

#### To do once the sniff is merged:
- [ ] Add the new whitelist flag to the wiki page.
- [ ] Add the new property to the wiki page.