### PR TITLE
Modern code/Extra: add sniff to check for single blank line after namespace declaration

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -176,4 +176,13 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/919 -->
 	<rule ref="WordPress.Classes.ClassInstantiation"/>
 
+	<!--
+	#############################################################################
+	Code style sniffs for more recent PHP features and syntaxes.
+	#############################################################################
+	-->
+
+	<!-- Check for single blank line after namespace declaration. -->
+	<rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
+
 </ruleset>


### PR DESCRIPTION
Related to #764

For now, I've added this as a separate section to `Extra`, but I'd like to use this to (re-)open the discussion on having separate (sub-)standards which only deal with code style or best practices (not mixed).

Please add your voice to the discussions on this in #740 and #1067 (and let's make the discussion not be a blocker for this PR).