### PR TITLE
AlternativeFunctions: detect `strip_tags()` and advise using `wp_strip_all_tags()` instead

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -84,6 +84,14 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
+			'strip_tags' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use the more comprehensive wp_strip_all_tags() instead.',
+				'functions' => array(
+					'strip_tags',
+				),
+			),
+
 		);
 	} // End getGroups().
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -21,3 +21,4 @@ fclose(); // Warning.
 fread(); // Warning.
 fwrite(); // Warning.
 file_put_contents(); // Warning.
+strip_tags( $something ); // Warning.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -56,6 +56,7 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			21 => 1,
 			22 => 1,
 			23 => 1,
+			24 => 1,
 		);
 
 	}


### PR DESCRIPTION
The advantage of `wp_strip_all_tags()` over `strip_tags()` is that it does not leave the content of removed `<script>` and `<style>` tags behind.

> This differs from `strip_tags()` because it removes the contents of the `<script>` and `<style>` tags. E.g. `strip_tags( '<script>something</script>' )` will return ‘something’. `wp_strip_all_tags()` will return ”

Refs:
* https://developer.wordpress.org/reference/functions/wp_strip_all_tags/
* http://php.net/manual/en/function.strip-tags.php