### PR TITLE
Add a couple of extra sniffs to `Extra`

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -156,6 +156,11 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/919 -->
 	<rule ref="WordPress.Classes.ClassInstantiation"/>
 
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1157 -->
+	<rule ref="WordPress.Security.PluginMenuSlug"/>
+	<rule ref="WordPress.WP.CronInterval"/>
+	<rule ref="WordPress.WP.PostsPerPage"/>
+	<rule ref="WordPress.WP.TimezoneChange"/>
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
A couple of sniffs which were previously in VIP are also useful for `Extra`. The messages in these sniffs have - where appropriate - been downgraded to warnings.

This commit adds these sniffs to the `Extra` ruleset.

Note: There are three more candidates for this:
* `DB.DirectDatabaseQuery`
* `DB.SlowDBQuery`
* `Security.ValidatedSanitizedInput`

I've not included the first two (yet) as those may need some more discussion first.
The third one is not included as it throws a lot of noise messages and has quite some open issues surrounding it, which should be addressed first IMO.