### PR TITLE
Rulesets: lower severity instead of excluding checks

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -58,11 +58,16 @@
 
 	<!-- Covers rule: For switch structures case should indent one tab from the
 	     switch statement and break one tab from the case statement. -->
-	<rule ref="PSR2.ControlStructures.SwitchDeclaration">
-		<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.NotLower"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine"/>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
+	<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.NotLower">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine">
+		<severity>0</severity>
 	</rule>
 
 	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
@@ -130,11 +135,18 @@
 	-->
 	<!-- Covers rule: When embedding multi-line PHP snippets within a HTML block, the
 	     PHP open and close tags must be on a line by themselves. -->
-	<rule ref="Squiz.PHP.EmbeddedPhp">
-		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
+	<rule ref="Squiz.PHP.EmbeddedPhp"/>
+	<rule ref="Squiz.PHP.EmbeddedPhp.SpacingBefore">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.PHP.EmbeddedPhp.Indent">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.PHP.EmbeddedPhp.OpenTagIndent">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.PHP.EmbeddedPhp.SpacingAfter">
+		<severity>0</severity>
 	</rule>
 
 
@@ -194,8 +206,11 @@
 			<property name="requiredSpacesAfterOpen" value="1"/>
 			<property name="requiredSpacesBeforeClose" value="1"/>
 		</properties>
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose"/>
 	</rule>
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose">
+		<severity>0</severity>
+	</rule>
+
 
 	<!-- Covers rule: Call a function, like so: my_function( $param1, func_param( $param2 ) ); -->
 	<rule ref="PEAR.Functions.FunctionCallSignature">

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -41,9 +41,12 @@
 
 	<!-- And yet more best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1143 -->
-	<rule ref="PEAR.Files.IncludingFile">
-		<exclude name="PEAR.Files.IncludingFile.UseInclude"/>
-		<exclude name="PEAR.Files.IncludingFile.UseIncludeOnce"/>
+	<rule ref="PEAR.Files.IncludingFile"/>
+	<rule ref="PEAR.Files.IncludingFile.UseInclude">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
+		<severity>0</severity>
 	</rule>
 	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
 		<type>warning</type>


### PR DESCRIPTION
_As discussed in #1157 with conclusion written up in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1157#issuecomment-345749743 ._

Hard excluding individual PHPCS rules makes it impossible for a custom ruleset to re-enable a rule.
By changing the severity instead, a custom ruleset can up the severity of a check to re-enable it.

Note: whether this will work or not depends on the loading order of rules. No guarantees given.
The fact that it may not work in certain circumstances, is something which should be addressed upstream.