### PR TITLE
Fixable precision alignment warnings

### DIFF
--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc.fixed
@@ -1,0 +1,56 @@
+<?php
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space].
+ * The four spaces will be replaced by a tab by the upstream sniff.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab].
+ * The space replacement here will be handled by the upstream sniff.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comments are indented with tabs and one space.
+	 *
+     * @var string  <= Bad.
+	 * @access private
+	 */
+
+	/*
+	 * OK: Multi-line comments are indented with tabs and one space.
+	 *
+     * <= Bad.
+	 */
+
+    function exampleFunctionD() {} // Bad: [tab][space].
+    function exampleFunctionE() {} // Bad: [tab][space][space].
+    function exampleFunctionF() {} // Bad: [tab][space][space][space].
+
+	 function exampleFunctionG() {} // WPCS: precision alignment ok.
+
+?>
+
+	<p>
+    Bad: Some text with precision alignment.
+	</p>
+
+<?php
+
+// Testing empty line within a comment.
+/*
+
+*/
+
+// Testing that incorrectly aligned docblocks and multi-line inline comments do not trigger errors.
+	/**
+	* Provision some options
+	*/
+
+	/*
+	* Provision some options
+	*/

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc.fixed
@@ -1,0 +1,44 @@
+@codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_COMMENT,T_DOC_COMMENT_WHITESPACE,T_INLINE_HTML,T_FUNCTION
+
+<?php
+
+	function exampleFunctionA() {} // OK: [tab].
+
+/*
+ * OK: [tab][space][space][space][space].
+ * The four spaces will be replaced by a tab by the upstream sniff.
+ */
+	    function exampleFunctionB() {}
+
+/*
+ * OK: [tab][space][space][tab][space][tab].
+ * The space replacement here will be handled by the upstream sniff.
+ */
+	  	 	function exampleFunctionC() {}
+
+	/**
+	 * OK: Doc comments are indented with tabs and one space.
+	 *
+     * @var string  <= Bad.
+	 * @access private
+	 */
+
+	/*
+	 * OK: Multi-line comments are indented with tabs and one space.
+	 *
+     * <= Bad.
+	 */
+
+    function exampleFunctionD() {} // Bad: [tab][space].
+    function exampleFunctionE() {} // Bad: [tab][space][space].
+    function exampleFunctionF() {} // Bad: [tab][space][space][space].
+
+?>
+
+	<p>
+    Bad: Some text with precision alignment.
+	</p>
+
+<?php
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_NONE

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.css.fixed
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.css.fixed
@@ -1,0 +1,5 @@
+#login-container {
+    margin-left: -225px;
+	width: 450px;
+    height: 450px; /* Bad. */
+}

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.js.fixed
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.js.fixed
@@ -1,0 +1,7 @@
+var x = {
+	abc: 1,
+    zyz: 2,
+    mno: {
+    abc: 4
+    },
+}


### PR DESCRIPTION
Makes precision alignment warnings fixable by `phpcbf`.