### PR TITLE
WhiteSpace.PrecisionAlignment: fix potential fatal error

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -141,7 +141,7 @@ class PrecisionAlignmentSniff extends Sniff {
 					$comment    = ltrim( $this->tokens[ $i ]['content'] );
 					$whitespace = str_replace( $comment, '', $this->tokens[ $i ]['content'] );
 					$length     = strlen( $whitespace );
-					if ( '*' === $comment[0] ) {
+					if ( isset( $comment[0] ) && '*' === $comment[0] ) {
 						$length--;
 					}
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -40,3 +40,8 @@
 	</p>
 
 <?php
+
+// Testing empty line within a comment.
+/*
+
+*/


### PR DESCRIPTION
If a multi-line comment contained a completely empty line, the sniff would throw a fatal error: `Fatal error: Uninitialized string offset: 0 in WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php on line 144`.

This fixes that.