### PR TITLE
Fix travis build: load PHPCS native bootstrap if available and test against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - nightly
 
 env:
@@ -33,7 +34,7 @@ matrix:
           packages:
             - libxml2-utils
 
-    # Run against HHVM and PHP nightly.
+    # Run against HHVM.
     - php: hhvm
       sudo: required
       dist: trusty

--- a/Test/phpcs3-bootstrap.php
+++ b/Test/phpcs3-bootstrap.php
@@ -34,6 +34,14 @@ if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 
 // Try and load the PHPCS autoloader.
 if ( false !== $phpcsDir && file_exists( $phpcsDir . $ds . 'autoload.php' ) ) {
 	require_once $phpcsDir . $ds . 'autoload.php';
+
+	/*
+	 * As of PHPCS 3.1, PHPCS support PHPUnit 6.x, but needs a bootstrap, so
+	 * load it if it's available.
+	 */
+	if ( file_exists( $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php' ) ) {
+		require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php';
+	}
 } else {
 	echo 'Uh oh... can\'t find PHPCS. Are you sure you are using PHPCS 3.x ?
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,5 +4,6 @@
 	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
 	backupGlobals="true"
 	bootstrap="./Test/bootstrap.php"
+	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true">
 </phpunit>


### PR DESCRIPTION
The upstream PR to support PHPUnit 6.x has (finally) been merged and will be released in PHPCS 3.1.

Currently builds against PHPCS `master` are failing because of this as the final version of the PHPCS PHPUnit 6.x support PR includes a test bootstrap in PHPCS which is not being loaded as we use our own bootstrap.

Easily solved though, by loading the upstream bootstrap - if the file exists - from our own PHPCS 3 bootstrap file. That way our unit testing will be compatible with all supported PHPCS 3.x versions.

The `beStrictAboutTestsThatDoNotTestAnything="false"` addition to the `phpunit.xml.dist` file is needed to prevent PHPUnit from reporting there are no tests in our test files (as the tests are in the upstream test suite and our "tests" are basically only data providers).

The changes made in #873 should, for now, not be reverted as PHPCS < 3.1 is not compatible with PHPUnit 6.x and accounting for all the different situation with an `if` statement in the build script would get unnecessarily complicated. See the table below for more details.

Once PHPCS 2.x support is dropped and the minimum supported PHPCS version has gone up to 3.1, we should be able to revert the changes made in #873 without issues (except for HHVM).

Upstream references:
* squizlabs/PHP_CodeSniffer#1383
* squizlabs/PHP_CodeSniffer#1384

Additionally:
* While looking at the travis builds to fix this I noticed that `nightly` has gone up to PHP `7.3.0-dev`, so I've added PHP 7.2 to the build matrix.

-----

### Detail overview of Travis build info as of today (Sept 8 2017):

PHP | Travis PHPUnit | PHPCS 2.x | PHPCS < 3.1 | PHPCS master | Notes
--- | -------- | ---- | ---- | ---- | ----
5.3 | 4.8.18 | :white_check_mark:  | :white_check_mark:  | :white_check_mark: |
5.4 | 4.8.35 | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
5.5 | 4.8.27 | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
5.6 | 5.5.0 | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
7.0 | 6.3.0 / 5.3.4 | :x:  | :x: | :white_check_mark: | If PHPUnit 5.3.4 :white_check_mark: for the previous two, but no telling what the logic is about which PHPUnit version is loaded
7.1 | 6.3.0 | :x:  | :x: | :white_check_mark: |
7.2 | 6.3.0 | :x:  | :x:  | :white_check_mark: |
nightly | 6.3.0 | :x: | :x:  | :white_check_mark: |
HHVM | 6.3.0 | :x:  | :x:  | :x: | Hit and miss, sometimes it will work, sometimes it won't