### PR TITLE
Core: Add `Generic.Functions.FunctionCallArgumentSpacing` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -213,6 +213,8 @@
 	<!-- Related to issue #970 / https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 -->
 	<rule ref="WordPress.Functions.FunctionCallSignatureNoParams"/>
 
+	<rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+
 	<!-- Rule: Perform logical comparisons, like so: if ( ! $foo ) { -->
 
 	<!-- Covers rule: When type casting, do it like so: $foo = (boolean) $bar; -->

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1269,12 +1269,12 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		$next_non_empty = $this->phpcsFile->findNext(
-			Tokens::$emptyTokens
-			, ( $stackPtr + 1 )
-			, null
-			, true
-			, null
-			, true
+			Tokens::$emptyTokens,
+			( $stackPtr + 1 ),
+			null,
+			true,
+			null,
+			true
 		);
 
 		// No token found.
@@ -1463,10 +1463,10 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Get the last non-empty token.
 		$prev = $this->phpcsFile->findPrevious(
-			Tokens::$emptyTokens
-			, ( $stackPtr - 1 )
-			, null
-			, true
+			Tokens::$emptyTokens,
+			( $stackPtr - 1 ),
+			null,
+			true
 		);
 
 		// Check if it is a safe cast.
@@ -1619,8 +1619,8 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		$key = $this->phpcsFile->getTokensAsString(
-			( $open_bracket + 1 )
-			, ( $this->tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
+			( $open_bracket + 1 ),
+			( $this->tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
 		);
 
 		return trim( $key );

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -109,10 +109,10 @@ class YodaConditionsSniff extends Sniff {
 
 		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
 			$next_non_empty = $this->phpcsFile->findNext(
-				array_merge( Tokens::$emptyTokens, array( T_DOUBLE_COLON ) )
-				, ( $next_non_empty + 1 )
-				, null
-				, true
+				array_merge( Tokens::$emptyTokens, array( T_DOUBLE_COLON ) ),
+				( $next_non_empty + 1 ),
+				null,
+				true
 			);
 		}
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -574,7 +574,7 @@ class I18nSniff extends Sniff {
 						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
 							// If it's docblock comment (wrong style) make sure that it's a translators comment.
 							$db_start      = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
-							$db_first_text = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ),  $previous_comment );
+							$db_first_text = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
 
 							if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
 								$this->phpcsFile->addWarning(

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -32,9 +32,9 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 		// Unset the lines related to version comments.
 		unset(
-			$errors[10],  $errors[12],  $errors[14],  $errors[16],  $errors[29],
-			$errors[55],  $errors[57],  $errors[59],  $errors[73],  $errors[76],
-			$errors[80],  $errors[118], $errors[125], $errors[161], $errors[174],
+			$errors[10], $errors[12], $errors[14], $errors[16], $errors[29],
+			$errors[55], $errors[57], $errors[59], $errors[73], $errors[76],
+			$errors[80], $errors[118], $errors[125], $errors[161], $errors[174],
 			$errors[178], $errors[210], $errors[233], $errors[251], $errors[255],
 			$errors[262], $errors[274], $errors[281], $errors[285], $errors[290],
 			$errors[295], $errors[303]


### PR DESCRIPTION
Adds sniff to check for whitespace around comma's within a function call. Allows for new lines. All errors thrown are fixable.

For closures it will also check whitespace around the equals sign for default values.

Example cases:
```php
a( 1,2 ); // NoSpaceAfterComma

a( 1   ,2 ); // SpaceBeforeComma + NoSpaceAfterComma

a( 1,   2 ); // TooMuchSpaceAfterComma

a(
   1,
   2
); // OK
```

Fixes #1189