### PR TITLE
StrictInArray: Allow for excluding warning when `false` is found

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -81,10 +81,20 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 
 		// We're only interested in the third parameter.
 		if ( false === isset( $parameters[3] ) || 'true' !== strtolower( $parameters[3]['raw'] ) ) {
+			$errorcode = 'MissingTrueStrict';
+
+			/*
+			 * Use a different error code when `false` is found to allow for excluding
+			 * the warning as this will be a conscious choice made by the dev.
+			 */
+			if ( isset( $parameters[3] ) && 'false' === strtolower( $parameters[3]['raw'] ) ) {
+				$errorcode = 'FoundNonStrictFalse';
+			}
+
 			$this->phpcsFile->addWarning(
 				'Not using strict comparison for %s; supply true for third argument.',
 				( isset( $parameters[3]['start'] ) ? $parameters[3]['start'] : $parameters[1]['start'] ),
-				'MissingTrueStrict',
+				$errorcode,
 				array( $matched_content )
 			);
 			return;


### PR DESCRIPTION
When a dev has supplied `false` as the third parameter, this will in all likelyhood be a very conscious choice.

Using a different error code for that particular code allows for modularly excluding the warning from the ruleset.

No adjusted unit tests as the affected tests will still give a warning, just with a different error code.