### PR TITLE
Update example ruleset based on feedback

### DIFF
--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -28,10 +28,15 @@
 		see the names of the sniffs reporting errors.
 		Once we know the sniff names, we can opt to exclude sniffs which don't
 		suit our project like so.
+
+		The below two examples just show how you can exclude rules.
+		They are not intended as advice about which sniffs to exclude.
 		-->
 
+		<!--
 		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
 		<exclude name="WordPress.XSS.EscapeOutput"/>
+		-->
 	</rule>
 
 	<!-- Let's also check that everything is properly documented. -->


### PR DESCRIPTION
Issue #1128 raised the interesting point that example exclusions maybe taken over literally by people who are not as familiar with PHPCS.

This minor change should prevent that.