### PR TITLE
Fix suggestions for unsafe _ex() function

### DIFF
--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -77,7 +77,7 @@ class EscapeOutputSniff extends Sniff {
 	 */
 	protected $unsafePrintingFunctions = array(
 		'_e'  => 'esc_html_e() or esc_attr_e()',
-		'_ex' => 'esc_html_ex() or esc_attr_ex()',
+		'_ex' => 'echo esc_html_x() or echo esc_attr_x()',
 	);
 
 	/**

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -24,7 +24,7 @@ function custom_column_display( $column, $post_id )
 {
     global $post;
     switch ( $column ) {
-        case 'some_number' : 
+        case 'some_number' :
             echo (int) $test;
             echo (int) get_post_meta( $post_id, SOME_NUMBER, true );
         break;
@@ -248,3 +248,12 @@ echo // WPCS: XSS ok.
 echo esc_html( $something ),
 	$something_else,
 	esc_html( $something_more ); // WPCS: XSS ok.
+
+_ex( 'Something', 'context' ); // Bad.
+_ex( $some_nasty_var, 'context' ); // Bad.
+echo esc_html_x( 'Something', 'context' ); // Ok.
+echo esc_html_x( $some_nasty_var, 'context' ); // Ok.
+
+?>
+	<input type="hidden" name="some-action" value="<?php echo esc_attr_x( 'none', 'context' ); ?>" /><!-- OK. -->
+<?php

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -72,6 +72,8 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			223 => 1,
 			225 => 1,
 			226 => 1,
+			252 => 1,
+			253 => 1,
 		);
 
 	} // end getErrorList()


### PR DESCRIPTION
WordPress does not have any `esc_attr_ex()` or `esc_html_ex()` functions, we have to `echo` the non-echoing variants, which do exist.