### PR TITLE
Sync the WP global var lists

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -647,6 +647,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'is_IIS'                           => true,
 		'is_iis7'                          => true,
 		'is_macIE'                         => true,
+		'is_NS4'                           => true,
 		'is_opera'                         => true,
 		'is_safari'                        => true,
 		'is_winIE'                         => true,

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -59,13 +59,16 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * @var array
 	 */
 	protected $wordpress_mixed_case_vars = array(
-		'EZSQL_ERROR' => true,
-		'is_IE'       => true,
-		'is_IIS'      => true,
-		'is_macIE'    => true,
-		'is_NS4'      => true,
-		'is_winIE'    => true,
-		'PHP_SELF'    => true,
+		'EZSQL_ERROR'       => true,
+		'GETID3_ERRORARRAY' => true,
+		'is_IE'             => true,
+		'is_IIS'            => true,
+		'is_macIE'          => true,
+		'is_NS4'            => true,
+		'is_winIE'          => true,
+		'PHP_SELF'          => true,
+		'post_ID'           => true,
+		'user_ID'           => true,
 	);
 
 	/**


### PR DESCRIPTION
The WP base `Sniff` class contains a list of WP global variables which is used by two sniffs.
The `ValidVariableName` sniff contains a secondary list of globals which don't follow the WP variable name guidelines.

I've done a quick compare and found some differences between the lists which needed to be fixed.

It would be nice to build up the mixed_case_vars list dynamically, but unfortunately, as the `ValidVariableName` sniff extends an upstream sniff rather than the WP `Sniff`, this is currently not an option.