### PR TITLE
Update default minimum WP version

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -78,7 +78,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '4.5';
+	public $minimum_supported_version = '4.6';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -534,6 +534,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => 'delete_user_meta()',
 			'version' => '3.0.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'funky_javascript_callback' => array(
 			'alt'     => '',
 			'version' => '3.0.0',
@@ -645,7 +646,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '3.1.0',
 		),
 		'get_dashboard_blog' => array(
-			'alt'     => '',
+			'alt'     => 'get_site()',
 			'version' => '3.1.0',
 		),
 		'get_editable_authors' => array(
@@ -769,6 +770,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => '$current_screen->render_screen_layout()',
 			'version' => '3.3.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'screen_meta' => array(
 			'alt'     => '$current_screen->render_screen_meta()',
 			'version' => '3.3.0',
@@ -822,11 +824,11 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '3.3.0',
 		),
 		'wpmu_admin_do_redirect' => array(
-			'alt'     => '',
+			'alt'     => 'wp_redirect()',
 			'version' => '3.3.0',
 		),
 		'wpmu_admin_redirect_add_updated_param' => array(
-			'alt'     => '',
+			'alt'     => 'add_query_arg()',
 			'version' => '3.3.0',
 		),
 
@@ -943,6 +945,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => 'WP_Image_Editor::rotate()',
 			'version' => '3.5.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'_save_post_hook' => array(
 			'alt'     => '',
 			'version' => '3.5.0',
@@ -976,7 +979,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '3.5.0',
 		),
 		'wp_cache_reset' => array(
-			'alt'     => '',
+			'alt'     => 'WP_Object_Cache::reset()',
 			'version' => '3.5.0',
 		),
 		'wp_create_thumbnail' => array(
@@ -1041,38 +1044,47 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_incoming_links' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_incoming_links_control' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_incoming_links_output' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_plugins' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_primary_control' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_recent_comments_control' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_secondary' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_secondary_control' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_dashboard_secondary_output' => array(
 			'alt'     => '',
 			'version' => '3.8.0',
@@ -1083,6 +1095,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => '',
 			'version' => '3.9.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'default_topic_count_text' => array(
 			'alt'     => '',
 			'version' => '3.9.0',
@@ -1183,6 +1196,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => '',
 			'version' => '4.3.0',
 		),
+		// Verified; see https://core.trac.wordpress.org/ticket/41121, patch 3.
 		'wp_ajax_wp_fullscreen_save_post' => array(
 			'alt'     => '',
 			'version' => '4.3.0',
@@ -1297,6 +1311,24 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'wp_dashboard_plugins_output' => array(
 			'alt'     => '',
 			'version' => '4.8.0',
+		),
+
+		// WP 4.9.0.
+		'get_shortcut_link' => array(
+			'alt'     => '',
+			'version' => '4.9.0',
+		),
+		'is_user_option_local' => array(
+			'alt'     => '',
+			'version' => '4.9.0',
+		),
+		'wp_ajax_press_this_add_category' => array(
+			'alt'     => '',
+			'version' => '4.9.0',
+		),
+		'wp_ajax_press_this_save_post' => array(
+			'alt'     => '',
+			'version' => '4.9.0',
 		),
 	);
 

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -307,10 +307,6 @@ get_admin_users_for_domain();
 post_permalink();
 wp_get_http();
 flush_widget_cache(); // Issue #731 - method WP_Widget_Recent_Comments::flush_widget_cache()
-
-/*
- * Warning.
- */
 /* ============ WP 4.5 ============ */
 add_object_page();
 add_utility_page();
@@ -319,6 +315,10 @@ get_comments_popup_template();
 get_currentuserinfo();
 is_comments_popup();
 popuplinks();
+
+/*
+ * Warning.
+ */
 /* ============ WP 4.6 ============ */
 post_form_autocomplete_off();
 wp_embed_handler_googlevideo();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -332,3 +332,8 @@ wp_get_network();
 wp_kses_js_entities();
 /* ============ WP 4.8 ============ */
 wp_dashboard_plugins_output();
+/* ============ WP 4.9 ============ */
+get_shortcut_link();
+is_user_option_local();
+wp_ajax_press_this_add_category();
+wp_ajax_press_this_save_post();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -50,11 +50,11 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 323, 12, 1 );
+		$warnings = array_fill( 323, 17, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[326], $warnings[333]
+			$warnings[326], $warnings[333], $warnings[335]
 		);
 
 		return $warnings;

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 
-		$errors = array_fill( 8, 302, 1 );
+		$errors = array_fill( 8, 310, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
@@ -37,7 +37,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[80], $errors[118], $errors[125], $errors[161], $errors[174],
 			$errors[178], $errors[210], $errors[233], $errors[251], $errors[255],
 			$errors[262], $errors[274], $errors[281], $errors[285], $errors[290],
-			$errors[295], $errors[303]
+			$errors[295], $errors[303], $errors[310]
 		);
 
 		return $errors;
@@ -50,11 +50,11 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 315, 20, 1 );
+		$warnings = array_fill( 323, 12, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[322], $warnings[326], $warnings[333]
+			$warnings[326], $warnings[333]
 		);
 
 		return $warnings;

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -67,7 +67,7 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.5"/>
+	<config name="minimum_supported_wp_version" value="4.6"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 4.9 having come out last week, it should now be 4.6.

@JDGrimes Want to run your deprecated function magic to see if we need to add functions/classes/parameters to the lists ?