### PR TITLE
AssignmentInCondition: fix bug where nested parentheses were presumed to be related to a ternary

### DIFF
--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -137,9 +137,24 @@ class AssignmentInConditionSniff extends Sniff {
 				$opener = $this->tokens[ $prev ]['parenthesis_opener'];
 				$closer = $prev;
 			} elseif ( isset( $token['nested_parenthesis'] ) ) {
-				end( $token['nested_parenthesis'] );
+				$closer = end( $token['nested_parenthesis'] );
 				$opener = key( $token['nested_parenthesis'] );
-				$closer = $stackPtr;
+
+				$next_statement_closer = $this->phpcsFile->findEndOfStatement( $stackPtr, array( T_COLON, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET ) );
+				if ( false !== $next_statement_closer && $next_statement_closer < $closer ) {
+					// Parentheses are unrelated to the ternary.
+					return;
+				}
+
+				$prev_statement_closer = $this->phpcsFile->findStartOfStatement( $stackPtr, array( T_COLON, T_OPEN_PARENTHESIS, T_OPEN_SQUARE_BRACKET ) );
+				if ( false !== $prev_statement_closer && $opener < $prev_statement_closer ) {
+					// Parentheses are unrelated to the ternary.
+					return;
+				}
+
+				if ( $closer > $stackPtr ) {
+					$closer = $stackPtr;
+				}
 			} else {
 				// No parenthesis found, can't determine where the conditional part of the ternary starts.
 				return;
@@ -196,6 +211,8 @@ class AssignmentInConditionSniff extends Sniff {
 				$errorCode = 'Found';
 				if ( T_WHILE === $token['code'] ) {
 					$errorCode = 'FoundInWhileCondition';
+				} elseif ( T_INLINE_THEN === $token['code'] ) {
+					$errorCode = 'FoundInTernaryCondition';
 				}
 
 				$this->phpcsFile->addWarning(

--- a/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
@@ -105,13 +105,49 @@ $mode = ( $a == 'on' ? 'true' : $a == 'off' ? 't' : 'f' );
 // Bad.
 $mode = ( $a = 'on' ) ? 'on' : 'off';
 $mode = ( $a = 'on' ) ?: 'off';
-$mode = ( $a = 'on' ) ? 'true' : ( $a = 'off' ) ? 't' : 'f'; // Bad x 2.
+$mode = ( $a = 'on' ) ? 'true' : ( $a = 'off' ? 't' : ${$a->prop} ); // Bad x 2.
 $mode = ( $a = 'on' ? 'on' : 'off' );
-$mode = ( $a = 'on' ?: 'off' );
+$mode = ( ${$a->prop} = 'on' ?: 'off' );
 $mode = ( $a = 'on' ? 'true' : ( $a = 'off' ? 't' : 'f' ) ); // Bad x 2.
-$mode = ( $a = 'on' ? 'true' : $a = 'off' ? 't' : 'f' ); // Bad x 3. The first ? triggers 1, the second (correctly) 2.
+$mode = ( $a['test'] = 'on' ? 'true' : $a['test'] = 'off' ? 't' : 'f' ); // Bad x 3. The first ? triggers 1, the second (correctly) 2.
 
 // Currently not checked.
 $mode = $a = 'on' ? 'on' : 'off';
 $mode = $a = 'on' ?: 'off';
 $mode = $a = 'on' ? 'true' : $a = 'off' ? 't' : 'f';
+
+// Issue #1227.
+( function () {
+	$foo = 42;
+	return 1 === 2 ? 'a' : 'b';
+} );
+
+call_user_func( function () {
+	$foo = 42;
+	return 1 === 2 ? 'a' : 'b';
+} );
+
+$content = preg_replace_callback(
+	'/(?s)<table class="viz full.+?<\/table>/',
+	function( $matches ) {
+		$rowcount = substr_count( $table, '<tr>' );
+		$height   = $rowcount < 6 ? '100' : '250';
+	},
+	$content
+);
+
+$array = array(
+	'a' => 1 = 2 ? 'a' : 'b', // OK: no relevant parenthesis found, so can't determine start/end of ternary.
+	'b' => (1 = 2) ? 'a' : 'b', // Bad.
+	'c' => (1 = 2 ? 'a' : 'b'), // Bad.
+	'd' => (1 === 2) ? 'a' : 'b', // OK.
+);
+
+$print = ( function () {
+?>
+<div id=<?php echo 1 = 2 ? 'a' : 'b' ?><!-- OK: no relevant parenthesis, so can't determine start/end of ternary. -->
+<div id=<?php echo (1 = 2) ? 'a' : 'b' ?><!-- Bad. -->
+<div id=<?php echo (1 = 2 ? 'a' : 'b') ?><!-- Bad. -->
+<div id=<?php echo (1 === 2 ? 'a' : 'b') ?><!-- OK. -->
+<?php
+});

--- a/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -87,6 +87,10 @@ class AssignmentInConditionUnitTest extends AbstractSniffUnitTest {
 			110 => 1,
 			111 => 2,
 			112 => 3,
+			141 => 1,
+			142 => 1,
+			149 => 1,
+			150 => 1,
 		);
 
 	}


### PR DESCRIPTION
For "assignment in condition" check with ternaries, only ternaries in parentheses are checked as it is neigh impossible to determine where the condition starts otherwise.
Obviously, for that to work, the sniff should only take parentheses into account which are actually related to the ternary.

Fixed now.

Fixes #1227

~~P.S.: there may be more "delimiters" which should be taken into consideration, not just the semicolon, but I couldn't come up with valid example code at this moment. (head in other things). Please let me know if you can think of some, including example code, and I'll adjust the sniff.~~

[Edit]:
The renewed commit now takes a number of additional delimiters into account.
It also adds a separate errorcode for assignments found in ternaries.