### PR TITLE
New Security.SafeRedirect sniff to encourage safe redirects

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -103,6 +103,9 @@
 
 	<rule ref="WordPress.Security.EscapeOutput"/>
 
+	<!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities. -->
+	<rule ref="WordPress.Security.SafeRedirect"/>
+
 	<!-- Verify that a nonce check is done before using values in superglobals.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/73 -->
 	<rule ref="WordPress.Security.NonceVerification"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -103,7 +103,8 @@
 
 	<rule ref="WordPress.Security.EscapeOutput"/>
 
-	<!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities. -->
+	<!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1264 -->
 	<rule ref="WordPress.Security.SafeRedirect"/>
 
 	<!-- Verify that a nonce check is done before using values in superglobals.

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -121,4 +121,7 @@
 		<type>error</type>
 	</rule>
 
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_safe_redirect-instead-of-wp_redirect -->
+	<rule ref="WordPress.Security.SafeRedirect"/>
+
 </ruleset>

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Security;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Encourages use of wp_safe_redirect() to avoid open redirect vulnerabilities.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'wp_redirect' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code.',
+				'functions' => array(
+					'wp_redirect',
+				),
+			),
+		);
+	} // End getGroups().
+
+} // End class.

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -37,7 +37,7 @@ class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
 		return array(
 			'wp_redirect' => array(
 				'type'      => 'warning',
-				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code.',
+				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
 				'functions' => array(
 					'wp_redirect',
 				),

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -214,15 +214,6 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_safe_redirect-instead-of-wp_redirect
-			'wp_redirect' => array(
-				'type'      => 'warning',
-				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
-				'functions' => array(
-					'wp_redirect',
-				),
-			),
-
 			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#mobile-detection
 			'wp_is_mobile' => array(
 				'type'      => 'error',

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.inc
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+wp_redirect( $location ); // Warning.
+wp_safe_redirect( $location ); // OK.

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\Security;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Security_SafeRedirect sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class SafeRedirectUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+
+	} // End getErrorList().
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3 => 1,
+		);
+
+	}
+
+} // End class.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.inc
@@ -73,7 +73,7 @@ get_previous_post_link(); // Error.
 get_next_post_link(); // Error.
 get_intermediate_image_sizes(); // Error.
 
-wp_redirect(); // Warning.
+
 wp_is_mobile(); // Error.
 
 setcookie( 'cookie[three]', 'cookiethree' ); // Warning.

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -70,7 +70,6 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			54 => 1,
 			55 => 1,
 			57 => 1,
-			76 => 1,
 			79 => 1,
 		);
 


### PR DESCRIPTION
Introduces a sniff that warns about the use of the `wp_redirect()` function, suggesting
`wp_safe_redirect()` instead, to avoid malicious redirects.

This is based on the warning currently in `VIP.RestrictedFunctions`, but
in a more generic form.

I've added the sniff to the `WordPress-Extra` ruleset.