### PR TITLE
VIP ruleset: remove the explicit inclusion of two sniffs which are also in `Core`

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -31,21 +31,11 @@
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-instead-of -->
 	<rule ref="WordPress.PHP.StrictComparisons"/>
 
-	<!-- https://vip.wordpress.com/documentation/best-practices/database-queries/ -->
-	<rule ref="WordPress.WP.PreparedSQL"/>
-
 	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
 	<rule ref="Squiz.PHP.CommentedOutCode">
 		<properties>
 			<property name="maxPercentage" value="45"/>
 		</properties>
-	</rule>
-
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->
-	<rule ref="Squiz.PHP.Eval"/>
-	<rule ref="Squiz.PHP.Eval.Discouraged">
-		<type>error</type>
-		<message>eval() is a security risk so not allowed.</message>
 	</rule>
 
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->


### PR DESCRIPTION
As the whole `Core` ruleset is included in `VIP`, there is no need for these sniffs to be included twice.