### PR TITLE
Add sniff to check for alignment of assignment operators to `Core`

### DIFF
--- a/Test/phpcs2-bootstrap.php
+++ b/Test/phpcs2-bootstrap.php
@@ -20,7 +20,7 @@ $ds = DIRECTORY_SEPARATOR;
 $phpcsDir = getenv( 'PHPCS_DIR' );
 
 if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer' ) ) {
-	$phpcsDir  = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+	$phpcsDir = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
 } elseif ( false !== $phpcsDir ) {
 	$phpcsDir = realpath( $phpcsDir );
 }

--- a/Test/phpcs3-bootstrap.php
+++ b/Test/phpcs3-bootstrap.php
@@ -26,7 +26,7 @@ $phpcsDir = getenv( 'PHPCS_DIR' );
 
 // This may be a Composer install.
 if ( false === $phpcsDir && is_dir( dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer' ) ) {
-	$phpcsDir  = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+	$phpcsDir = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
 } elseif ( false !== $phpcsDir ) {
 	$phpcsDir = realpath( $phpcsDir );
 }

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -68,12 +68,20 @@
 	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
 	<rule ref="WordPress.WhiteSpace.DisallowInlineTabs"/>
 
+	<!-- Implied through the examples: align the assignment operator in a block of assignments. -->
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<properties>
+			<property name="maxPadding" value="40"/>
+		</properties>
+	</rule>
+
 	<!-- Implied through the examples: align the double arrows. -->
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
 		<properties>
 			<property name="maxColumn" value="60"/>
 		</properties>
 	</rule>
+
 
 	<!--
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -55,10 +55,6 @@
 		<type>warning</type>
 	</rule>
 
-	<!-- This sniff is not refined enough for general use -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29970107 -->
-	<!--<rule ref="Generic.Formatting.MultipleStatementAlignment"/>-->
-
 	<!-- Hook callbacks may not use all params -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -121,9 +121,9 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 
 		if ( in_array( $token['code'], array( T_NEW, T_EXTENDS, T_IMPLEMENTS ), true ) ) {
 			if ( T_NEW === $token['code'] ) {
-				$nameEnd   = ( $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS, T_WHITESPACE, T_SEMICOLON, T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
+				$nameEnd = ( $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS, T_WHITESPACE, T_SEMICOLON, T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
-				$nameEnd   = ( $this->phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
+				$nameEnd = ( $this->phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
 			}
 
 			$length    = ( $nameEnd - ( $stackPtr + 1 ) );

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -177,6 +177,7 @@ class NonceVerificationSniff extends Sniff {
 				$this->customNonceVerificationFunctions,
 				$this->nonceVerificationFunctions
 			);
+
 			$this->addedCustomFunctions['nonce'] = $this->customNonceVerificationFunctions;
 		}
 
@@ -185,6 +186,7 @@ class NonceVerificationSniff extends Sniff {
 				$this->customSanitizingFunctions,
 				$this->sanitizingFunctions
 			);
+
 			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
 		}
 
@@ -193,6 +195,7 @@ class NonceVerificationSniff extends Sniff {
 				$this->customUnslashingSanitizingFunctions,
 				$this->unslashingSanitizingFunctions
 			);
+
 			$this->addedCustomFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;
 		}
 	}

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -59,13 +59,14 @@ class ClassInstantiationSniff extends Sniff {
 		 *
 		 * Currently does not account for classnames passed as a variable variable.
 		 */
-		$this->classname_tokens                               = Tokens::$emptyTokens;
-		$this->classname_tokens[ T_NS_SEPARATOR ]             = T_NS_SEPARATOR;
-		$this->classname_tokens[ T_STRING ]                   = T_STRING;
-		$this->classname_tokens[ T_SELF ]                     = T_SELF;
-		$this->classname_tokens[ T_STATIC ]                   = T_STATIC;
-		$this->classname_tokens[ T_PARENT ]                   = T_PARENT;
-		$this->classname_tokens[ T_ANON_CLASS ]               = T_ANON_CLASS;
+		$this->classname_tokens                   = Tokens::$emptyTokens;
+		$this->classname_tokens[ T_NS_SEPARATOR ] = T_NS_SEPARATOR;
+		$this->classname_tokens[ T_STRING ]       = T_STRING;
+		$this->classname_tokens[ T_SELF ]         = T_SELF;
+		$this->classname_tokens[ T_STATIC ]       = T_STATIC;
+		$this->classname_tokens[ T_PARENT ]       = T_PARENT;
+		$this->classname_tokens[ T_ANON_CLASS ]   = T_ANON_CLASS;
+
 		// Classname in a variable.
 		$this->classname_tokens[ T_VARIABLE ]                 = T_VARIABLE;
 		$this->classname_tokens[ T_DOUBLE_COLON ]             = T_DOUBLE_COLON;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -570,7 +570,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$is_error     = true;
+		$is_error    = true;
 		$raw_content = $this->strip_quotes( $parameters[1]['raw'] );
 
 		if ( $this->is_prefixed( $raw_content ) === true ) {
@@ -600,8 +600,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
 				// If the first part of the parameter is a double quoted string, try again with only
 				// the part before the first variable (if any).
-				$exploded                = explode( '$', $first_non_empty_content );
-				$first                   = rtrim( $exploded[0], '{' );
+				$exploded = explode( '$', $first_non_empty_content );
+				$first    = rtrim( $exploded[0], '{' );
 				if ( '' !== $first ) {
 					if ( $this->is_prefixed( $first ) === true ) {
 						return;

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -97,7 +97,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$regex  = $this->prepare_regex();
+		$regex = $this->prepare_regex();
 
 		$case_errors = 0;
 		$underscores = 0;

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -202,7 +202,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			}
 
 			if ( isset( $error, $error_name ) ) {
-				$data  = array( $original_var_name );
+				$data = array( $original_var_name );
 				$phpcs_file->addError( $error, $stack_ptr, $error_name, $data );
 			}
 		}
@@ -327,6 +327,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 				$customProperties,
 				$this->whitelisted_mixed_case_member_var_names
 			);
+
 			$this->addedCustomProperties['properties'] = $this->customPropertiesWhitelist;
 			$this->addedCustomProperties['variables']  = $this->customVariablesWhitelist;
 		}

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -49,7 +49,7 @@ class StrictComparisonsSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		if ( ! $this->has_whitelist_comment( 'loose comparison', $stackPtr ) ) {
-			$error  = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
+			$error = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
 			$this->phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
 		}
 

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -149,7 +149,12 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$targets[] = T_STYLE;
 
 		// Set the target selectors regex only once.
-		$selectors = array_map( 'preg_quote', $this->target_css_selectors, array_fill( 0, count( $this->target_css_selectors ), '`' ) );
+		$selectors = array_map(
+			'preg_quote',
+			$this->target_css_selectors,
+			array_fill( 0, count( $this->target_css_selectors ), '`' )
+		);
+		// Parse the selectors array into the regex string.
 		$this->target_css_selectors_regex = sprintf( $this->target_css_selectors_regex, implode( '|', $selectors ) );
 
 		// Add function call targets.
@@ -368,7 +373,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 					break;
 				}
 			}
-			$start = ( $i + 1 );
+			$start    = ( $i + 1 );
 			$selector = trim( $this->phpcsFile->getTokensAsString( $start, ( $opener - $start ) ) );
 			unset( $i );
 

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -61,7 +61,7 @@ class CronIntervalSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
-		$token  = $this->tokens[ $stackPtr ];
+		$token = $this->tokens[ $stackPtr ];
 
 		if ( 'cron_schedules' !== $this->strip_quotes( $token['content'] ) ) {
 			return;

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -240,6 +240,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 				$this->customCacheGetFunctions,
 				$this->cacheGetFunctions
 			);
+
 			$this->addedCustomFunctions['cacheget'] = $this->customCacheGetFunctions;
 		}
 
@@ -248,6 +249,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 				$this->customCacheSetFunctions,
 				$this->cacheSetFunctions
 			);
+
 			$this->addedCustomFunctions['cacheset'] = $this->customCacheSetFunctions;
 		}
 
@@ -256,6 +258,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 				$this->customCacheDeleteFunctions,
 				$this->cacheDeleteFunctions
 			);
+
 			$this->addedCustomFunctions['cachedelete'] = $this->customCacheDeleteFunctions;
 		}
 	}

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -167,6 +167,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 				$this->customSanitizingFunctions,
 				$this->sanitizingFunctions
 			);
+
 			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
 		}
 
@@ -175,6 +176,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 				$this->customUnslashingSanitizingFunctions,
 				$this->unslashingSanitizingFunctions
 			);
+
 			$this->addedCustomFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;
 		}
 	}

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -58,8 +58,8 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function getGroups() {
 		// Make sure all array keys are lowercase.
-		$keys = array_keys( $this->deprecated_classes );
-		$keys = array_map( 'strtolower', $keys );
+		$keys                     = array_keys( $this->deprecated_classes );
+		$keys                     = array_map( 'strtolower', $keys );
 		$this->deprecated_classes = array_combine( $keys, $this->deprecated_classes );
 
 		return array(

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1307,8 +1307,8 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 		// Make sure all array keys are lowercase.
-		$keys = array_keys( $this->deprecated_functions );
-		$keys = array_map( 'strtolower', $keys );
+		$keys                       = array_keys( $this->deprecated_functions );
+		$keys                       = array_map( 'strtolower', $keys );
 		$this->deprecated_functions = array_combine( $keys, $this->deprecated_functions );
 
 		return array(

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -314,9 +314,9 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			$message = 'The parameter "%s" at position #%s of %s() has been deprecated since WordPress version %s.';
+			$message  = 'The parameter "%s" at position #%s of %s() has been deprecated since WordPress version %s.';
 			$is_error = version_compare( $parameter_args['version'], $this->minimum_supported_version, '<' );
-			$code = $this->string_to_errorcode( ucfirst( $matched_content ) . 'Param' . $position . 'Found' );
+			$code     = $this->string_to_errorcode( ucfirst( $matched_content ) . 'Param' . $position . 'Found' );
 
 			$data = array(
 				$parameters[ $position ]['raw'],

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -468,9 +468,9 @@ class I18nSniff extends Sniff {
 				// Prepare the strings for use a regex.
 				$replace_regexes[ $i ] = '`\Q' . $unordered_matches[ $i ] . '\E`';
 				// Note: the initial \\ is a literal \, the four \ in the replacement translate to also to a literal \.
-				$replacements[ $i ]    = str_replace( '\\', '\\\\', $suggestions[ $i ] );
+				$replacements[ $i ] = str_replace( '\\', '\\\\', $suggestions[ $i ] );
 				// Note: the $ needs escaping to prevent numeric sequences after the $ being interpreted as match replacements.
-				$replacements[ $i ]    = str_replace( '$', '\\$', $replacements[ $i ] );
+				$replacements[ $i ] = str_replace( '$', '\\$', $replacements[ $i ] );
 			}
 
 			$fix = $this->addFixableMessage(

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -403,7 +403,7 @@ class EscapeOutputSniff extends Sniff {
 						// If we're able to resolve the function name, do so.
 						if ( $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
 							$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
-							$ptr = $mapped_function;
+							$ptr          = $mapped_function;
 						}
 					}
 
@@ -482,6 +482,7 @@ class EscapeOutputSniff extends Sniff {
 				$customEscapeFunctions,
 				$this->escapingFunctions
 			);
+
 			$this->addedCustomFunctions['escape']   = $this->customEscapingFunctions;
 			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
 		}
@@ -491,6 +492,7 @@ class EscapeOutputSniff extends Sniff {
 				$this->customAutoEscapedFunctions,
 				$this->autoEscapedFunctions
 			);
+
 			$this->addedCustomFunctions['autoescape'] = $this->customAutoEscapedFunctions;
 		}
 
@@ -500,6 +502,7 @@ class EscapeOutputSniff extends Sniff {
 				$this->customPrintingFunctions,
 				$this->printingFunctions
 			);
+
 			$this->addedCustomFunctions['print'] = $this->customPrintingFunctions;
 		}
 	}


### PR DESCRIPTION
This sniff has already been added and removed a couple of times previously, see the discussion in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#r29970107 amongst others.

Adding the `maxPadding` property will hopefully make the sniff more acceptable.

Sister-PR to the array arrow alignment sniff PR as requested in #1122.

The value for `maxPadding` which I've chosen is arbitrary - similar to my notes about `maxColumn` in #1135 - and could probably use some scrutiny before deciding on the real number to use. /cc @pento 

If it would change, both commits in this PR will change.

--- 
[Edit]: Oh and I ran this sniff (combined with #1135) over WP Core as well to check for new fixer conflicts and none were found, so we're good in that respect.
