### PR TITLE
PreparedSQL: allow for safe casts

### DIFF
--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -65,6 +65,9 @@ class PreparedSQLSniff extends Sniff {
 		T_START_NOWDOC             => true,
 		T_NOWDOC                   => true,
 		T_END_NOWDOC               => true,
+		T_INT_CAST                 => true,
+		T_DOUBLE_CAST              => true,
+		T_BOOL_CAST                => true,
 	);
 
 	/**
@@ -160,6 +163,10 @@ class PreparedSQLSniff extends Sniff {
 			if ( T_VARIABLE === $this->tokens[ $this->i ]['code'] ) {
 				if ( '$wpdb' === $this->tokens[ $this->i ]['content'] ) {
 					$this->is_wpdb_method_call( $this->i, $this->methods );
+					continue;
+				}
+
+				if ( $this->is_safe_casted( $this->i ) ) {
 					continue;
 				}
 			}

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.inc
@@ -102,5 +102,9 @@ $wpdb->query( // WPCS: unprepared SQL OK.
 		WHERE post_title LIKE '" . $escaped_var . "';"
 );
 
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE ID = " . (int) $foo . ";" ); // Ok.
+
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE value = " . (float) $foo . ";" ); // Ok.
+
 // Don't throw an error during live coding.
 wpdb::prepare( "SELECT * FROM $wpdb->posts


### PR DESCRIPTION
As `floatval()`, `intval()` and the likes are in the `$SQLEscapingFunctions` array, we should also allow for variables being safe casted.

This PR makes it so:
* The tokens for `(int)`, `(float)` and `(bool)` will no longer trigger an error.
* Variables which are preceeded by one of these will be considered safe.

Included unit tests.