### PR TITLE
New ArbitraryParenthesesSpacing sniff for Core

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -225,6 +225,21 @@
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
+	<!-- Rule: In a switch block, there must be no space before the colon for a case statement. -->
+	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
+
+	<!-- Rule: Similarly, there should be no space before the colon on return type declarations. -->
+
+	<!-- Covers rule: Unless otherwise specified, parentheses should have spaces inside of them. -->
+	<!-- Duplicate of upstream. Should defer to upstream version once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1701 -->
+	<rule ref="WordPress.WhiteSpace.ArbitraryParenthesesSpacing">
+		<properties>
+			<property name="spacingInside" value="1"/>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -137,7 +137,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		if ( T_DOUBLE_COLON === $token['code'] ) {
 			$nameEnd   = $this->phpcsFile->findPrevious( T_STRING, ( $stackPtr - 1 ) );
 			$nameStart = ( $this->phpcsFile->findPrevious( array( T_STRING, T_NS_SEPARATOR, T_NAMESPACE ), ( $nameEnd - 1 ), null, true, null, true ) + 1 );
-			$length    = ( $nameEnd - ( $nameStart - 1) );
+			$length    = ( $nameEnd - ( $nameStart - 1 ) );
 			$classname = $this->phpcsFile->getTokensAsString( $nameStart, $length );
 
 			if ( T_NS_SEPARATOR !== $this->tokens[ $nameStart ]['code'] ) {

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -235,7 +235,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 
 				$next_non_whitespace = $this->phpcsFile->findNext(
 					T_WHITESPACE,
-					($maybe_comma + 1 ),
+					( $maybe_comma + 1 ),
 					$closer,
 					true
 				);

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -217,7 +217,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		 */
 		$next_arrow = $this->phpcsFile->findNext(
 			T_DOUBLE_ARROW,
-			($opener + 1),
+			( $opener + 1 ),
 			$closer
 		);
 
@@ -241,7 +241,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 			// Find the position of the next double arrow.
 			$next_arrow = $this->phpcsFile->findNext(
 				T_DOUBLE_ARROW,
-				($next_arrow + 1),
+				( $next_arrow + 1 ),
 				$closer
 			);
 		}

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -105,7 +105,7 @@ class ClassInstantiationSniff extends Sniff {
 		if ( 'PHP' === $this->phpcsFile->tokenizerType ) {
 			$prev_non_empty = $this->phpcsFile->findPrevious(
 				Tokens::$emptyTokens,
-				($stackPtr - 1),
+				( $stackPtr - 1 ),
 				null,
 				true
 			);
@@ -128,7 +128,7 @@ class ClassInstantiationSniff extends Sniff {
 		 */
 		$next_non_empty_after_class_name = $this->phpcsFile->findNext(
 			$this->classname_tokens,
-			($stackPtr + 1),
+			( $stackPtr + 1 ),
 			null,
 			true,
 			null,

--- a/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Check & fix whitespace on the inside of arbitrary parentheses.
+ *
+ * Arbitrary parentheses are those which are not owned by a function (call), array or control structure.
+ * Spacing on the outside is not checked on purpose as this would too easily conflict with other spacing rules.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of the same sniff as pulled upstream.
+ * Once the upstream sniff has been merged and the minimum WPCS PHPCS requirement has gone up to
+ * the version in which the sniff was merged, this version can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1701} }}
+ */
+class ArbitraryParenthesesSpacingSniff extends Sniff {
+
+	/**
+	 * The number of spaces desired on the inside of the parentheses.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var integer
+	 */
+	public $spacingInside = 0;
+
+	/**
+	 * Allow newlines instead of spaces.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var boolean
+	 */
+	public $ignoreNewlines = false;
+
+	/**
+	 * Tokens which when they precede an open parenthesis indicate
+	 * that this is a type of structure this sniff should ignore.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	private $ignoreTokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		$this->ignoreTokens                           = Tokens::$functionNameTokens;
+		$this->ignoreTokens[ T_VARIABLE ]             = T_VARIABLE;
+		$this->ignoreTokens[ T_CLOSE_PARENTHESIS ]    = T_CLOSE_PARENTHESIS;
+		$this->ignoreTokens[ T_CLOSE_CURLY_BRACKET ]  = T_CLOSE_CURLY_BRACKET;
+		$this->ignoreTokens[ T_CLOSE_SQUARE_BRACKET ] = T_CLOSE_SQUARE_BRACKET;
+		$this->ignoreTokens[ T_CLOSE_SHORT_ARRAY ]    = T_CLOSE_SHORT_ARRAY;
+		$this->ignoreTokens[ T_ANON_CLASS ]           = T_ANON_CLASS;
+		$this->ignoreTokens[ T_USE ]                  = T_USE;
+		$this->ignoreTokens[ T_LIST ]                 = T_LIST;
+		$this->ignoreTokens[ T_DECLARE ]              = T_DECLARE;
+
+		// The below two tokens have been added to the Tokens::$functionNameTokens array in PHPCS 3.1.0,
+		// so they can be removed once the minimum PHPCS requirement of WPCS has gone up.
+		$this->ignoreTokens[ T_SELF ]   = T_SELF;
+		$this->ignoreTokens[ T_STATIC ] = T_STATIC;
+
+		// Language constructs where the use of parentheses should be discouraged instead.
+		$this->ignoreTokens[ T_THROW ]      = T_THROW;
+		$this->ignoreTokens[ T_YIELD ]      = T_YIELD;
+		$this->ignoreTokens[ T_YIELD_FROM ] = T_YIELD_FROM;
+		$this->ignoreTokens[ T_CLONE ]      = T_CLONE;
+
+		return array(
+			T_OPEN_PARENTHESIS,
+			T_CLOSE_PARENTHESIS,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( isset( $this->tokens[ $stackPtr ]['parenthesis_owner'] ) ) {
+			// This parenthesis is owned by a function/control structure etc.
+			return;
+		}
+
+		// More checking for the type of parenthesis we *don't* want to handle.
+		$opener = $stackPtr;
+		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( ! isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
+				// Parse error.
+				return;
+			}
+
+			$opener = $this->tokens[ $stackPtr ]['parenthesis_opener'];
+		}
+
+		$preOpener = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $opener - 1 ), null, true );
+		if ( false !== $preOpener && isset( $this->ignoreTokens[ $this->tokens[ $preOpener ]['code'] ] ) ) {
+			// Function or language construct call.
+			return;
+		}
+
+		/*
+		 * Check for empty parentheses.
+		 */
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] )
+		) {
+			$nextNonEmpty = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( $nextNonEmpty === $this->tokens[ $stackPtr ]['parenthesis_closer'] ) {
+				$this->phpcsFile->addWarning( 'Empty set of arbitrary parentheses found.', $stackPtr, 'FoundEmpty' );
+
+				return ( $this->tokens[ $stackPtr ]['parenthesis_closer'] + 1 );
+			}
+		}
+
+		/*
+		 * Check the spacing on the inside of the parentheses.
+		 */
+		$this->spacingInside = (int) $this->spacingInside;
+
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ ( $stackPtr + 1 ) ], $this->tokens[ ( $stackPtr + 2 ) ] )
+		) {
+			$nextToken = $this->tokens[ ( $stackPtr + 1 ) ];
+
+			if ( T_WHITESPACE !== $nextToken['code'] ) {
+				$inside = 0;
+			} else {
+				if ( $this->tokens[ ( $stackPtr + 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
+					$inside = 'newline';
+				} else {
+					$inside = $nextToken['length'];
+				}
+			}
+
+			if ( $this->spacingInside !== $inside
+				&& ( 'newline' !== $inside || false === $this->ignoreNewlines )
+			) {
+				$error = 'Expected %s space after open parenthesis; %s found';
+				$data  = array(
+					$this->spacingInside,
+					$inside,
+				);
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceAfterOpen', $data );
+
+				if ( true === $fix ) {
+					$expected = '';
+					if ( $this->spacingInside > 0 ) {
+						$expected = str_repeat( ' ', $this->spacingInside );
+					}
+
+					if ( 0 === $inside ) {
+						if ( '' !== $expected ) {
+							$this->phpcsFile->fixer->addContent( $stackPtr, $expected );
+						}
+					} elseif ( 'newline' === $inside ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $stackPtr + 2 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $expected );
+						$this->phpcsFile->fixer->endChangeset();
+					} else {
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $expected );
+					}
+				}
+			}
+		}
+
+		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ ( $stackPtr - 1 ) ], $this->tokens[ ( $stackPtr - 2 ) ] )
+		) {
+			$prevToken = $this->tokens[ ( $stackPtr - 1 ) ];
+
+			if ( T_WHITESPACE !== $prevToken['code'] ) {
+				$inside = 0;
+			} else {
+				if ( $this->tokens[ ( $stackPtr - 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
+					$inside = 'newline';
+				} else {
+					$inside = $prevToken['length'];
+				}
+			}
+
+			if ( $this->spacingInside !== $inside
+				&& ( 'newline' !== $inside || false === $this->ignoreNewlines )
+			) {
+				$error = 'Expected %s space before close parenthesis; %s found';
+				$data  = array(
+					$this->spacingInside,
+					$inside,
+				);
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClose', $data );
+
+				if ( true === $fix ) {
+					$expected = '';
+					if ( $this->spacingInside > 0 ) {
+						$expected = str_repeat( ' ', $this->spacingInside );
+					}
+
+					if ( 0 === $inside ) {
+						if ( '' !== $expected ) {
+							$this->phpcsFile->fixer->addContentBefore( $stackPtr, $expected );
+						}
+					} elseif ( 'newline' === $inside ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $stackPtr - 2 ); $i > 0; $i-- ) {
+							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), $expected );
+						$this->phpcsFile->fixer->endChangeset();
+					} else {
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), $expected );
+					}
+				}
+			}
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Make sure the sniff does not act on structures it shouldn't act on.
+ * All parentheses have extra spacing around it to test this properly.
+ */
+$b = functioncall( $something ) ;
+$b = function( $something ) {};
+$c = myFunction( $arg1 , $arg2 = array( ) );
+
+function something( $param ) {}
+
+$d = new MyClass(  );
+$e = new class(  ) {};
+
+try {
+} catch( Exception ) {
+}
+
+include( PATH . 'file.php' );
+
+if ( in_array( $arg1, array( 'foo','bar' ) ) ) {}
+isset( $abc );
+unset( $abc );
+empty( $abc );
+eval( $abc );
+exit( $abc );
+clone( $_date1 <= $_date2 ? $_date1 : $_date2 );
+declare( ticks=1 );
+list( $post_mime_types, $avail_post_mime_types ) = wp_edit_attachments_query( $q );
+throw( $e );
+yield from ( function(){} );
+
+$obj->{$var}( $foo,$bar );
+
+(function( $a, $b ) {
+	return function( $c, $d ) use ( $a, $b ) {
+		echo $a, $b, $c, $d;
+	};
+})( 'a','b' )( 'c','d' );
+
+$closure( $foo,$bar );
+$var = $closure() + $closure( $foo,$bar ) + self::$closure( $foo,$bar );
+
+class Test {
+	public static function baz( $foo, $bar ) {
+		$a = new self( $foo,$bar );
+		$b = new static( $foo,$bar );
+	}
+}
+
+/*
+ * Test warning for empty parentheses.
+ */
+$a = 4 + (); // Warning.
+$a = 4 + (   ); // Warning.
+$a = 4 + (/* Not empty */);
+
+/*
+ * Test the actual sniff.
+ */
+if ((null !== $extra) && ($row->extra !== $extra)) {}
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {} // Bad x 4.
+
+if ((        null !== $extra // Bad x 1.
+	&& is_int($extra))
+	&& ( $row->extra !== $extra // Bad x 1.
+		|| $something      ) // Bad x 1.
+) {}
+
+if (( null !== $extra ) // Bad x 2.
+	&& ( $row->extra !== $extra ) // Bad x 2.
+) {}
+
+$a = (null !== $extra);
+$a = ( null !== $extra ); // Bad x 2.
+
+$sx = $vert ? ($w - 1) : 0;
+
+$this->is_overloaded = ( ( ini_get("mbstring.func_overload") & 2 ) != 0 ) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 );
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
+
+$directory = ('/' == $file[ strlen($file)-1 ]);
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if ((null !== $extra) && ($row->extra !== $extra)) {} // Bad x 4.
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {}
+
+if ((        null !== $extra // Bad x 1.
+	&& is_int($extra)) // Bad x 1.
+	&& ( $row->extra !== $extra
+		|| $something      ) // Bad x 1.
+) {}
+
+if ((null !== $extra) // Bad x 2.
+	&& ($row->extra !== $extra) // Bad x 2.
+) {}
+
+$a = (null !== $extra); // Bad x 2.
+$a = ( null !== $extra );
+
+$sx = $vert ? ($w - 1) : 0; // Bad x 2.
+
+$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 ); // Bad x 4.
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {} // Bad x 2.
+
+$directory = ('/' == $file[ strlen($file)-1 ]); // Bad x 2.
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+/*
+ * Test handling of ignoreNewlines.
+ */
+if (
+	(
+		null !== $extra
+	) && (
+		$row->extra !== $extra
+	)
+) {} // Bad x 4, 1 x line 123, 2 x line 125, 1 x line 127.
+
+
+$a = (
+	null !== $extra
+); // Bad x 2, 1 x line 131, 1 x line 133.
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (
+	(
+		null !== $extra
+	) && (
+		$row->extra !== $extra
+	)
+) {} // Bad x 4, 1 x line 137, 2 x line 139, 1 x line 141.
+
+$a = (
+	null !== $extra
+); // Bad x 2, 1 x line 144, 1 x line 146.
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+if (
+	(
+		null !== $extra
+	) && (
+		$row->extra !== $extra
+	)
+) {}
+
+$a = (
+	null !== $extra
+);
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Make sure the sniff does not act on structures it shouldn't act on.
+ * All parentheses have extra spacing around it to test this properly.
+ */
+$b = functioncall( $something ) ;
+$b = function( $something ) {};
+$c = myFunction( $arg1 , $arg2 = array( ) );
+
+function something( $param ) {}
+
+$d = new MyClass(  );
+$e = new class(  ) {};
+
+try {
+} catch( Exception ) {
+}
+
+include( PATH . 'file.php' );
+
+if ( in_array( $arg1, array( 'foo','bar' ) ) ) {}
+isset( $abc );
+unset( $abc );
+empty( $abc );
+eval( $abc );
+exit( $abc );
+clone( $_date1 <= $_date2 ? $_date1 : $_date2 );
+declare( ticks=1 );
+list( $post_mime_types, $avail_post_mime_types ) = wp_edit_attachments_query( $q );
+throw( $e );
+yield from ( function(){} );
+
+$obj->{$var}( $foo,$bar );
+
+(function( $a, $b ) {
+	return function( $c, $d ) use ( $a, $b ) {
+		echo $a, $b, $c, $d;
+	};
+})( 'a','b' )( 'c','d' );
+
+$closure( $foo,$bar );
+$var = $closure() + $closure( $foo,$bar ) + self::$closure( $foo,$bar );
+
+class Test {
+	public static function baz( $foo, $bar ) {
+		$a = new self( $foo,$bar );
+		$b = new static( $foo,$bar );
+	}
+}
+
+/*
+ * Test warning for empty parentheses.
+ */
+$a = 4 + (); // Warning.
+$a = 4 + (   ); // Warning.
+$a = 4 + (/* Not empty */);
+
+/*
+ * Test the actual sniff.
+ */
+if ((null !== $extra) && ($row->extra !== $extra)) {}
+
+if ((null !== $extra) && ($row->extra !== $extra)) {} // Bad x 4.
+
+if ((null !== $extra // Bad x 1.
+	&& is_int($extra))
+	&& ($row->extra !== $extra // Bad x 1.
+		|| $something) // Bad x 1.
+) {}
+
+if ((null !== $extra) // Bad x 2.
+	&& ($row->extra !== $extra) // Bad x 2.
+) {}
+
+$a = (null !== $extra);
+$a = (null !== $extra); // Bad x 2.
+
+$sx = $vert ? ($w - 1) : 0;
+
+$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 );
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
+
+$directory = ('/' == $file[ strlen($file)-1 ]);
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (( null !== $extra ) && ( $row->extra !== $extra )) {} // Bad x 4.
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {}
+
+if (( null !== $extra // Bad x 1.
+	&& is_int($extra) ) // Bad x 1.
+	&& ( $row->extra !== $extra
+		|| $something ) // Bad x 1.
+) {}
+
+if (( null !== $extra ) // Bad x 2.
+	&& ( $row->extra !== $extra ) // Bad x 2.
+) {}
+
+$a = ( null !== $extra ); // Bad x 2.
+$a = ( null !== $extra );
+
+$sx = $vert ? ( $w - 1 ) : 0; // Bad x 2.
+
+$this->is_overloaded = ( ( ini_get("mbstring.func_overload") & 2 ) != 0 ) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ( $operation->axis & 1 ) != 0, ( $operation->axis & 2 ) != 0 ); // Bad x 4.
+
+if ( $success && ( 'nothumb' == $target || 'all' == $target ) ) {} // Bad x 2.
+
+$directory = ( '/' == $file[ strlen($file)-1 ] ); // Bad x 2.
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+/*
+ * Test handling of ignoreNewlines.
+ */
+if (
+	(null !== $extra) && ($row->extra !== $extra)
+) {} // Bad x 4, 1 x line 123, 2 x line 125, 1 x line 127.
+
+
+$a = (null !== $extra); // Bad x 2, 1 x line 131, 1 x line 133.
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (
+	( null !== $extra ) && ( $row->extra !== $extra )
+) {} // Bad x 4, 1 x line 137, 2 x line 139, 1 x line 141.
+
+$a = ( null !== $extra ); // Bad x 2, 1 x line 144, 1 x line 146.
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+if (
+	(
+		null !== $extra
+	) && (
+		$row->extra !== $extra
+	)
+) {}
+
+$a = (
+	null !== $extra
+);
+// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ArbitraryParenthesesSpacing sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			64  => 4,
+			66  => 1,
+			68  => 1,
+			69  => 1,
+			72  => 2,
+			73  => 2,
+			77  => 2,
+			81  => 4,
+			90  => 4,
+			94  => 1,
+			95  => 1,
+			97  => 1,
+			100 => 2,
+			101 => 2,
+			104 => 2,
+			107 => 2,
+			109 => 4,
+			111 => 4,
+			113 => 2,
+			115 => 2,
+			123 => 1,
+			125 => 2,
+			127 => 1,
+			131 => 1,
+			133 => 1,
+			137 => 1,
+			139 => 2,
+			141 => 1,
+			144 => 1,
+			146 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			55 => 1,
+			56 => 1,
+		);
+
+	}
+
+} // End class.


### PR DESCRIPTION
This new sniff checks the spacing on the **_inside_** of arbitrary parentheses.
A conscious choice has been made not to check on the outside as this would very quickly conflict with other sniffs.

Arbitrary parentheses, for the purposes of this sniff, are all parentheses which do not belong to a control structure, function declaration, function call or language construct.
This is to prevent conflicts and duplication with rules for those type of constructs.

**Notes:**
* The sniff will throw (fixable) errors when an incorrect amount of whitespace (too much/too little) has been found on the inside or the parenthesis.
* The sniff will throw a warning when an empty set of arbitrary parentheses is encountered.
* The desired amount of whitespace on the inside of the parentheses can be configured using the `spacingInside` property. Default: `0`.
    For WP-Core, this value is changed in the ruleset to `1`.
* Whether or not to allow new lines can be configured using the `ignoreNewlines` property. Default: `false`.
    For WP-Core, this value is changed in the ruleset to `true`.

Includes extensive unit tests.

I have run this new sniff as part of a complete run over WP Core and have not detected any issues nor new fixer conflicts caused by this sniff.

The sniff has been set up to be pulled upstream and once upstream has been merged and the minimum PHPCS requirement for WPCS has gone up, to be removed from WPCS.
Sister-PR upstream: https://github.com/squizlabs/PHP_CodeSniffer/pull/1701

Fixes #1194

-----
#### Todo once the sniff has been merged:
- [ ] Add info on the custom properties to the wiki
