### PR TITLE
CS: exclude while assignment in condition from own CS rules

### DIFF
--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -15,6 +15,7 @@
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
This is now possible since PR #1207 has been merged.

Using an assignment in condition is a typical pattern used when walking the token arrays and should be ok for this library.