### PR TITLE
AssignmentInCondition: add separate errorcode for assignment found in while

### DIFF
--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -193,10 +193,15 @@ class AssignmentInConditionSniff extends Sniff {
 			}
 
 			if ( true === $hasVariable ) {
+				$errorCode = 'Found';
+				if ( T_WHILE === $token['code'] ) {
+					$errorCode = 'FoundInWhileCondition';
+				}
+
 				$this->phpcsFile->addWarning(
 					'Variable assignment found within a condition. Did you mean to do a comparison?',
 					$hasAssignment,
-					'Found'
+					$errorCode
 				);
 			} else {
 				$this->phpcsFile->addWarning(


### PR DESCRIPTION
A `while()` condition is the only control structure in which it is sometimes legitimate to use an assignment in condition.

Having a separate error code will enable people to selectively exclude warnings for this.

N.B.: same change has been pulled upstream.

N.B.2: I've not applied this to the second error message as when it's a non-variable assignment, it doesn't matter whether it's in a loop or not, it's always wrong.