### PR TITLE
PrefixAllGlobals: make the prefix comparison more code style independent

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -750,6 +750,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					array( $prefix )
 				);
 				unset( $this->prefixes[ $key ] );
+				continue;
 			}
 
 			// Lowercase the prefix to allow for direct compare.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -56,6 +56,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Target prefixes after validation.
 	 *
+	 * All prefixes are lowercased for case-insensitive compare.
+	 *
 	 * @since 0.12.0
 	 *
 	 * @var string[]
@@ -667,31 +669,19 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 * @since 0.14.0 Allows for other non-word characters as well as underscores to better support hook names.
+	 * @since 1.0.0  Does not require a word seperator anymore after a prefix.
+	 *               This allows for improved code style independent checking,
+	 *               i.e. allows for camelCase naming and the likes.
 	 *
 	 * @param string $name Name to check for a prefix.
 	 *
-	 * @return bool True when the name is the prefix or starts with the prefix + a separator.
+	 * @return bool True when the name is the prefix or starts with the prefix.
 	 *              False otherwise.
 	 */
 	private function is_prefixed( $name ) {
-
 		foreach ( $this->validated_prefixes as $prefix ) {
-			if ( strtolower( $name ) === $prefix ) {
-				// Ok, prefix *is* the hook/constant name.
+			if ( stripos( $name, $prefix ) === 0 ) {
 				return true;
-
-			} else {
-				$prefix_found = stripos( $name, $prefix . '_' );
-
-				if ( 0 === $prefix_found ) {
-					// Ok, prefix found at start of hook/constant name.
-					return true;
-				}
-
-				if ( preg_match( '`^' . preg_quote( $prefix, '`' ) . '\W`i', $name ) === 1 ) {
-					// Ok, prefix with other non-word character found at start of hook/constant name.
-					return true;
-				}
 			}
 		}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -88,7 +88,7 @@ do_action( "tgmpa_plugin_action_{$acronym_filter_var}" );
  * Bad: prefix not correctly used.
  */
 function abtgmpa_do_something() {} // Bad.
-function tgmpacd_do_something() {} // Bad.
+function tgmpacd_do_something() {} // OK.
 
 
 /*
@@ -326,5 +326,12 @@ do_action( 'add_meta_boxes' );
 add_shortcode( 'acronym_hello', function( $attrs, $content = null ) { // OK. Variables are function params.
 	// Do something.
 } );
+
+// Issue #1239 - word separator check is not the concern of this sniff.
+do_action( 'acronymAction' ); // OK.
+apply_filters( 'acronymFilter', $var ); // OK.
+
+function acronymDoSomething( $param = 'default' ) {} // OK.
+class AcronymExample {} // OK.
 
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -51,7 +51,6 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					39  => 1,
 					40  => 1,
 					90  => 1,
-					91  => 1,
 					// Backfills.
 					225 => ( function_exists( '\mb_strpos' ) ) ? 0 : 1,
 					230 => ( function_exists( '\array_column' ) ) ? 0 : 1,

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -33,7 +33,6 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 			case 'PrefixAllGlobalsUnitTest.inc':
 				return array(
 					1   => 2, // 2 x error for incorrect prefix passed.
-					10  => 1,
 					18  => 1,
 					21  => 1,
 					22  => 1,


### PR DESCRIPTION
This allows for prefixed functions, classes, hooks in camelCase and other naming conventions.

Fixes #1239 

While looking at the prefix check, I noticed a secondary bug which is fixed in a separate commit:

Invalid prefixes which did not pass the second validation check would still be added to the `validated_prefixes` array and the sniff would still run, even though no valid prefixes were available.

