### PR TITLE
UnitTests: fix unintentional syntax/parse errors in the test case files

### DIFF
--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -338,7 +338,7 @@ $my_array = [
 /*
  * Test multi-line strings as the value for an array item.
  */
-$test => array(
+$test = array(
 	'notes1'         => '<p>
 			Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
 		</p>',

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -338,7 +338,7 @@ $my_array = [
 /*
  * Test multi-line strings as the value for an array item.
  */
-$test => array(
+$test = array(
 	'notes1'         => '<p>
 			Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
 		</p>',

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -338,7 +338,7 @@ $my_array = [
 /*
  * Test multi-line strings as the value for an array item.
  */
-$test => array(
+$test = array(
     'notes1'         => '<p>
             Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
         </p>',

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -338,7 +338,7 @@ $my_array = [
 /*
  * Test multi-line strings as the value for an array item.
  */
-$test => array(
+$test = array(
     'notes1'         => '<p>
             Whether to use <code>isset()</code> or <code>array_key_exists()</code> depends on what you want to know:
         </p>',

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.inc
@@ -133,7 +133,7 @@ $b = function () {
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customSanitizingFunctions sanitize_pc,sanitize_twitter
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customUnslashingSanitizingFunctions do_something
 
-function foo_5() {
+function foo_6() {
 
 	sanitize_twitter( $_POST['foo'] ); // OK.
 	sanitize_pc( $_POST['bar'] ); // OK.
@@ -143,7 +143,7 @@ function foo_5() {
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customSanitizingFunctions sanitize_pc
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customUnslashingSanitizingFunctions false
 
-function foo_5() {
+function foo_7() {
 
 	do_something( $_POST['foo'] ); // Bad.
 	sanitize_pc( $_POST['bar'] ); // OK.
@@ -154,7 +154,7 @@ function foo_5() {
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customNonceVerificationFunctions false
 // @codingStandardsChangeSetting WordPress.CSRF.NonceVerification customSanitizingFunctions false
 
-function foo_5() {
+function foo_8() {
 
 	do_something( $_POST['foo'] ); // Bad.
 	sanitize_pc( $_POST['bar'] ); // Bad.

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.inc
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.inc
@@ -41,7 +41,7 @@ $renderer = new $this->inline_diff_renderer;
 $b = ( new MyClass )->my_function();
 $b = ( new MyClass )::$property;
 
-class ClassA {
+class ClassAA {
 	public static function get_instance() {
 		return new self;
 	}
@@ -51,7 +51,7 @@ class ClassA {
 	}
 }
 
-class ClassB extends ClassA {
+class ClassBB extends ClassA {
 	public function get_parent_instance() {
 		return new parent;
 	}

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
@@ -41,7 +41,7 @@ $renderer = new $this->inline_diff_renderer();
 $b = ( new MyClass() )->my_function();
 $b = ( new MyClass() )::$property;
 
-class ClassA {
+class ClassAA {
 	public static function get_instance() {
 		return new self();
 	}
@@ -51,7 +51,7 @@ class ClassA {
 	}
 }
 
-class ClassB extends ClassA {
+class ClassBB extends ClassA {
 	public function get_parent_instance() {
 		return new parent();
 	}

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
@@ -33,7 +33,7 @@ class OurMysqli implements mysqli {}
 class TheirMysqli implements \mysqli {}
 
 $db5 = new PDO();
-$db6 - new PDO->exec();
+$db6 = ( new PDO() )->exec();
 PDO::getAvailableDrivers();
 
 $db7 = new PDOStatement;
@@ -49,18 +49,18 @@ $db9 = new \My\DBlayer;
 $db9 = new \My\DBlayer; // Ok - within excluded group.
 
 echo mysqli::$affected_rows; // Error.
-class YourMysqli extends \mysqli {} // Error.
+class YourMysqliA extends \mysqli {} // Error.
 
 // Exclude all groups:
 // @codingStandardsChangeSetting WordPress.DB.RestrictedClasses exclude test,mysql
 $db9 = new \My\DBlayer; // Ok - within excluded group.
 
 echo mysqli::$affected_rows; // Ok - within excluded group.
-class YourMysqli extends \mysqli {} // Ok - within excluded group.
+class YourMysqliB extends \mysqli {} // Ok - within excluded group.
 
 // Reset group exclusions.
 // @codingStandardsChangeSetting WordPress.DB.RestrictedClasses exclude false
 $db9 = new \My\DBlayer; // Error.
 
 echo mysqli::$affected_rows; // Error.
-class YourMysqli extends \mysqli {} // Error.
+class YourMysqliC extends \mysqli {} // Error.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -120,14 +120,14 @@ apply_filters( 'acronym', $var );
 /*
  * OK - not in the global namespace.
  */
-function acronym_do_something( $param = 'default' ) {
+function acronym_do_something_else( $param = 'default' ) {
 	$var = 'abc';
 	${$something} = 'value';
 }
 
 function ( $param ) {
 	$var = 'abc';
-}
+};
 
 class Acronym_Example {
 	const SOME_CONSTANT = 'value';
@@ -143,7 +143,7 @@ $acronym_class = new class {
 	public $var = 'abc';
 
 	function do_something( $param = 'default' ) {}
-}
+};
 
 namespace Acronym {
 	function do_something( $param = 'default' ) {}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -43,12 +43,12 @@ class Foo implements ArrayAccess {
 class Its_A_Kind_Of_Magic {
 	function __construct() {} // Ok.
 	function __destruct() {} // Ok.
-	function __call() {} // Ok.
-	function __callStatic() {} // Ok.
-	function __get() {} // Ok.
-	function __set() {} // Ok.
-	function __isset() {} // Ok.
-	function __unset() {} // Ok.
+	function __call( $a, $b ) {} // Ok.
+	static function __callStatic( $a, $b ) {} // Ok.
+	function __get( $a ) {} // Ok.
+	function __set( $a, $b ) {} // Ok.
+	function __isset( $a ) {} // Ok.
+	function __unset( $a ) {} // Ok.
 	function __sleep() {} // Ok.
 	function __wakeup() {} // Ok.
 	function __toString() {} // Ok.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -5,25 +5,25 @@ $varname  = 'hello';
 $_varName = 'hello'; // Bad.
 
 class MyClass {
-	$varName  = 'hello'; // Bad.
-	$var_name = 'hello';
-	$varname  = 'hello';
-	$_varName = 'hello'; // Bad.
+	var $varName  = 'hello'; // Bad.
+	var $var_name = 'hello';
+	var $varname  = 'hello';
+	var $_varName = 'hello'; // Bad.
 
-	public $varName  = 'hello'; // Bad.
-	public $var_name = 'hello';
-	public $varname  = 'hello';
-	public $_varName = 'hello'; // Bad.
+	public $varNamf  = 'hello'; // Bad.
+	public $var_namf = 'hello';
+	public $varnamf  = 'hello';
+	public $_varNamf = 'hello'; // Bad.
 
-	protected $varName  = 'hello'; // Bad.
-	protected $var_name = 'hello';
-	protected $varname  = 'hello';
-	protected $_varName = 'hello'; // Bad.
+	protected $varNamg  = 'hello'; // Bad.
+	protected $var_namg = 'hello';
+	protected $varnamg  = 'hello';
+	protected $_varNamg = 'hello'; // Bad.
 
-	private $_varName  = 'hello'; // Bad.
-	private $_var_name = 'hello';
-	private $_varname  = 'hello';
-	private $varName   = 'hello'; // Bad.
+	private $_varNamh  = 'hello'; // Bad.
+	private $_var_namh = 'hello';
+	private $_varnamh  = 'hello';
+	private $varNamh   = 'hello'; // Bad.
 }
 
 echo $varName; // Bad.

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
@@ -122,7 +122,7 @@ $b = function () {
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheGetFunctions my_cacheget
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheSetFunctions my_cacheset,my_other_cacheset
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheDeleteFunctions my_cachedel
-function cache_custom() {
+function cache_customA() {
 	global $wpdb;
 
 	$quux = my_cacheget( 'quux' );
@@ -132,7 +132,7 @@ function cache_custom() {
 	}
 }
 
-function cache_custom() {
+function cache_customB() {
 	global $wpdb;
 
 	$quux = my_cacheget( 'quux' );
@@ -142,7 +142,7 @@ function cache_custom() {
 	}
 }
 
-function cache_custom() {
+function cache_customC() {
 	global $wpdb;
 
 	$wpdb->query( 'SELECT X FROM Y' ); // DB call ok; OK.
@@ -152,7 +152,7 @@ function cache_custom() {
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheSetFunctions my_cacheset
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheDeleteFunctions false
 
-function cache_custom() {
+function cache_customD() {
 	global $wpdb;
 
 	$quux = my_cacheget( 'quux' );
@@ -162,7 +162,7 @@ function cache_custom() {
 	}
 }
 
-function cache_custom() {
+function cache_customE() {
 	global $wpdb;
 
 	$quux = my_cacheget( 'quux' );
@@ -172,7 +172,7 @@ function cache_custom() {
 	}
 }
 
-function cache_custom() {
+function cache_customF() {
 	global $wpdb;
 
 	$wpdb->query( 'SELECT X FROM Y' ); // DB call ok; Bad.
@@ -182,7 +182,7 @@ function cache_custom() {
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheGetFunctions false
 // @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheSetFunctions false
 
-function cache_custom() {
+function cache_customG() {
 	global $wpdb;
 
 	$quux = my_cacheget( 'quux' );
@@ -244,7 +244,7 @@ function custom_modify_term_relationship() {
 }
 
 // Test Nowdocs and Heredocs
-function foo() {
+function foofoo() {
 	global $wpdb;
 
 	$listofthings = $wpdb->get_col( <<<'EOD'
@@ -264,7 +264,7 @@ EOD
 	return $listofthings;
 }
 
-function baz() {
+function bazbaz() {
 	global $wpdb;
 
 	$baz = wp_cache_get( 'baz' );
@@ -278,7 +278,7 @@ EOD
 	}
 }
 
-function cache_add_instead_of_set() {
+function cache_add_instead_of_setter() {
 	global $wpdb;
 
 	$baz = wp_cache_get( 'baz' );

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.inc
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.inc
@@ -8,7 +8,7 @@ $foo->bar(); // Ignored, this is a function not a variable.
 
 $foo->bar_method(); // Ignored.
 
-FOO::var; // Matches: 'FOO::var'.
+FOO::vars; // Matches: 'FOO::var'.
 
 FOO::var_test;
 
@@ -16,7 +16,7 @@ FOO::reg; // Matches: 'FOO::reg*'.
 
 FOO::regex; // Matches: 'FOO::reg*'.
 
-FOO::var(); // Ignored.
+FOO::vars(); // Ignored.
 
 FOO::$static; // Matches: 'FOO::$static'.
 
@@ -26,7 +26,7 @@ $foo["test"]; // Matches: '$foo['test']' AND $foo['test'].
 
 bar( $tallyho ); // Matches: '$tallyho'.
 test( $bar->bar ); // Matches: '$bar->bar'.
-BAR::var; // Matches: 'BAR::var'.
+BAR::vars; // Matches: 'BAR::var'.
 
 /*
  * Test exclude property.
@@ -39,7 +39,7 @@ FOO::regex; // Ok - within excluded group.
 
 bar( $tallyho ); // Error.
 test( $bar->bar ); // Error.
-BAR::var; // Error.
+BAR::vars; // Error.
 
 // Exclude all groups:
 // @codingStandardsChangeSetting WordPress.Variables.VariableRestrictions exclude test,another
@@ -49,7 +49,7 @@ FOO::regex; // Ok - within excluded group.
 
 bar( $tallyho ); // Ok - within excluded group.
 test( $bar->bar ); // Ok - within excluded group.
-BAR::var; // Ok - within excluded group.
+BAR::vars; // Ok - within excluded group.
 
 // Reset group exclusions.
 // @codingStandardsChangeSetting WordPress.Variables.VariableRestrictions exclude false
@@ -59,4 +59,4 @@ FOO::regex; // Error.
 
 bar( $tallyho ); // Error.
 test( $bar->bar ); // Error.
-BAR::var; // Error.
+BAR::vars; // Error.

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -34,7 +34,7 @@ class VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 				'message'       => 'Detected usage of %s',
 				'object_vars'   => array(
 					'$foo->bar',
-					'FOO::var',
+					'FOO::vars',
 					'FOO::reg*',
 					'FOO::$static',
 				),
@@ -50,7 +50,7 @@ class VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 				'message'       => 'Detected usage of %s',
 				'object_vars'   => array(
 					'$bar->bar',
-					'BAR::var',
+					'BAR::vars',
 					'BAR::reg*',
 					'BAR::$static',
 				),

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
@@ -13,21 +13,21 @@
  *
  * @param string $wordpress OK: Here the incorrect spelling is OK to comply with the variable name rules.
  */
-function something( $wordpress ) {} // OK.
+function somethingA( $wordpress ) {} // OK.
 
 /**
  * Function comment
  *
  * @param string $my_wordpress_test OK: Here the incorrect spelling is OK to comply with the variable name rules.
  */
-function something( $my_wordpress_test ) {} // OK.
+function somethingB( $my_wordpress_test ) {} // OK.
 
 /**
  * Bad: In this comment wordPresss should be fixed.
  *
  * @param string $test Bad: In this comment word press should be fixed.
  */
-function something( $test ) {} // OK.
+function somethingC( $test ) {} // OK.
 
 function wordpress_function() {} // OK - comply with the function name rules.
 

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
@@ -13,21 +13,21 @@
  *
  * @param string $wordpress OK: Here the incorrect spelling is OK to comply with the variable name rules.
  */
-function something( $wordpress ) {} // OK.
+function somethingA( $wordpress ) {} // OK.
 
 /**
  * Function comment
  *
  * @param string $my_wordpress_test OK: Here the incorrect spelling is OK to comply with the variable name rules.
  */
-function something( $my_wordpress_test ) {} // OK.
+function somethingB( $my_wordpress_test ) {} // OK.
 
 /**
  * Bad: In this comment WordPress should be fixed.
  *
  * @param string $test Bad: In this comment WordPress should be fixed.
  */
-function something( $test ) {} // OK.
+function somethingC( $test ) {} // OK.
 
 function wordpress_function() {} // OK - comply with the function name rules.
 

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -12,7 +12,7 @@ echo WP_User_Search::$users_per_page;
 echo \WP_User_Search::prepare_query();
 class My_User_Search extends WP_User_Search {}
 class Our_User_Search implements WP_User_Search {}
-$a = new WP_User_Search->query();
+$a = (new WP_User_Search())->query();
 
 /*
  * Warning.

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -7,7 +7,7 @@
  */
 // Ok, not a (global) constant.
 namespace STYLESHEETPATH {}
-namespace MY\OTHER\STYLESHEETPATH\NAMESPACE {}
+namespace MY\OTHER\STYLESHEETPATH\NS {}
 use STYLESHEETPATH;
 use Something, STYLESHEETPATH, SomethingElse;
 class STYLESHEETPATH {

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -46,14 +46,14 @@ if ( false ) :
 else :
 endif;
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
-function($arg){} // Bad.
-function ( $arg ) {
+$a = function($arg){}; // Bad.
+$a = function ( $arg ) {
 	// Ok.
-}
+};
 
-function () {
+$a = function () {
 	// Ok.
-}
+};
 
 function something($arg){} // Bad.
 function foo( $arg ) {
@@ -69,17 +69,17 @@ function    and_another() {} // Bad, space before function name prohibited.
 function
 bar() {} // Bad.
 function baz()     {} // Bad.
-function test()
+function testA()
 {} // Bad.
 
 function &return_by_ref() {} // Ok.
 
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
 
-function() {} // Ok.
-function( $arg ) {} // Ok.
-function($arg){} // Bad.
-function () {} // Bad.
+$a = function() {}; // Ok.
+$a = function( $arg ) {}; // Ok.
+$a = function($arg){}; // Bad.
+$a = function () {}; // Bad.
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad.
@@ -102,8 +102,8 @@ use Foo\Admin;
 
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
 
-function( $arg ) {} // Ok.
-function ( $arg ) {} // Ok.
+$a = function( $arg ) {}; // Ok.
+$a = function ( $arg ) {}; // Ok.
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
@@ -167,7 +167,7 @@ if ( $foo ) {
     /**
      * Comment
      */
-    class bar() {
+    class bar {
 
     }//end class
 
@@ -177,7 +177,7 @@ if ( $foo ) {
 
 // Check for too many spaces as long as the next non-blank token is on the same line.
 function test( $blah   ) {} // Bad.
-function(   $bar   ) {}  // Bad.
+$a = function(   $bar   ) {}; // Bad.
 
 if (    'abc' === $test ) { // Bad.
 	echo 'hi';
@@ -193,7 +193,7 @@ while ( $blah   ) { // Bad.
 	echo 'bye bye';
 }
 
-for (   $i = 0; $i < 1; $++    ) { // Bad.
+for (   $i = 0; $i < 1; $i++    ) { // Bad.
 	echo 'hi';
 }
 

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -44,14 +44,14 @@ if ( false ) :
 else :
 endif;
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
-function ( $arg ) {} // Bad.
-function ( $arg ) {
+$a = function ( $arg ) {}; // Bad.
+$a = function ( $arg ) {
 	// Ok.
-}
+};
 
-function () {
+$a = function () {
 	// Ok.
-}
+};
 
 function something( $arg ) {} // Bad.
 function foo( $arg ) {
@@ -66,16 +66,16 @@ function another() {} // Bad, space before open parenthesis prohibited.
 function and_another() {} // Bad, space before function name prohibited.
 function bar() {} // Bad.
 function baz() {} // Bad.
-function test() {} // Bad.
+function testA() {} // Bad.
 
 function &return_by_ref() {} // Ok.
 
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
 
-function() {} // Ok.
-function( $arg ) {} // Ok.
-function( $arg ) {} // Bad.
-function() {} // Bad.
+$a = function() {}; // Ok.
+$a = function( $arg ) {}; // Ok.
+$a = function( $arg ) {}; // Bad.
+$a = function() {}; // Bad.
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad.
@@ -98,8 +98,8 @@ use Foo\Admin;
 
 // @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
 
-function( $arg ) {} // Ok.
-function ( $arg ) {} // Ok.
+$a = function( $arg ) {}; // Ok.
+$a = function ( $arg ) {}; // Ok.
 
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
@@ -162,7 +162,7 @@ if ( $foo ) {
     /**
      * Comment
      */
-    class bar() {
+    class bar {
 
     }//end class
 
@@ -172,7 +172,7 @@ if ( $foo ) {
 
 // Check for too many spaces as long as the next non-blank token is on the same line.
 function test( $blah ) {} // Bad.
-function(   $bar ) {}  // Bad.
+$a = function(   $bar ) {}; // Bad.
 
 if ( 'abc' === $test ) { // Bad.
 	echo 'hi';
@@ -188,7 +188,7 @@ while ( $blah ) { // Bad.
 	echo 'bye bye';
 }
 
-for ( $i = 0; $i < 1; $++ ) { // Bad.
+for ( $i = 0; $i < 1; $i++ ) { // Bad.
 	echo 'hi';
 }
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -1,18 +1,18 @@
 <?php
 
-	function exampleFunction() {} // OK: [tab].
+	function exampleFunctionA() {} // OK: [tab].
 
 /*
  * OK: [tab][space][space][space][space].
  * The four spaces will be replaced by a tab by the upstream sniff.
  */
-	    function exampleFunction() {}
+	    function exampleFunctionB() {}
 
 /*
  * OK: [tab][space][space][tab][space][tab].
  * The space replacement here will be handled by the upstream sniff.
  */
-	  	 	function exampleFunction() {}
+	  	 	function exampleFunctionC() {}
 
 	/**
 	 * OK: Doc comments are indented with tabs and one space.
@@ -27,11 +27,11 @@
 	   * <= Bad.
 	 */
 
-	 function exampleFunction() {} // Bad: [tab][space].
-	  function exampleFunction() {} // Bad: [tab][space][space].
-	   function exampleFunction() {} // Bad: [tab][space][space][space].
+	 function exampleFunctionD() {} // Bad: [tab][space].
+	  function exampleFunctionE() {} // Bad: [tab][space][space].
+	   function exampleFunctionF() {} // Bad: [tab][space][space][space].
 
-	 function exampleFunction() {} // WPCS: precision alignment ok.
+	 function exampleFunctionG() {} // WPCS: precision alignment ok.
 
 ?>
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -2,19 +2,19 @@
 
 <?php
 
-	function exampleFunction() {} // OK: [tab].
+	function exampleFunctionA() {} // OK: [tab].
 
 /*
  * OK: [tab][space][space][space][space].
  * The four spaces will be replaced by a tab by the upstream sniff.
  */
-	    function exampleFunction() {}
+	    function exampleFunctionB() {}
 
 /*
  * OK: [tab][space][space][tab][space][tab].
  * The space replacement here will be handled by the upstream sniff.
  */
-	  	 	function exampleFunction() {}
+	  	 	function exampleFunctionC() {}
 
 	/**
 	 * OK: Doc comments are indented with tabs and one space.
@@ -29,9 +29,9 @@
 	   * <= Bad.
 	 */
 
-	 function exampleFunction() {} // Bad: [tab][space].
-	  function exampleFunction() {} // Bad: [tab][space][space].
-	   function exampleFunction() {} // Bad: [tab][space][space][space].
+	 function exampleFunctionD() {} // Bad: [tab][space].
+	  function exampleFunctionE() {} // Bad: [tab][space][space].
+	   function exampleFunctionF() {} // Bad: [tab][space][space][space].
 
 ?>
 


### PR DESCRIPTION
Fixes a variety of parse errors, syntax errors and fatal "function/variable already declared" errors in the test case files.

These fixes are not necessarily needed for the unit tests to work properly, but - except for when intentional to test something - having valid unit test code makes sense.