### PR TITLE
MultipleStatementAlignment: property name consistency

### DIFF
--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -38,7 +38,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 	 *
 	 * @var bool
 	 */
-	public $ignoreNewline = true;
+	public $ignoreNewlines = true;
 
 	/**
 	 * Whether the alignment should be exact.
@@ -111,7 +111,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 	 *               * Setting this to `=0` is useless as in that case there are
 	 *                 no multi-line items in the array anyway.
 	 *
-	 * This setting will respect the `ignoreNewline` and `maxColumnn` settings.
+	 * This setting will respect the `ignoreNewlines` and `maxColumnn` settings.
 	 *
 	 * @since 0.14.0
 	 *
@@ -331,7 +331,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				continue;
 			}
 
-			if ( true === $this->ignoreNewline
+			if ( true === $this->ignoreNewlines
 				&& $this->tokens[ $last_index_token ]['line'] !== $this->tokens[ $double_arrow ]['line']
 			) {
 				// Ignore this item as it has a new line between the item key and the double arrow.

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
@@ -107,17 +107,17 @@ $array = array(
 	'ccc'
 		=> 'd',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = array(
 	'a'
 		=> 'b', // Bad.
 	'ccc'
 		=> 'd', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = array(
 	'a'     => 'b',
@@ -148,7 +148,7 @@ $array = array(
 		      => 'h', // Bad.
 );
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -225,7 +225,7 @@ $array = array(
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = array(
 	'a'    => 'b',
@@ -269,7 +269,7 @@ $array = array(
 );
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
@@ -107,15 +107,15 @@ $array = array(
 	'ccc'
 		=> 'd',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = array(
 	'a'   => 'b', // Bad.
 	'ccc' => 'd', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = array(
 	'a'     => 'b',
@@ -142,7 +142,7 @@ $array = array(
 	'g'     => 'h', // Bad.
 );
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -219,7 +219,7 @@ $array = array(
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = array(
 	'a'    => 'b',
@@ -255,7 +255,7 @@ $array = array(
 );
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
@@ -107,17 +107,17 @@ $array = [
     'ccc'
         => 'd',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = [
     'a'
         => 'b', // Bad.
     'ccc'
         => 'd', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = [
     'a'     => 'b',
@@ -148,7 +148,7 @@ $array = [
               => 'h', // Bad.
 ];
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -225,7 +225,7 @@ $array = [
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = [
     'a'    => 'b',
@@ -269,7 +269,7 @@ $array = [
 ];
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
@@ -107,15 +107,15 @@ $array = [
     'ccc'
         => 'd',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = [
     'a'   => 'b', // Bad.
     'ccc' => 'd', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = [
     'a'     => 'b',
@@ -142,7 +142,7 @@ $array = [
     'g'     => 'h', // Bad.
 ];
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -219,7 +219,7 @@ $array = [
 
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline false
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = [
     'a'    => 'b',
@@ -255,7 +255,7 @@ $array = [
 ];
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
 // @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewline true
+// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*


### PR DESCRIPTION
Everywhere else where a "ignore new lines" property is used, both in WPCS as well as in PHPCS upstream, the property is called `ignoreNewlines`.

Only just now realized that the `s` was missing from the property in the new `Arrays.MultipleStatementAlignment` sniff.

This fixes that.

Not a BC-break as the sniff has not been in a release yet.

### To do after merge:
- [ ] Update the custom properties wiki page