### PR TITLE
New RestrictedPHPFunctions sniff to initially forbid `create_function`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -348,6 +348,10 @@
 		<message>eval() is a security risk so not allowed.</message>
 	</rule>
 
+	<!-- Rule: create_function() function, which internally performs an eval(),
+	     is deprecated in PHP 7.2. Both of these must not be used. -->
+	<rule ref="WordPress.PHP.RestrictedPHPFunctions"/>
+
 
 	<!--
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -107,12 +107,7 @@
 	<rule ref="WordPress.CSRF.NonceVerification"/>
 
 	<rule ref="WordPress.PHP.DevelopmentFunctions"/>
-	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
-		<!-- WP core still supports PHP 5.2+  -->
-		<properties>
-			<property name="exclude" value="create_function"/>
-		</properties>
-	</rule>
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions"/>
 	<rule ref="WordPress.WP.DeprecatedClasses"/>
 	<rule ref="WordPress.WP.DeprecatedParameters"/>

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -18,6 +18,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 `create_function` was moved to the PHP.RestrictedFunctions sniff.
  */
 class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
@@ -36,14 +37,6 @@ class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 		return array(
-			'create_function' => array(
-				'type'      => 'warning',
-				'message'   => '%s() is discouraged, please use anonymous functions instead.',
-				'functions' => array(
-					'create_function',
-				),
-			),
-
 			'serialize' => array(
 				'type'      => 'warning',
 				'message'   => '%s() found. Serialized data has known vulnerability problems with Object Injection. JSON is generally a better approach for serializing data. See https://www.owasp.org/index.php/PHP_Object_Injection',

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Forbids the use of various native PHP functions and suggests alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to forbid.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'create_function' => array(
+				'type'      => 'error',
+				'message'   => '%s() is deprecated as of PHP 7.2, please use full fledged functions or anonymous functions instead.',
+				'functions' => array(
+					'create_function',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // End class.

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.inc
@@ -2,9 +2,9 @@
 
 
 
-add_action( 'widgets_init', create_function( '', // Warning.
-	'return register_widget( "time_more_on_time_widget" );'
-) );
+
+
+
 
 serialize(); // Warning.
 unserialize(); // Warning.

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+add_action( 'widgets_init', create_function( '', // Error.
+	'return register_widget( "time_more_on_time_widget" );'
+) );

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -16,10 +16,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @package WPCS\WordPressCodingStandards
  *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0
  */
-class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
+class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -27,8 +26,9 @@ class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array();
-
+		return array(
+			3 => 1,
+		);
 	}
 
 	/**
@@ -37,33 +37,7 @@ class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			9  => 1,
-			10 => 1,
-			12 => 1,
-			15 => 1,
-			16 => 1,
-			17 => 1,
-			18 => 1,
-			19 => 1,
-			20 => 1,
-			21 => 1,
-			22 => 1,
-			23 => 1,
-			24 => 1,
-			25 => 1,
-			28 => 1,
-			29 => 1,
-			30 => 1,
-			31 => 1,
-			32 => 1,
-			35 => 1,
-			36 => 1,
-			37 => 1,
-			38 => 1,
-			39 => 1,
-			40 => 1,
-		);
+		return array();
 
 	}
 

--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -10,10 +10,9 @@
 	<rule ref="WordPress-VIP"/>
 
 	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
-		<!-- From "Extra": The create_function group is excluded as WP core still supports PHP 5.2 and 5.2 does not support anonymous functions. -->
 		<!-- From "VIP": The obfuscation group is excluded as there are plenty of legitimate uses for the base64 functions. -->
 		<properties>
-			<property name="exclude" value="create_function,obfuscation"/>
+			<property name="exclude" value="obfuscation"/>
 		</properties>
 	</rule>
 </ruleset>


### PR DESCRIPTION
The following has been added to the handbook:

> create_function() function, which internally performs an eval(), is deprecated in PHP 7.2. Both of these must not be used.

https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#clever-code

`create_function` was already discouraged in `Extra` via the `WordPress.PHP.DiscouragedPHPFunctions` sniff.
As it is now forbidden for Core, this check has been moved a new `WordPress.PHP.RestrictedPHPFunctions` sniff and added to the `Core` ruleset.