### PR TITLE
Naming Conventions: make exceptions for core hooks intended to be reused

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -92,6 +92,18 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
+	 * A list of core hooks that are allowed to be called by plugins and themes.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $whitelisted_core_hooks = array(
+		'widget_title'   => true,
+		'add_meta_boxes' => true,
+	);
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @since 0.12.0
@@ -572,6 +584,13 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		$is_error    = true;
 		$raw_content = $this->strip_quotes( $parameters[1]['raw'] );
+
+		if (
+			'define' !== $matched_content
+			&& isset( $this->whitelisted_core_hooks[ $raw_content ] )
+		) {
+			return;
+		}
 
 		if ( $this->is_prefixed( $raw_content ) === true ) {
 			return;

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -318,3 +318,7 @@ namespace Testing {
 	define( 'MY' . __NAMESPACE__, __FILE__ ); // Error, not actually namespaced.
 	define( 'MY\\' . __NAMESPACE__, __FILE__ ); // OK, even though strangely setup, the constant is in a namespace.
 }
+
+// OK: whitelisted core hooks.
+apply_filters( 'widget_title', $title );
+do_action( 'add_meta_boxes' );


### PR DESCRIPTION
Some core actions and filters are intended to be called by plugins and themes, so we don't need to throw an error when they are.
