### PR TITLE
Array properties: always be lenient about spaces

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1038,8 +1038,11 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Allow for a comma delimited list.
 		if ( is_string( $custom ) ) {
-			$custom = array_filter( array_map( 'trim', explode( ',', $custom ) ) );
+			$custom = explode( ',', $custom );
 		}
+
+		// Always trim whitespace from the values.
+		$custom = array_filter( array_map( 'trim', $custom ) );
 
 		if ( true === $flip ) {
 			$custom = array_fill_keys( $custom, false );


### PR DESCRIPTION
While PHPCS does not allow for additional spaces in custom properties which are passed through a ruleset, WPCS was already lenient about this when the property was (incorrectly) passed as a string.

This fix will also make WPCS lenient about this when the property is passed as an array.

Inspired by upstream issue squizlabs/PHP_CodeSniffer#1688

So for WPCS, all of the below four examples will now work properly as expected:
```xml
<property name="customAutoEscapedFunctions" value="foo, bar" />
<property name="customAutoEscapedFunctions" value="foo,bar" />
<property name="customAutoEscapedFunctions" value="foo, bar" type="array" />
<property name="customAutoEscapedFunctions" value="foo,bar" type="array" />
```

The upstream issue still stands, but a fix for that would only go into PHPCS master, so won't be available to us for a while. In the mean time, this will work for WPCS.

No unit tests included as this will not work when changing a property inline (PHPCS upstream issue).
I have tested this with a custom ruleset though and can confirm that the fix works.
