### PR TITLE
ArrayDeclarationSpacing: add a property to make an exception for single item associative arrays

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -36,8 +36,20 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *                 which were not covered elsewhere. The `ArrayDeclaration` sniff has
  *                 now been deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Single item associative arrays can now be excepted from the
+ *                 "must be multi-line" rule using the
+ *                 `allow_single_item_single_line_associative_arrays` property.
  */
 class ArrayDeclarationSpacingSniff extends Sniff {
+
+	/**
+	 * Whether or not to allow single item associative arrays to be single line.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool Defaults to false.
+	 */
+	public $allow_single_item_single_line_associative_arrays = false;
 
 	/**
 	 * Token this sniff targets.
@@ -176,7 +188,11 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 
 			$array_items = $this->get_function_call_parameters( $stackPtr );
 
-			if ( ! empty( $array_items ) ) {
+			if ( ( false === $this->allow_single_item_single_line_associative_arrays
+					&& ! empty( $array_items ) )
+				|| ( true === $this->allow_single_item_single_line_associative_arrays
+					&& count( $array_items ) > 1 )
+			) {
 				/*
 				 * Make sure the double arrow is for *this* array, not for a nested one.
 				 */

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -36,8 +36,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *                 which were not covered elsewhere. The `ArrayDeclaration` sniff has
  *                 now been deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Single item associative arrays can now be excepted from the
- *                 "must be multi-line" rule using the
+ * @since   0.14.0 Single item associative arrays are now by default exempt from the
+ *                 "must be multi-line" rule. This behaviour can be changed using the
  *                 `allow_single_item_single_line_associative_arrays` property.
  */
 class ArrayDeclarationSpacingSniff extends Sniff {
@@ -47,9 +47,9 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 	 *
 	 * @since 0.14.0
 	 *
-	 * @var bool Defaults to false.
+	 * @var bool Defaults to true.
 	 */
-	public $allow_single_item_single_line_associative_arrays = false;
+	public $allow_single_item_single_line_associative_arrays = true;
 
 	/**
 	 * Token this sniff targets.
@@ -219,10 +219,15 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 
 				if ( true === $array_has_keys ) {
 
+					$phrase = 'an';
+					if ( true === $this->allow_single_item_single_line_associative_arrays ) {
+						$phrase = 'a multi-item';
+					}
 					$fix = $this->phpcsFile->addFixableError(
-						'When an array uses associative keys, each value should start on a new line.',
+						'When %s array uses associative keys, each value should start on a new line.',
 						$closer,
-						'AssociativeKeyFound'
+						'AssociativeArrayFound',
+						array( $phrase )
 					);
 
 					if ( true === $fix ) {

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
@@ -10,7 +10,7 @@ $query_vars = array('food'); // Bad, no spaces after opening and before closing 
 // Test for fixing of extra whitespace.
 $test = array(   1, 2     );
 
-$bad = array( 'key' => 'value' ); // Bad, each value of an associative array should start on a new line.
+$bad = array( 'key' => 'value' ); // OK, one item single-line associative arrays are ok.
 
 // Test for fixing nested associative arrays.
 $bad = array( array( 'key1' => 'value1', 'key2' => array('sub1' => 1, 'sub2' => 2) ), $key3 => 'value3', array( 'value4', 10 => 'value5', ) ); // Bad.
@@ -100,12 +100,12 @@ $foo = array(1
 $fields = array(
 	'value' => 'type');
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
-
-$bad = array( 'key' => 'value' ); // OK.
 $bad = array('key' => 'value'); // Bad, spacing around parenthesis.
 $bad = array(     'key' => 'value'     ); // Bad, spacing around parenthesis.
 
-$bad = array( 'key1' => 'value1', 'key2' => 'value2' ); // Bad, more than one item should still be fixed.
-
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+
+$bad = array( 'key' => 'value' ); // Bad.
+$bad = array( 'key1' => 'value1', 'key2' => 'value2' ); // Bad.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
@@ -99,3 +99,13 @@ $foo = array(1
 
 $fields = array(
 	'value' => 'type');
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+
+$bad = array( 'key' => 'value' ); // OK.
+$bad = array('key' => 'value'); // Bad, spacing around parenthesis.
+$bad = array(     'key' => 'value'     ); // Bad, spacing around parenthesis.
+
+$bad = array( 'key1' => 'value1', 'key2' => 'value2' ); // Bad, more than one item should still be fixed.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
@@ -10,9 +10,7 @@ $query_vars = array( 'food' ); // Bad, no spaces after opening and before closin
 // Test for fixing of extra whitespace.
 $test = array( 1, 2 );
 
-$bad = array(
-'key' => 'value'
-); // Bad, each value of an associative array should start on a new line.
+$bad = array( 'key' => 'value' ); // OK, one item single-line associative arrays are ok.
 
 // Test for fixing nested associative arrays.
 $bad = array(
@@ -152,15 +150,17 @@ $fields = array(
 	'value' => 'type'
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
-
-$bad = array( 'key' => 'value' ); // OK.
 $bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
 $bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
 
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+
+$bad = array(
+'key' => 'value'
+); // Bad.
 $bad = array(
 'key1' => 'value1',
 'key2' => 'value2'
-); // Bad, more than one item should still be fixed.
+); // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
@@ -151,3 +151,16 @@ $foo = array(
 $fields = array(
 	'value' => 'type'
 );
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+
+$bad = array( 'key' => 'value' ); // OK.
+$bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
+$bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
+
+$bad = array(
+'key1' => 'value1',
+'key2' => 'value2'
+); // Bad, more than one item should still be fixed.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
@@ -82,3 +82,13 @@ $foo = [1
 
 $fields = [
 	'value' => 'type'];
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+
+$bad = [ 'key' => 'value' ]; // OK.
+$bad = ['key' => 'value']; // Bad, spacing around parenthesis.
+$bad = [     'key' => 'value'     ]; // Bad, spacing around parenthesis.
+
+$bad = [ 'key1' => 'value1', 'key2' => 'value2' ]; // Bad, more than one item should still be fixed.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
@@ -10,7 +10,7 @@ $query_vars = ['food']; // Bad, no spaces after opening and before closing paren
 // Test for fixing of extra whitespace.
 $test = [   1, 2     ];
 
-$bad = [ 'key' => 'value' ]; // Bad, each value of an associative array should start on a new line.
+$bad = [ 'key' => 'value' ]; // OK, one item single-line associative arrays are ok.
 
 // Test for fixing nested associative arrays.
 $bad = [ [ 'key1' => 'value1', 'key2' => ['sub1' => 1, 'sub2' => 2] ], $key3 => 'value3', [ 'value4', 10 => 'value5', ] ]; // Bad.
@@ -83,12 +83,12 @@ $foo = [1
 $fields = [
 	'value' => 'type'];
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
-
-$bad = [ 'key' => 'value' ]; // OK.
 $bad = ['key' => 'value']; // Bad, spacing around parenthesis.
 $bad = [     'key' => 'value'     ]; // Bad, spacing around parenthesis.
 
-$bad = [ 'key1' => 'value1', 'key2' => 'value2' ]; // Bad, more than one item should still be fixed.
-
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+
+$bad = [ 'key' => 'value' ]; // Bad.
+$bad = [ 'key1' => 'value1', 'key2' => 'value2' ]; // Bad.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
@@ -10,9 +10,7 @@ $query_vars = [ 'food' ]; // Bad, no spaces after opening and before closing par
 // Test for fixing of extra whitespace.
 $test = [ 1, 2 ];
 
-$bad = [
-'key' => 'value'
-]; // Bad, each value of an associative array should start on a new line.
+$bad = [ 'key' => 'value' ]; // OK, one item single-line associative arrays are ok.
 
 // Test for fixing nested associative arrays.
 $bad = [
@@ -136,15 +134,17 @@ $fields = [
 	'value' => 'type'
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
-
-$bad = [ 'key' => 'value' ]; // OK.
 $bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
 $bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
 
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+
+$bad = [
+'key' => 'value'
+]; // Bad.
 $bad = [
 'key1' => 'value1',
 'key2' => 'value2'
-]; // Bad, more than one item should still be fixed.
+]; // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
@@ -135,3 +135,16 @@ $foo = [
 $fields = [
 	'value' => 'type'
 ];
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+
+$bad = [ 'key' => 'value' ]; // OK.
+$bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
+$bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
+
+$bad = [
+'key1' => 'value1',
+'key2' => 'value2'
+]; // Bad, more than one item should still be fixed.
+
+// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -36,7 +36,6 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 				return array(
 					8   => 2,
 					11  => 2,
-					13  => 1,
 					16  => 4,
 					20  => 2,
 					22  => 1,
@@ -59,8 +58,9 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 					97  => 1,
 					98  => 2,
 					101 => 1,
-					106 => 2,
-					107 => 2,
+					103 => 2,
+					104 => 2,
+					108 => 1,
 					109 => 1,
 				);
 
@@ -69,7 +69,6 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 				return array(
 					8   => 2,
 					11  => 2,
-					13  => 1,
 					16  => 4,
 					20  => 2,
 					22  => 1,
@@ -88,8 +87,9 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 					80  => 1,
 					81  => 2,
 					84  => 1,
-					89  => 2,
-					90  => 2,
+					86  => 2,
+					87  => 2,
+					91  => 1,
 					92  => 1,
 				);
 

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -59,6 +59,9 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 					97  => 1,
 					98  => 2,
 					101 => 1,
+					106 => 2,
+					107 => 2,
+					109 => 1,
 				);
 
 			// Short arrays.
@@ -85,6 +88,9 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 					80  => 1,
 					81  => 2,
 					84  => 1,
+					89  => 2,
+					90  => 2,
+					92  => 1,
 				);
 
 			default:


### PR DESCRIPTION
Allow for a property to be set in a custom ruleset to allow single item associative arrays to be single line.

If someone can come up with a better (less lengthy) property name: please let me know and I'd happily adjust the PR.

I've chosen to implement this as a `true`/`false` toggle.
The toggle defaults to `false` based on the rule as it is in the handbook.

Alternatively, it could be implemented numerically, i.e. number of items needed before the associative array rule takes effect with a default of `0`, but that felt like it would make the rule very arbitrary where one project would have it at `1`, another at `3` etc., which would counter the use of having the rule at all.

Fixes #1104

----

#### TO DO

- [ ] Add info on the new property to the customizable properties wiki page