### PR TITLE
Update example ruleset for new `minimum_supported_wp_version` config variable

### DIFF
--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -67,6 +67,8 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
+	<config name="minimum_supported_wp_version" value="4.5"/>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="my-textdomain,library-textdomain"/>
@@ -76,24 +78,6 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array" value="my_prefix"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedClasses">
-		<properties>
-			<property name="minimum_supported_version" value="4.5"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedFunctions">
-		<properties>
-			<property name="minimum_supported_version" value="4.5"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedParameters">
-		<properties>
-			<property name="minimum_supported_version" value="4.5"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Related to #1094