### PR TITLE
Bump version constraint of suggested package to support PHP 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ When installing the WordPress Coding Standards as a dependency in a larger proje
 
 There are two actively maintained Composer plugins which can handle the registration of standards with PHP_CodeSniffer for you:
 * [composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
-* [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.1"
+* [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.3"
 
 It is strongly suggested to `require` one of these plugins in your project to handle the registration of external standards with PHPCS for you.
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
Set version constraint to allow for use with PHP 5.3 (thanks, @GaryJones 🙂).