### PR TITLE
PrefixAllGlobals: bug fix - don't trigger on closure parameter definition

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -492,7 +492,10 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			// Function parameters do not need to be prefixed.
 			if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 				foreach ( $this->tokens[ $stackPtr ]['nested_parenthesis'] as $opener => $closer ) {
-					if ( isset( $this->tokens[ $opener ]['parenthesis_owner'] ) && T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code'] ) {
+					if ( isset( $this->tokens[ $opener ]['parenthesis_owner'] )
+						&& ( T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code']
+							|| T_CLOSURE === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code'] )
+					) {
 						return;
 					}
 				}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -16,3 +16,5 @@ trait T_Example {}
 
 // Issue #1056.
 define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -326,3 +326,5 @@ do_action( 'add_meta_boxes' );
 add_shortcode( 'acronym_hello', function( $attrs, $content = null ) { // OK. Variables are function params.
 	// Do something.
 } );
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -322,3 +322,7 @@ namespace Testing {
 // OK: whitelisted core hooks.
 apply_filters( 'widget_title', $title );
 do_action( 'add_meta_boxes' );
+
+add_shortcode( 'acronym_hello', function( $attrs, $content = null ) { // OK. Variables are function params.
+	// Do something.
+} );


### PR DESCRIPTION
Fixes #1275

This PR also contains a minor fix to the unit test case files (in a separate commit):
* Custom properties should be reset at the end of the unit test file in which they are used.