### PR TITLE
Ruleset: maintain compatibility with PHPCS 2.x

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -50,15 +50,18 @@
 	<!-- Encourage having only one class/interface/trait per file. -->
 	<!-- Once the minimum WPCS PHPCS requirement has gone up to PHPCS 3.1.0, these three sniffs can be
 	     replaced by the more comprehensive Generic.Files.OneObjectStructurePerFile sniff. -->
-	<rule ref="Generic.Files.OneClassPerFile">
+	<rule ref="Generic.Files.OneClassPerFile"/>
+	<rule ref="Generic.Files.OneClassPerFile.MultipleFound">
 		<type>warning</type>
 		<message>Best practice suggestion: Declare only one class in a file.</message>
 	</rule>
-	<rule ref="Generic.Files.OneInterfacePerFile">
+	<rule ref="Generic.Files.OneInterfacePerFile"/>
+	<rule ref="Generic.Files.OneInterfacePerFile.MultipleFound">
 		<type>warning</type>
 		<message>Best practice suggestion: Declare only one interface in a file.</message>
 	</rule>
-	<rule ref="Generic.Files.OneTraitPerFile">
+	<rule ref="Generic.Files.OneTraitPerFile"/>
+	<rule ref="Generic.Files.OneTraitPerFile.MultipleFound">
 		<type>warning</type>
 		<message>Best practice suggestion: Declare only one trait in a file.</message>
 	</rule>


### PR DESCRIPTION
In PHPCS 3.x, the message, type and a number of other errorcode properties can be changed for all errors in a sniff in one go.
In PHPCS 2.x this is not yet possible and needs to be configured for each errorcode individually.

Issues introduced (by me) in #1111