### PR TITLE
PrecisionAlignment: fix false positive in combination with incorrectly aligned comments

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -123,14 +123,15 @@ class PrecisionAlignmentSniff extends Sniff {
 
 				case 'T_DOC_COMMENT_WHITESPACE':
 					$length = $this->tokens[ $i ]['length'];
-					if ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
-						|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code']
+					$spaces = ( $length % $this->tab_width );
+
+					if ( ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
+						|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
+						&& 0 !== $spaces
 					) {
 						// One alignment space expected before the *.
-						$length--;
+						--$spaces;
 					}
-
-					$spaces = ( $length % $this->tab_width );
 					break;
 
 				case 'T_COMMENT':
@@ -141,11 +142,11 @@ class PrecisionAlignmentSniff extends Sniff {
 					$comment    = ltrim( $this->tokens[ $i ]['content'] );
 					$whitespace = str_replace( $comment, '', $this->tokens[ $i ]['content'] );
 					$length     = strlen( $whitespace );
-					if ( isset( $comment[0] ) && '*' === $comment[0] ) {
-						$length--;
-					}
+					$spaces     = ( $length % $this->tab_width );
 
-					$spaces = ( $length % $this->tab_width );
+					if ( isset( $comment[0] ) && '*' === $comment[0] && 0 !== $spaces ) {
+						--$spaces;
+					}
 					break;
 
 				case 'T_INLINE_HTML':

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -45,3 +45,12 @@
 /*
 
 */
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/


### PR DESCRIPTION
If the stars for a docblock/multi-line inline comment  were not properly aligned, the sniff would throw an error even though there was no precision alignment.
The incorrect alignment of the _stars_ is not this sniffs concern, but for another sniff.

Includes unit tests.

As the sniff is new to `0.14.0`, this bugfix should be included in the upcoming release.