### PR TITLE
Fix Precision Alignment issues found in the WPCS code base

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -149,9 +149,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		$inst = array();
 
 		/*
-		   Covers:
-		   $foo = array( 'bar' => 'taz' );
-		   $foo['bar'] = $taz;
+		 * Covers:
+		 * $foo = array( 'bar' => 'taz' );
+		 * $foo['bar'] = $taz;
 		 */
 		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1660,8 +1660,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		if ( $in_condition_only ) {
 			/*
-			   This is a stricter check, requiring the variable to be used only
-			   within the validation condition.
+			 * This is a stricter check, requiring the variable to be used only
+			 * within the validation condition.
 			 */
 
 			// If there are no conditions, there's no validation.
@@ -1684,8 +1684,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		} else {
 			/*
-			   We are are more loose, requiring only that the variable be validated
-			   in the same function/file scope as it is used.
+			 * We are are more loose, requiring only that the variable be validated
+			 * in the same function/file scope as it is used.
 			 */
 
 			$scope_start = 0;

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -146,9 +146,9 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 		if ( 0 === strpos( $methodName, '__' ) ) {
 			$magicPart = strtolower( substr( $methodName, 2 ) );
 			if ( ! isset( $this->magicMethods[ $magicPart ] ) && ! isset( $this->methodsDoubleUnderscore[ $magicPart ] ) ) {
-				 $error     = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
-				 $errorData = array( $className . '::' . $methodName );
-				 $phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore', $errorData );
+				$error     = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+				$errorData = array( $className . '::' . $methodName );
+				$phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore', $errorData );
 			}
 
 			return;

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -112,8 +112,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 				$string = $this->strip_quotes( $this->tokens[ $i ]['content'] );
 
 				/*
-				   Here be dragons - a double quoted string can contain extrapolated variables
-				   which don't have to comply with these rules.
+				 * Here be dragons - a double quoted string can contain extrapolated variables
+				 * which don't have to comply with these rules.
 				 */
 				if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
 					$transform       = $this->transform_complex_string( $string, $regex );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -169,7 +169,7 @@ class I18nSniff extends Sniff {
 
 		$func_open_paren_token = $this->phpcsFile->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
 		if ( false === $func_open_paren_token || T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code'] ) {
-			 return;
+			return;
 		}
 
 		$arguments_tokens = array();


### PR DESCRIPTION
When the Precision Alignment sniff was pulled, the issues this threw up in the WPCS codebase were not fixed (yet). This PR fixed that.