### PR TITLE
Extra: Encourage the best practice of only declaring one class/interface/trait per file

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -47,6 +47,22 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
 
+	<!-- Encourage having only one class/interface/trait per file. -->
+	<!-- Once the minimum WPCS PHPCS requirement has gone up to PHPCS 3.1.0, these three sniffs can be
+	     replaced by the more comprehensive Generic.Files.OneObjectStructurePerFile sniff. -->
+	<rule ref="Generic.Files.OneClassPerFile">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one class in a file.</message>
+	</rule>
+	<rule ref="Generic.Files.OneInterfacePerFile">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one interface in a file.</message>
+	</rule>
+	<rule ref="Generic.Files.OneTraitPerFile">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one trait in a file.</message>
+	</rule>
+
 	<rule ref="WordPress-Core"/>
 
 	<!-- Verify modifier keywords for declared methods and properties in classes.


### PR DESCRIPTION
PHPCS 3.1.0 will introduce a new `Generic.Files.OneObjectStructurePerFile` sniff will which check for all three in one go, but cannot be used yet. See: https://github.com/squizlabs/PHP_CodeSniffer/issues/1627 and https://github.com/squizlabs/PHP_CodeSniffer/pull/1630

The current sniffs in this proposal will not catch one file containing a class + an interface + a trait, but will catch any file containing two or more of the same type of object structure.

I've chosen to downgrade the message to a warning and to soften the error message a little.
Once these sniffs have been in for a while and we have not received negative feedback about them, we could chose to defer to the upstream sniffs and let them `error` with a sterner message.