### PR TITLE
Revert "Fix build failure"

### DIFF
--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
@@ -324,7 +324,7 @@ $deprecated_functions = [
     'user_can_edit_post_comments'=> 'multi-line
                     string', // Bad - no space.
     'the_category_ID'
-        => function_call( // Ok, ignore newline is being respected.
+       => function_call( // Ok, ignore newline is being respected.
         $a,
         $b
     ),

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
@@ -310,7 +310,7 @@ $deprecated_functions = [
     'user_can_edit_post_comments' => 'multi-line
                     string', // Bad - no space.
     'the_category_ID'
-        => function_call( // Ok, ignore newline is being respected.
+       => function_call( // Ok, ignore newline is being respected.
         $a,
         $b
     ),


### PR DESCRIPTION
This reverts commit c27064aa0a455cb4d924864612369b2847108d44 / PR #1238.

The upstream issue which was causing the build failure has been fixed, so I'm bringing back the odd spacing to allow us to continue to detect these kind of fixer conflicts early.