### PR TITLE
PrecisionAlignment: fix various bugs

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -74,6 +74,7 @@ class PrecisionAlignmentSniff extends Sniff {
 	public function register() {
 		return array(
 			T_OPEN_TAG,
+			T_OPEN_TAG_WITH_ECHO,
 		);
 	}
 

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -99,7 +99,7 @@ class PrecisionAlignmentSniff extends Sniff {
 			T_COMMENT                => true,
 		);
 
-		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+		for ( $i = 0; $i < $this->phpcsFile->numTokens; $i++ ) {
 			if ( ! isset( $this->tokens[ ( $i + 1 ) ] ) ) {
 				break;
 			}

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -101,17 +101,16 @@ class PrecisionAlignmentSniff extends Sniff {
 		);
 
 		for ( $i = 0; $i < $this->phpcsFile->numTokens; $i++ ) {
-			if ( ! isset( $this->tokens[ ( $i + 1 ) ] ) ) {
-				break;
-			}
 
 			if ( 1 !== $this->tokens[ $i ]['column'] ) {
 				continue;
 			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) === false
-				|| T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code']
+				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
+					&& T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] )
 				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar
 				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
-				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] )
+				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
+					&& isset( $this->ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] ) )
 			) {
 				continue;
 			}
@@ -126,8 +125,9 @@ class PrecisionAlignmentSniff extends Sniff {
 					$length = $this->tokens[ $i ]['length'];
 					$spaces = ( $length % $this->tab_width );
 
-					if ( ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
-						|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
+					if ( isset( $this->tokens[ ( $i + 1 ) ] )
+						&& ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
+							|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
 						&& 0 !== $spaces
 					) {
 						// One alignment space expected before the *.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.4.inc
@@ -1,0 +1,5 @@
+  <div><!-- Bad.-->
+	  <p><a href="http://url/"><!-- Bad.-->
+		  <?= 'print this string' ?><!-- Bad.-->
+	  </a/></p><!-- Bad.-->
+  </div><!-- Bad.-->

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -82,6 +82,15 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 					39 => 1,
 				);
 
+			case 'PrecisionAlignmentUnitTest.4.inc':
+				return array(
+					1 => 1, // Will show a `Internal.NoCodeFound` warning in PHP 5.3 with short open tags off.
+					2 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					3 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					4 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					5 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+				);
+
 			case 'PrecisionAlignmentUnitTest.css':
 				return array(
 					4 => 1,


### PR DESCRIPTION
### Bug 1 - examine *all* lines

The PHP open tag may not be the first token in a file - think views starting with inline HTML -.

By starting the loop to examine all lines at the `$stackPtr`, inline HTML lines before the first PHP open tag were not being examined.

This fixes that.

### Bug 2 - trigger on echo open tag

Files which do not contain a full PHP open tag `<?php`, but do contain short open echo tags `<?=` - i.e. views - were not being examined at all.

N.B.: this improvement will not work in PHPCS 2.x in combination with PHP 5.3 when the `short_open_tag` ini setting is turned off.
I deemed creating a work-around for that specific situation not worth the effort as PHPCS 2.x as well as PHP 5.3 support will be dropped this summer anyway.

### Bug 3 - examine inline HTML at end of of file

The new line character is normally tokenized as `T_WHITESPACE`, however, not so when at the end of inline HTML, where it is tokenized as part of the `T_INLINE_HTML` token.

Bowing out of the sniff when no next token could be found, prevents the last line of inline HTML at the end of a file from being examined.


:point_right:  The PR includes unit tests covered all three bugs.
  