### PR TITLE
Add New "WordPress.PHP.DiscourageGoto" sniff to `Extra`

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -126,6 +126,16 @@
 		<message>eval() is a security risk so not allowed.</message>
 	</rule>
 
+	<!-- Forbid the use of the `goto` language construct.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1149 -->
+	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1664 -->
+	<rule ref="WordPress.PHP.DiscourageGoto"/>
+	<rule ref="WordPress.PHP.DiscourageGoto.Found">
+		<type>error</type>
+		<message>The "goto" language construct should not be used.</message>
+	</rule>
+
 	<!-- Scripts & style should be enqueued.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/35 -->
 	<rule ref="WordPress.WP.EnqueuedResources"/>

--- a/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
+/**
+ * Discourage the use of the PHP `goto` language construct.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of an upstream PR. Once the minimum PHPCS
+ * requirement for WPCS goes up beyond the version in which the upstream PR
+ * is merged, this sniff can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1664} }}
+ */
+class DiscourageGotoSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_GOTO,
+			T_GOTO_LABEL,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$this->phpcsFile->addWarning( 'Using the "goto" language construct is discouraged', $stackPtr, 'Found' );
+	}
+
+}//end class

--- a/WordPress/Tests/PHP/DiscourageGotoUnitTest.inc
+++ b/WordPress/Tests/PHP/DiscourageGotoUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+goto a;
+echo 'Foo';
+
+a:
+echo 'Bar';
+
+for($i=0,$j=50; $i<100; $i++) {
+    while($j--) {
+        if($j==17) goto end;
+    }
+}
+echo "i = $i";
+
+end: {
+  echo 'j hit 17';
+}

--- a/WordPress/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/WordPress/Tests/PHP/DiscourageGotoUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PHP.DiscourageGoto sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class DiscourageGotoUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3  => 1,
+			6  => 1,
+			11 => 1,
+			16 => 1,
+		);
+	}
+
+}


### PR DESCRIPTION
Usage of `goto` is seen as a typical code smell.

This sniff is a duplicate of the same as pulled upstream in PR squizlabs/PHP_CodeSniffer#1664
Once the minimum PHPCS requirement for WPCS goes up beyond the version in which the upstream PR  is merged, this sniff can be safely removed.

The fact that this is a duplicate with an upstream sniff is also the reason why the sniff itself throws a `warning` which is changed to an `error` via the ruleset.

Includes unit tests.

Adding this sniff to `Extra` for now. The sniff can be moved to `Core` once the handbook has been adjusted (if it will be).

Fixes #1149