### PR TITLE
Fix syntax error in test file

### DIFF
--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.inc
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.inc
@@ -18,3 +18,6 @@ $_REQUEST['wp_customize'] = 'on'; // Ok.
 
 // Issue: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/542
 if ( isset( $_GET['updated'] ) ) { // input var okay ?>
+   // Do something.
+<?php
+}


### PR DESCRIPTION
Wasn't impeding the unit tests or anything, but was causing issues when I was running some tests to detect fixer conflicts.

Fixing the syntax error will allow for adding an additional test to the travis run to automatically check for fixer conflicts based on the existing unit tests at some point in the future.

For this additional travis test to be added, upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/1645 will need to be merged first.