### PR TITLE
Travis: Add simple test for fixer conflicts to the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,12 @@ script:
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --filter WordPress $(pwd)/Test/AllTests.php; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar  --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
+    # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
+    # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
+    # For the first run, the exit code will be 1 (= all fixable errors fixed).
+    # `travis_retry` should then kick in to run the fixer again which should now return 0 (= no fixable errors found).
+    # All error codes for the PHPCBF: https://github.com/squizlabs/PHP_CodeSniffer/issues/1270#issuecomment-272768413
+    - if [[ "$SNIFF" == "1" ]]; then travis_retry $PHPCS_DIR/bin/phpcbf -p ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/


### PR DESCRIPTION
Now https://github.com/squizlabs/PHP_CodeSniffer/pull/1645 has been merged, I can pull the follow up PR to #1123.

By running the complete WPCS suite over the test case files, we should be able to catch at least some fixer conflicts early.

As PHPCS exits with an error code of `1` when all fixable errors have been fixed correctly, we need to run the command twice over the test files to get a `0` exit code allowing the build to pass.

Any other error code indicates a fixer conflict or other problem remaining.

The travis report will output a summary report which will indicate the files which "FAILED TO FIX" which can be used to start investigating the fixer conflict.