### PR TITLE
Improve fixes for PEAR.Files.IncludingFile.BracketsNotRequired

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -405,7 +405,10 @@
 	<rule ref="Generic.Files.EndFileNewline"/>
 
 	<!-- No whitespace should come before semicolons. -->
-	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+	<!-- Extends upstream sniff. Should defer to upstream version once minimum PHPCS requirement
+		 has gone up to version containing bugfix.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1691 -->
+	<rule ref="WordPress.WhiteSpace.SemicolonSpacing"/>
 
 	<!-- Lowercase PHP constants, like true, false and null. -->
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions -->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -404,6 +404,9 @@
 	<!-- All files should end with a new line. -->
 	<rule ref="Generic.Files.EndFileNewline"/>
 
+	<!-- No whitespace should come before semicolons. -->
+	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+
 	<!-- Lowercase PHP constants, like true, false and null. -->
 	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions -->
 	<rule ref="Generic.PHP.LowerCaseConstant"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -55,6 +55,11 @@
 		<type>warning</type>
 	</rule>
 
+	<!-- Check correct spacing of language constructs. This also ensures that the
+	     above rule for not using brackets with require is fixed correctly.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1153 -->
+	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+
 	<!-- Hook callbacks may not use all params -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->

--- a/WordPress/PHPCSAliases.php
+++ b/WordPress/PHPCSAliases.php
@@ -45,6 +45,9 @@ if ( ! defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
 	if ( ! class_exists( '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' ) ) {
 		class_alias( 'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff', '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' );
 	}
+	if ( ! class_exists( '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff', '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff' );
+	}
 
 	define( 'WPCS_PHPCS_ALIASES_SET', true );
 

--- a/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff as PHPCS_Squiz_SemicolonSpacingSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Ensure there is no whitespace before a semicolon, while allowing for empty conditions in a `for`.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void|int
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Don't examine semi-colons for empty conditions in `for()` control structures.
+		if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			$close_parenthesis = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
+
+			if ( isset( $tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
+				$owner = $tokens[ $close_parenthesis ]['parenthesis_owner'];
+
+				if ( T_FOR === $tokens[ $owner ]['code'] ) {
+					$previous = $phpcsFile->findPrevious(
+						Tokens::$emptyTokens,
+						( $stackPtr - 1 ),
+						$tokens[ $owner ]['parenthesis_opener'],
+						true
+					);
+
+					if ( false !== $previous
+						&& ( $previous === $tokens[ $owner ]['parenthesis_opener']
+							|| T_SEMICOLON === $tokens[ $previous ]['code'] )
+					) {
+						return;
+					}
+				}
+			}
+		}
+
+		return parent::process( $phpcsFile, $stackPtr );
+	}
+
+} // End class.

--- a/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Test that the sniff does *not* throw incorrect errors for whitespace before semi-colons in
+ * "empty" parts of a `for` control structure.
+ */
+for ($i = 1; ; $i++) {}
+for ( ; $ptr >= 0; $ptr-- ) {}
+for ( ; ; ) {}
+
+// But it should when the whitespace is between a condition and a semi-colon.
+for ( $i = 1 ; ; $i++ ) {}

--- a/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Test that the sniff does *not* throw incorrect errors for whitespace before semi-colons in
+ * "empty" parts of a `for` control structure.
+ */
+for ($i = 1; ; $i++) {}
+for ( ; $ptr >= 0; $ptr-- ) {}
+for ( ; ; ) {}
+
+// But it should when the whitespace is between a condition and a semi-colon.
+for ( $i = 1; ; $i++ ) {}

--- a/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the SemicolonSpacing sniff.
+ *
+ * Only the WPCS specific difference with the upstream sniff is being tested.
+ * The upstream sniff is tested upstream.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class SemicolonSpacingUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			12 => 1,
+		);
+
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+
+	}
+
+} // End class.


### PR DESCRIPTION
Adds two sniffs that correct spacing on either side of the `require*`
after the parentheses are removed:

- `Squiz.WhiteSpace.SemicolonSpacing` (added to `Core`) — Requires no
  whitespace before the semicolon.
- `Squiz.WhiteSpace.LanguageConstructSpacing` (added to `Extra`) —
  Requires exactly one space after a control structure.

I ran both of these over some code to see if there were any issues, and the only problem that turned up was with the semicolon sniff on this code:

```php
		for ( ; $next <= $end; ++$next ) {
```

```
---------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------------------------------------------
 62 | ERROR | [x] Space found before semicolon; expected "(;" but found "( ;" (Squiz.WhiteSpace.SemicolonSpacing.Incorrect)
---------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------------------------------------------------------------------------
```

Of course, removing the space will trigger:

```
  62 | ERROR | [x] No space after opening parenthesis is prohibited
     |       |     (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
```

I could not find a workaround, adding a `/* comment */` did not help. I could refactor the code, of course, but in this case `$next` is assigned a value outside for readability. Perhaps the `SemicolongSpacing` sniff should ignore `for` loops anyway, since there is already a `Squiz.ControlStructures.ForLoopDeclaration` sniff specifically to check their formatting. We could see about fixing that upstream, ~~but IMO it doesn't need to be a blocker for merging this~~.

Looks like there is actually [the same issue in WPCS](https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards/jobs/278955953#L571) though:

https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/e96329ae758b95a5402d674935b442e073fef756/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php#L423

So we may have to address that before merging.

Fixes #1153