### PR TITLE
Modern code/Extra: Add checks for USE declarations

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -185,5 +185,8 @@
 
 	<!-- Check for single blank line after namespace declaration. -->
 	<rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
+	
+	<!-- Check for correct use of USE declarations. -->
+	<rule ref="PSR2.Namespaces.UseDeclaration"/>
 
 </ruleset>


### PR DESCRIPTION
Adds checks for:

* Single space after `use` keyword.
* One `use` keyword per declaration.
* `use` declarations must go after first namespace declaration.
* One blank line after last `use` statement.

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php