### PR TITLE
Fix build failure

### DIFF
--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
@@ -324,7 +324,7 @@ $deprecated_functions = [
     'user_can_edit_post_comments'=> 'multi-line
                     string', // Bad - no space.
     'the_category_ID'
-       => function_call( // Ok, ignore newline is being respected.
+        => function_call( // Ok, ignore newline is being respected.
         $a,
         $b
     ),

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
@@ -310,7 +310,7 @@ $deprecated_functions = [
     'user_can_edit_post_comments' => 'multi-line
                     string', // Bad - no space.
     'the_category_ID'
-       => function_call( // Ok, ignore newline is being respected.
+        => function_call( // Ok, ignore newline is being respected.
         $a,
         $b
     ),


### PR DESCRIPTION
The build failure has to do with an upstream fixer conflict between two sniffs fighting over tabs vs spaces.
This is related to a recent upstream change and should be reported there for further attention.

As the space is not important for this particular unit test, let's just prevent the conflict from happening for now.