### PR TITLE
Fix two "typo"'s in deprecation messages

### DIFF
--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -53,7 +53,7 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
 			$this->phpcsFile->addWarning(
-				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.VIP.TimezoneChange". Please update your custom ruleset.',
+				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.WP.TimezoneChange". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
@@ -65,7 +65,7 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
 			$this->phpcsFile->addWarning(
-				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.VIP.TimezoneChange". Please update your custom ruleset.',
+				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.WP.TimezoneChange". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -57,7 +57,7 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
 			$this->phpcsFile->addWarning(
-				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.XSS.EscapeOutput". Please update your custom ruleset.',
+				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.Security.EscapeOutput". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
@@ -72,7 +72,7 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
 			$this->phpcsFile->addWarning(
-				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.XSS.EscapeOutput". Please update your custom ruleset.',
+				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.Security.EscapeOutput". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);


### PR DESCRIPTION
Fixes the incorrect message text as reported in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1242#issuecomment-353124042

I double-checked all the deprecation messages to be on the safe side and found one other sniff in which the new name had not been adjusted. That one is fixed here too.