### PR TITLE
PrefixAllGlobals: handle variables created by foreach

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -211,7 +211,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 
 			$item_name  = '';
-			$error_text = 'Unknown syntax used by';
+			$error_text = 'Unknown syntax used';
 			$error_code = 'NonPrefixedSyntaxFound';
 
 			switch ( $this->tokens[ $stackPtr ]['type'] ) {

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -334,4 +334,40 @@ apply_filters( 'acronymFilter', $var ); // OK.
 function acronymDoSomething( $param = 'default' ) {} // OK.
 class AcronymExample {} // OK.
 
+// Issue #1236 - detect non-prefixed variables created in control structure conditions.
+if ( ( $acronym_abc = function_call() ) === true ) {} // OK.
+if ( ( $abc = function_call() ) === true ) {} // Bad.
+
+$acronym_something = array();
+foreach ( $acronym_something as $acronym_some ) {} // OK.
+foreach ( $acronym_something as $something ) {} // Bad.
+
+while ( ( $acronymSomething = function_call() ) === true ) {} // OK.
+while ( ( $something = function_call() ) === true ) {} // Bad.
+
+for ( $acronym_i = 0; $acronym_i < 10; $acronym_i++ ) {} // OK.
+for ( $i = 0; $i < 10; $i++ ) {} // Bad.
+
+switch( true ) {
+	case ($acronym_case = 'abc'): // OK.
+		break;
+	case ($case = 'abc'): // Bad.
+		break;
+	case ($case === 'abc'): // OK, not an assignment.
+		break;
+}
+
+// All OK: Variables created within a non-global scope do not need to be prefixed.
+function acronymFunction() {
+	if ( ( $abc = function_call() ) === true ) {}
+	foreach ( $acronym_something as $something ) {}
+	while ( ( $something = function_call() ) === true ) {}
+	for ( $i = 0; $i < 10; $i++ ) {}
+
+	switch( true ) {
+		case ($case = 'abc'):
+			break;
+	}
+}
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -56,6 +56,11 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					234 => ( defined( '\E_DEPRECATED' ) ) ? 0 : 1,
 					238 => ( class_exists( '\IntlTimeZone' ) ) ? 0 : 1,
 					318 => 1,
+					339 => 1,
+					343 => 1,
+					346 => 1,
+					349 => 1,
+					354 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.1.inc':


### PR DESCRIPTION
Variables created by control structures, such as `$b` in `foreach ( $a as $b )` should also be prefixed when in the global namespace.

Verified that variable assignments in other control structures, `if`, `while`, `for` are correctly detected already and added unit tests to make sure they will continue to be detected correctly.

~~Goto labels are a special kind of control structure and while these are restricted to the same file and context, I have not been able to find any confirmation that `goto` labels have a concept of "local" versus "global".~~

~~Therefore `goto` labels when used will always need to be prefixed too.~~

This PR takes care of this.

Fixes #1236
  