### PR TITLE
Improve whitelist comments + issue with PreparedSQL sniff

### DIFF
--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -10,6 +10,7 @@
 namespace WordPress\Sniffs\WP;
 
 use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Sniff for prepared SQL.
@@ -53,7 +54,6 @@ class PreparedSQLSniff extends Sniff {
 		T_OBJECT_OPERATOR          => true,
 		T_OPEN_PARENTHESIS         => true,
 		T_CLOSE_PARENTHESIS        => true,
-		T_WHITESPACE               => true,
 		T_STRING_CONCAT            => true,
 		T_CONSTANT_ENCAPSED_STRING => true,
 		T_OPEN_SQUARE_BRACKET      => true,
@@ -97,6 +97,9 @@ class PreparedSQLSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
+
+		$this->ignored_tokens = $this->ignored_tokens + Tokens::$emptyTokens;
+
 		return array(
 			T_VARIABLE,
 			T_STRING,

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -90,5 +90,17 @@ $wpdb->query( // Some arbitrary comment.
 		WHERE post_title LIKE '" . $escaped_var . "';"
 ); // Bad x 1.
 
+$wpdb->query(
+	"SELECT *
+		FROM $wpdb->posts
+		WHERE post_title LIKE '" . $escaped_var . "';"
+); // WPCS: unprepared SQL OK.
+
+$wpdb->query( // WPCS: unprepared SQL OK.
+	"SELECT *
+		FROM $wpdb->posts
+		WHERE post_title LIKE '" . $escaped_var . "';"
+);
+
 // Don't throw an error during live coding.
 wpdb::prepare( "SELECT * FROM $wpdb->posts

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -84,5 +84,11 @@ ND
 
 wpdb::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad.
 
+$wpdb->query( // Some arbitrary comment.
+	"SELECT *
+		FROM $wpdb->posts
+		WHERE post_title LIKE '" . $escaped_var . "';"
+); // Bad x 1.
+
 // Don't throw an error during live coding.
 wpdb::prepare( "SELECT * FROM $wpdb->posts

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -44,6 +44,7 @@ class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 			64 => 1,
 			71 => 1,
 			85 => 1,
+			90 => 1,
 		);
 	}
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -237,3 +237,14 @@ function do_footer_nav() {
 		)
 	);
 }
+
+?><?php echo $html_fragment // XSS pass. ?><?php
+
+echo // WPCS: XSS ok.
+	esc_html( $something ),
+	$something_else,
+	esc_html( $something_more );
+
+echo esc_html( $something ),
+	$something_else,
+	esc_html( $something_more ); // WPCS: XSS ok.


### PR DESCRIPTION
**This PR contains a bugfix and an enhancement. Pulled in one go as they would otherwise conflict.**

While working on some improvements for the `PreparedSQLPlaceholders` sniff, which includes a whitelist comment, I came across the following issue:

```php
// This works fine.
$sql = $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s", $replacements ); // WPCS: PreparedSQLPlaceholders replacement count OK.

/*
 * This would trigger a "Use placeholders and $wpdb->prepare();
 * found // WPCS: PreparedSQLPlaceholders replacement count OK." error.
 */
$sql = $wpdb->prepare( // WPCS: PreparedSQLPlaceholders replacement count OK.
	"SELECT *
		FROM $wpdb->users
		WHERE id = %d
			AND user_login = %s",
	$replacements
);
```

**Bugfix:** That the `WP.PreparedSQL` sniff triggers an error for comments is clearly wrong, so that is fixed in the first commit.

Next I had a look at the `has_whitelist_comment()` method as - based on the number of questions I've seen about the whitelist comment placement and the number of times I've struggled with it myself in the past -, it doesn't always seem intuitive where to place the whitelist comment.

Whitelist comments only worked if they were:
* the last token in an embedded PHP snippet
* òr at the end of the line for the token which triggers the whitelist check.

However, for a "normal" user, it is often unclear what token triggers the whitelist check, so people find it hard to correctly place the whitelist comments.

**Enhancement:** The second commit changes the behaviour of the whitelist comment method and now allows for both the above as well as a whitelist comment directly after the semi-colon ending the statement.

I do wonder why this wasn't implemented when the method was originally and if there were pertinent reasons not to do so. Maybe @JDGrimes or @westonruter knows ?

So taking the above example, this will now work:
```php
$sql = $wpdb->prepare(
	"SELECT *
		FROM $wpdb->users
		WHERE id = %d
			AND user_login = %s",
	$replacements
); // WPCS: PreparedSQLPlaceholders replacement count OK.
```

Unit tests for both are, of course, included.

#### TODO when merged
- [ ] Update wiki whitelist comment page