### PR TITLE
CronInterval: make the minimum cron interval configurable

### DIFF
--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -23,11 +23,25 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.11.0 - Extends the WordPress_Sniff class.
  *                 - Now deals correctly with WP time constants.
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 The minimum cron interval tested against is now configurable.
  */
 class CronIntervalSniff extends Sniff {
 
 	/**
+	 * Minimum allowed cron interval in seconds.
+	 *
+	 * Defaults to 900 (= 15 minutes), which is the requirement for the VIP platform.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var int
+	 */
+	public $min_interval = 900;
+
+	/**
 	 * Known WP Time constant names and their value.
+	 *
+	 * @since 0.11.0
 	 *
 	 * @var array
 	 */
@@ -168,8 +182,19 @@ class CronIntervalSniff extends Sniff {
 			}
 		}
 
-		if ( isset( $interval ) && $interval < 900 ) {
-			$this->phpcsFile->addError( 'Scheduling crons at %s sec ( less than 15 min ) is prohibited.', $stackPtr, 'CronSchedulesInterval', array( $interval ) );
+		$this->min_interval = (int) $this->min_interval;
+
+		if ( isset( $interval ) && $interval < $this->min_interval ) {
+			$minutes = round( ( $this->min_interval / 60 ), 1 );
+			$this->phpcsFile->addError(
+				'Scheduling crons at %s sec ( less than %s minutes ) is prohibited.',
+				$stackPtr,
+				'CronSchedulesInterval',
+				array(
+					$interval,
+					$minutes,
+				)
+			);
 			return;
 		}
 

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.inc
@@ -13,11 +13,11 @@ add_filter( 'cron_schedules', 'my_add_weekly'); // Error: 6 min.
 
 
 class Foo {
-	function __construct() {
+	public function __construct() {
 		add_filter( 'cron_schedules', array( $this, 'my_add_quickly' ) ); // Error: 10 min.
 	}
 
-	function my_add_quickly( $schedules ) {
+	public function my_add_quickly( $schedules ) {
 		$schedules['every_10_mins'] = array(
 			'interval' => 10 * 60,
 			'display' => __( 'Once every 10 minutes' )
@@ -80,3 +80,51 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	];
 	return $schedules;
 } ); // Warning: time undetermined.
+
+// @codingStandardsChangeSetting WordPress.VIP.CronInterval min_interval 600
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_2_mins'] = array(
+		'interval' => 2 * 60,
+		'display' => __( 'Once every 2 minutes' )
+	);
+	return $schedules;
+} ); // Error: 2 min.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_10_mins'] = array(
+		'interval' => 10 * 60,
+		'display' => __( 'Once every 10 minutes' )
+	);
+	return $schedules;
+} ); // OK: 10 min.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_hour'] = [
+		'interval' => HOUR_IN_SECONDS,
+		'display' => __( 'Once every hour' )
+	];
+	return $schedules;
+} ); // OK: > 10 min.
+
+// @codingStandardsChangeSetting WordPress.VIP.CronInterval min_interval 1800
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_2_mins'] = array(
+		'interval' => 2 * 60,
+		'display' => __( 'Once every 2 minutes' )
+	);
+	return $schedules;
+} ); // Error: 2 min.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_15_mins'] = array(
+		'interval' => 15 * 60,
+		'display' => __( 'Once every 15 minutes' )
+	);
+	return $schedules;
+} ); // Error: 15 min.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_hour'] = [
+		'interval' => HOUR_IN_SECONDS,
+		'display' => __( 'Once every hour' )
+	];
+	return $schedules;
+} ); // Ok: > 30 min.
+
+// @codingStandardsChangeSetting WordPress.VIP.CronInterval min_interval 900

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -28,13 +28,16 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			12 => 1,
-			17 => 1,
-			37 => 1,
-			43 => 1,
-			53 => 1,
-			56 => 1, // False positive.
-			67 => 1,
+			12  => 1,
+			17  => 1,
+			37  => 1,
+			43  => 1,
+			53  => 1,
+			56  => 1, // False positive.
+			67  => 1,
+			85  => 1,
+			108 => 1,
+			115 => 1,
 		);
 
 	}


### PR DESCRIPTION
This change allows for passing a minimum cron interval through a property in a custom ruleset.

Includes unit tests.

Includes one additional minor documentation fix for a previously added property.

As per a comment I made in proposal 2 in #1157

- [ ] Add info about the new property to the wiki