### PR TITLE
AlternativeFunctions: add warning about using PHP native rand generation

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -92,6 +92,24 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
+			'rand_seeding' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Rand seeding is not necessary when using the wp_rand() function (as you should).',
+				'functions' => array(
+					'srand',
+					'mt_srand',
+				),
+			),
+
+			'rand' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use the far less predictable wp_rand() instead.',
+				'functions' => array(
+					'rand',
+					'mt_rand',
+				),
+			),
+
 		);
 	} // End getGroups().
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -22,3 +22,8 @@ fread(); // Warning.
 fwrite(); // Warning.
 file_put_contents(); // Warning.
 strip_tags( $something ); // Warning.
+rand(); // Warning.
+mt_rand(); // Warning.
+srand(); // Warning.
+mt_srand(); // Warning.
+wp_rand(); // OK.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -57,6 +57,10 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			22 => 1,
 			23 => 1,
 			24 => 1,
+			25 => 1,
+			26 => 1,
+			27 => 1,
+			28 => 1,
 		);
 
 	}


### PR DESCRIPTION
Fixes #1248

I've included the discouraged random seed generation functions in this PR as:
* they are not needed when using `wp_rand()`
* they are discouraged for use in PHP anyway

Refs:
* https://developer.wordpress.org/reference/functions/wp_rand/
* http://php.net/manual/en/function.rand.php
* http://php.net/manual/en/function.mt-rand.php
* http://php.net/manual/en/function.srand.php
* http://php.net/manual/en/function.mt-srand.php