### PR TITLE
ArrayIndentation: deal correctly with trailing comments

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -179,6 +179,19 @@ class ArrayIndentationSniff extends Sniff {
 				true
 			);
 
+			// Deal with trailing comments.
+			if ( false !== $first_content
+				&& T_COMMENT === $this->tokens[ $first_content ]['code']
+				&& $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
+			) {
+				$first_content = $this->phpcsFile->findNext(
+					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+					( $first_content + 1 ),
+					$end_of_this_item,
+					true
+				);
+			}
+
 			if ( false === $first_content ) {
 				$end_of_previous_item = $end_of_this_item;
 				continue;

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -391,3 +391,11 @@ else {
 		'<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
 	),
 );
+
+// Issue #1179.
+b(
+	array(
+	1 => false, // wat
+	2 => false,
+	)
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -391,3 +391,11 @@ else {
 		'<p>The code snippet is simplified for brevity. Please refer to the source of this file on <a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" target="_blank">GitHub</a> for full details on how to use filter_var_array().</p>',
 	),
 );
+
+// Issue #1179.
+b(
+	array(
+		1 => false, // wat
+		2 => false,
+	)
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -392,4 +392,12 @@ else {
     ),
 );
 
+// Issue #1179.
+b(
+    [
+    1 => false, // wat
+    2 => false,
+    ]
+);
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -392,4 +392,12 @@ else {
     ),
 );
 
+// Issue #1179.
+b(
+    [
+        1 => false, // wat
+        2 => false,
+    ]
+);
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -162,6 +162,8 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 			347 => 1,
 			356 => 1,
 			369 => 1,
+			398 => 1,
+			399 => 1,
 		);
 	}
 


### PR DESCRIPTION
If a previous array item has a trailing comment, the sniff would bow out as it would defer to the ArrayDeclarationSpacing sniff to fix a multi-line array where items are not all on their own line first.
However, in the case of a trailing comment and the next array item in actual fact starting on its own line, the ArrayDeclarationSpacing sniff would (correctly) not kick in and the indentation error for the item would never be addressed.

This fixes that. Includes unit tests.

N.B.: Verified & confirmed that the ArrayDeclaration sniff already handled this situation correctly.

Fixes #1179