### PR TITLE
Add WP_Ajax_UnitTestCase to \WordPress\Sniff::$test_class_whitelist

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -839,10 +839,15 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @var string[]
 	 */
 	protected $test_class_whitelist = array(
-		'WP_UnitTestCase'            => true,
-		'WP_Ajax_UnitTestCase'       => true,
-		'PHPUnit_Framework_TestCase' => true,
-		'PHPUnit\Framework\TestCase' => true,
+		'WP_UnitTestCase'                            => true,
+		'WP_Ajax_UnitTestCase'                       => true,
+		'WP_Canonical_UnitTestCase'                  => true,
+		'WP_Test_REST_TestCase'                      => true,
+		'WP_Test_REST_Controller_Testcase'           => true,
+		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
+		'WP_XMLRPC_UnitTestCase'                     => true,
+		'PHPUnit_Framework_TestCase'                 => true,
+		'PHPUnit\Framework\TestCase'                 => true,
 	);
 
 	/**

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -840,6 +840,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 */
 	protected $test_class_whitelist = array(
 		'WP_UnitTestCase'            => true,
+		'WP_Ajax_UnitTestCase'       => true,
 		'PHPUnit_Framework_TestCase' => true,
 		'PHPUnit\Framework\TestCase' => true,
 	);


### PR DESCRIPTION
I was getting a `WordPress.Files.FileName.InvalidClassFileName` error for test when I extended `WP_Ajax_UnitTestCase`.