### PR TITLE
Add customisable property to set the posts_per_page variable

### DIFF
--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -29,8 +29,9 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 *
 	 * Posts per page limit to check against.
 	 *
-	 * @var int
 	 * @since 0.14.0
+	 *
+	 * @var int
 	 */
 	public $posts_per_page = 100;
 

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -20,6 +20,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Added the posts_per_page property.
  */
 class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
@@ -29,6 +30,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * Posts per page limit to check against.
 	 *
 	 * @var int
+	 * @since 0.14.0
 	 */
 	public $posts_per_page = 100;
 
@@ -62,7 +64,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 *                       with custom error message passed to ->process().
 	 */
 	public function callback( $key, $val, $line, $group ) {
-		$key = strtolower( $key );
+		$key                  = strtolower( $key );
 		$this->posts_per_page = (int) $this->posts_per_page;
 
 		if (

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -24,6 +24,15 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
+	 * Posts per page property
+	 *
+	 * Posts per page limit to check against.
+	 *
+	 * @var int
+	 */
+	public $posts_per_page = 100;
+
+	/**
 	 * Groups of variables to restrict.
 	 *
 	 * @return array
@@ -54,17 +63,19 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 */
 	public function callback( $key, $val, $line, $group ) {
 		$key = strtolower( $key );
+		$this->posts_per_page = (int) $this->posts_per_page;
+
 		if (
 			( 'nopaging' === $key && ( 'true' === $val || 1 === $val ) )
 			||
-			( in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' == $val )
+			( in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' === $val )
 			) {
 
 			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
 
 		} elseif ( in_array( $key, array( 'posts_per_page', 'numberposts' ), true ) ) {
 
-			if ( $val > 100 ) {
+			if ( $val > $this->posts_per_page ) {
 				return 'Detected high pagination limit, `%s` is set to `%s`';
 			}
 		}

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
@@ -1,11 +1,8 @@
 <?php
-// @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 200
+
 $args = array(
 	'nopaging'       => true, // Bad.
 	'posts_per_page' => 999, // Bad.
-	'posts_per_page' => 100, // Ok.
-	'posts_per_page' => 200, // Ok.
-	'posts_per_page' => 201, // Bad.
 	'posts_per_page' => -1, // Bad.
 	'posts_per_page' => 1, // Ok.
 	'posts_per_page' => '1', // Ok.
@@ -19,3 +16,15 @@ $query_args['posts_per_page'] = '1'; // Ok.
 $query_args['posts_per_page'] = '-1'; // Bad.
 
 $query_args['my_posts_per_page'] = -1; // Ok.
+
+// @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 50
+ $query_args['posts_per_page'] = 50; // OK.
+ $query_args['posts_per_page'] = 100; // Bad.
+ $query_args['posts_per_page'] = 200; // Bad.
+ $query_args['posts_per_page'] = 300; // Bad.
+// @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 200
+ $query_args['posts_per_page'] = 50; // OK.
+ $query_args['posts_per_page'] = 100; // OK.
+ $query_args['posts_per_page'] = 200; // OK.
+ $query_args['posts_per_page'] = 300; // Bad.
+// @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 100

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
@@ -2,9 +2,9 @@
 // @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 200
 $args = array(
 	'nopaging'       => true, // Bad.
-  'posts_per_page' => 999, // Bad.
-  'posts_per_page' => 100, // Ok.
-  'posts_per_page' => 200, // Ok.
+	'posts_per_page' => 999, // Bad.
+	'posts_per_page' => 100, // Ok.
+	'posts_per_page' => 200, // Ok.
 	'posts_per_page' => 201, // Bad.
 	'posts_per_page' => -1, // Bad.
 	'posts_per_page' => 1, // Ok.

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
@@ -1,8 +1,11 @@
 <?php
-
+// @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 200
 $args = array(
 	'nopaging'       => true, // Bad.
-	'posts_per_page' => 999, // Bad.
+  'posts_per_page' => 999, // Bad.
+  'posts_per_page' => 100, // Ok.
+  'posts_per_page' => 200, // Ok.
+	'posts_per_page' => 201, // Bad.
 	'posts_per_page' => -1, // Bad.
 	'posts_per_page' => 1, // Ok.
 	'posts_per_page' => '1', // Ok.

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -30,10 +30,11 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 		return array(
 			4  => 1,
 			5  => 1,
-			6  => 1,
-			11  => 2,
-			13 => 1,
+			8  => 1,
+			9  => 1,
+			14 => 2,
 			16 => 1,
+			19 => 1,
 		);
 
 	}

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -30,11 +30,14 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 		return array(
 			4  => 1,
 			5  => 1,
-			8  => 1,
-			9  => 1,
-			14 => 2,
+			6  => 1,
+			11  => 2,
+			13 => 1,
 			16 => 1,
-			19 => 1,
+			22 => 1,
+			23 => 1,
+			24 => 1,
+			29 => 1,
 		);
 
 	}


### PR DESCRIPTION
WordPress VIP rule restricts the number of `posts_per_page` variable to 100, with this change you will be able to set the limit of the `posts_per_page` variable in your `ruleset.xml` like:

~~~xml
<rule ref="WordPress.VIP.PostsPerPage">
	<properties>
		<property name="posts_per_page" value="200"/>
	</properties>
</rule>
~~~