### PR TITLE
Move `eval` and `goto` restrictions from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -332,6 +332,22 @@
 	     to the next block, this must be explicitly commented. -->
 	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
 
+	<!-- Rule: The goto statement must never be used. -->
+	<!-- Duplicate of upstream. Should defer to upstream version once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1664 -->
+	<rule ref="WordPress.PHP.DiscourageGoto"/>
+	<rule ref="WordPress.PHP.DiscourageGoto.Found">
+		<type>error</type>
+		<message>The "goto" language construct should not be used.</message>
+	</rule>
+
+	<!-- Rule: The eval() construct is very dangerous, and is impossible to secure. ... these must not be used. -->
+	<rule ref="Squiz.PHP.Eval"/>
+	<rule ref="Squiz.PHP.Eval.Discouraged">
+		<type>error</type>
+		<message>eval() is a security risk so not allowed.</message>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -120,22 +120,6 @@
 	<rule ref="WordPress.WP.DiscouragedConstants"/>
 	<rule ref="WordPress.WP.DiscouragedFunctions"/>
 
-	<rule ref="Squiz.PHP.Eval"/>
-	<rule ref="Squiz.PHP.Eval.Discouraged">
-		<type>error</type>
-		<message>eval() is a security risk so not allowed.</message>
-	</rule>
-
-	<!-- Forbid the use of the `goto` language construct.
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1149 -->
-	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
-		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1664 -->
-	<rule ref="WordPress.PHP.DiscourageGoto"/>
-	<rule ref="WordPress.PHP.DiscourageGoto.Found">
-		<type>error</type>
-		<message>The "goto" language construct should not be used.</message>
-	</rule>
-
 	<!-- Scripts & style should be enqueued.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/35 -->
 	<rule ref="WordPress.WP.EnqueuedResources"/>


### PR DESCRIPTION
The Core handbook has been adjusted:
> The goto statement must never be used.
>
> The eval() construct is very dangerous, and is impossible to secure. Additionally, the create_function() function, which internally performs an eval(), is deprecated in PHP 7.2. Both of these must not be used.

https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#clever-code

This moves the related checks which were already contained in `Extra` to the `Core` ruleset.