### PR TITLE
[WordPress.WP.I18n] Allow omitting $text_domain arg when 'default'

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -345,7 +345,7 @@ class I18nSniff extends Sniff {
 
 		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
 			$code = $this->string_to_errorcode( 'MissingArg' . ucfirst( $arg_name ) );
-			if ( 'domain' !== $arg_name || ! empty( $this->text_domain ) ) {
+			if ( 'domain' !== $arg_name || ( ! empty( $this->text_domain ) && ! in_array( 'default', $this->text_domain, true ) ) ) {
 				$this->addMessage( 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
 			}
 			return false;

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -5,7 +5,7 @@
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
 
 __( 'string' ); // Bad - no text domain passed.
 __( 'string', 'something' ); // Bad - text domain mismatch.
@@ -112,7 +112,7 @@ __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
 
-// The domain 'default' was also added to the text domains.
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
 __( 'String default text domain.', 'default' ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
 
@@ -150,6 +150,11 @@ Not
 really.
 EOD
 , 'my-slug' ); // OK.
+
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain default
+__( 'String default text domain.', 'my-slug' ); // Bad because text_domain is only 'default'.
+__( 'String default text domain.', 'default' ); // Ok because domain is being explicit.
+__( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain null
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -156,5 +156,5 @@ __( 'String default text domain.', 'my-slug' ); // Bad because text_domain is on
 __( 'String default text domain.', 'default' ); // Ok because domain is being explicit.
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain null
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -5,7 +5,7 @@
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
 
 __( 'string' ); // Bad - no text domain passed.
 __( 'string', 'something' ); // Bad - text domain mismatch.
@@ -112,7 +112,7 @@ __( 'String with a literal %%', 'my-slug'); // Ok, replacement would be a single
 __( 'String with a literal %% and a %s placeholder', 'my-slug'); // Ok.
 __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'my-slug' ); // Ok.
 
-// The domain 'default' was also added to the text domains.
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
 __( 'String default text domain.', 'default' ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
 
@@ -150,6 +150,11 @@ Not
 really.
 EOD
 , 'my-slug' ); // OK.
+
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain default
+__( 'String default text domain.', 'my-slug' ); // Bad because text_domain is only 'default'.
+__( 'String default text domain.', 'default' ); // Ok because domain is being explicit.
+__( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain null
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -156,5 +156,5 @@ __( 'String default text domain.', 'my-slug' ); // Bad because text_domain is on
 __( 'String default text domain.', 'default' ); // Ok because domain is being explicit.
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain null
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.2.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.2.inc
@@ -103,4 +103,4 @@ __( 'foo 100% bar', 'my-slug' ); // Ok, not a placeholder.
 // Issue #830.
 _e(); // Bad.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain null
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false

--- a/WordPress/Tests/WP/I18nUnitTest.2.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.2.inc
@@ -2,7 +2,7 @@
 /*
  * Test sniffing for translator comments.
  */
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
+// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
 
 /* Basic test ****************************************************************/
 __( 'No placeholders here.', 'my-slug' ); // Ok, no placeholders, so no translators comment needed.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -132,6 +132,7 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					138 => 1,
 					143 => 1,
 					148 => 1,
+					155 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
This will facilitate the WordPress core to ship with `WordPress.WP.I18n` enabled with a ruleset that has:

```xml
	<rule ref="WordPress.WP.I18n">
		<properties>
			<property name="text_domain" value="default" />
		</properties>
	</rule>
```

There seems to be an issue with unit tests whereby the `codingStandardsChangeSetting` directives aren't getting recognized. Help appreciated.