### PR TITLE
Fix version numbers in docblock tags

### DIFF
--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -21,7 +21,7 @@ use WordPress\Sniff;
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `Security` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `Security` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificationSniff {
@@ -30,7 +30,7 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -42,7 +42,7 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.6.0  Removed the add_unique_message() function as it is no longer needed.
  * @since   0.11.0 This class now extends WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
 class DirectDatabaseQuerySniff extends Sniff {
 

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -23,7 +23,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @since   0.8.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `WP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  */
 class PreparedSQLSniff extends Sniff {
 

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -23,7 +23,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *                 comment, replacing the 'tax_query' whitelist comment which is now
  *                 deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
 class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -21,7 +21,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `PHP` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `PHP` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class DontExtractSniff extends \WordPress\Sniffs\PHP\DontExtractSniff {
@@ -30,7 +30,7 @@ class DontExtractSniff extends \WordPress\Sniffs\PHP\DontExtractSniff {
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -42,7 +42,7 @@ class DontExtractSniff extends \WordPress\Sniffs\PHP\DontExtractSniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/PHP/DontExtractSniff.php
+++ b/WordPress/Sniffs/PHP/DontExtractSniff.php
@@ -20,7 +20,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `Functions` category to the `PHP` category.
+ * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */
 class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -26,7 +26,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.12.0 This sniff will now also check for output escaping when using shorthand
  *                 echo tags `<?=`.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `XSS` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `XSS` category to the `Security` category.
  */
 class EscapeOutputSniff extends Sniff {
 

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -20,7 +20,7 @@ use WordPress\Sniff;
  *
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `CSRF` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  */
 class NonceVerificationSniff extends Sniff {
 

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -21,7 +21,7 @@ use WordPress\AbstractFunctionParameterSniff;
  * @since   0.3.0
  * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
 class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -22,7 +22,7 @@ use WordPress\Sniff;
  * @since   0.4.0  This class now extends WordPress_Sniff.
  * @since   0.5.0  Method getArrayIndexKey() has been moved to WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
 class ValidatedSanitizedInputSniff extends Sniff {
 

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -25,7 +25,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 The minimum cron interval tested against is now configurable.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `WP` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `WP` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class CronIntervalSniff extends \WordPress\Sniffs\WP\CronIntervalSniff {
@@ -46,7 +46,7 @@ class CronIntervalSniff extends \WordPress\Sniffs\WP\CronIntervalSniff {
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -58,7 +58,7 @@ class CronIntervalSniff extends \WordPress\Sniffs\WP\CronIntervalSniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -25,7 +25,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.11.0 This class now extends WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `DB` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `DB` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQuerySniff {
@@ -34,7 +34,7 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -46,7 +46,7 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -22,7 +22,7 @@ use WordPress\AbstractFunctionParameterSniff;
  * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `Security` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `Security` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class PluginMenuSlugSniff extends \WordPress\Sniffs\Security\PluginMenuSlugSniff {
@@ -31,7 +31,7 @@ class PluginMenuSlugSniff extends \WordPress\Sniffs\Security\PluginMenuSlugSniff
 	 * Keep track of whether the warning has been thrown to prevent
 	 * the message being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -42,7 +42,7 @@ class PluginMenuSlugSniff extends \WordPress\Sniffs\Security\PluginMenuSlugSniff
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -21,7 +21,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 Added the posts_per_page property.
- * @since   0.15.0 This sniff has been split into two, with the check for high pagination
+ * @since   1.0.0  This sniff has been split into two, with the check for high pagination
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */
@@ -33,7 +33,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	 * Posts per page limit to check against.
 	 *
 	 * @since      0.14.0
-	 * @deprecated 0.15.0 Property is used by the WP version of the sniff.
+	 * @deprecated 1.0.0  Property is used by the WP version of the sniff.
 	 *
 	 * @var int
 	 */
@@ -42,7 +42,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	/**
 	 * Keep track of whether the deprecated property warning has been thrown.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -24,7 +24,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *                 deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `DB` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `DB` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class SlowDBQuerySniff extends \WordPress\Sniffs\DB\SlowDBQuerySniff {
@@ -33,7 +33,7 @@ class SlowDBQuerySniff extends \WordPress\Sniffs\DB\SlowDBQuerySniff {
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -45,7 +45,7 @@ class SlowDBQuerySniff extends \WordPress\Sniffs\DB\SlowDBQuerySniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -23,7 +23,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
  *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `WP` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `WP` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
@@ -32,7 +32,7 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -44,7 +44,7 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -23,7 +23,7 @@ use WordPress\Sniff;
  * @since   0.5.0  Method getArrayIndexKey() has been moved to WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `Security` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `Security` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedSanitizedInputSniff {
@@ -32,7 +32,7 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -44,7 +44,7 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.12.0 The $wp_globals property has been moved to the WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `WP` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `WP` category.
  *                    This file remains for now to prevent BC breaks.
  *
  * @uses \WordPress\Sniff::$custom_test_class_whitelist
@@ -33,7 +33,7 @@ class GlobalVariablesSniff extends \WordPress\Sniffs\WP\GlobalVariablesOverrideS
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -45,7 +45,7 @@ class GlobalVariablesSniff extends \WordPress\Sniffs\WP\GlobalVariablesOverrideS
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *                 - Now deals correctly with WP time constants.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 The minimum cron interval tested against is now configurable.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
 class CronIntervalSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.4.0  This class now extends WordPress_Sniff.
  * @since   0.12.0 The $wp_globals property has been moved to the WordPress_Sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `Variables` category to the `WP`
+ * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  *
  * @uses    \WordPress\Sniff::$custom_test_class_whitelist

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -21,7 +21,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 Added the posts_per_page property.
- * @since   0.15.0 This sniff has been split into two, with the check for high pagination
+ * @since   1.0.0  This sniff has been split into two, with the check for high pagination
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @since   0.8.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `DB` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `DB` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class PreparedSQLSniff extends \WordPress\Sniffs\DB\PreparedSQLSniff {
@@ -33,7 +33,7 @@ class PreparedSQLSniff extends \WordPress\Sniffs\DB\PreparedSQLSniff {
 	 * Keep track of whether the warning has been thrown to prevent
 	 * the message being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -44,7 +44,7 @@ class PreparedSQLSniff extends \WordPress\Sniffs\DB\PreparedSQLSniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Sniffs/WP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/WP/TimezoneChangeSniff.php
@@ -22,7 +22,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
  *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
 class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -27,7 +27,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *                 echo tags `<?=`.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @deprecated 0.15.0 This sniff has been moved to the `Security` category.
+ * @deprecated 1.0.0  This sniff has been moved to the `Security` category.
  *                    This file remains for now to prevent BC breaks.
  */
 class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
@@ -36,7 +36,7 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 	 * Keep track of whether the warnings have been thrown to prevent
 	 * the messages being thrown for every token triggering the sniff.
 	 *
-	 * @since 0.15.0
+	 * @since 1.0.0
 	 *
 	 * @var array
 	 */
@@ -48,7 +48,7 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 	/**
 	 * Don't use.
 	 *
-	 * @deprecated 0.15.0
+	 * @deprecated 1.0.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
 class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.8.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `WP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  */
 class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
 class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Functions/DontExtractUnitTest.php
+++ b/WordPress/Tests/Functions/DontExtractUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `Functions` category to the `PHP` category.
+ * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */
 class DontExtractUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
- * @since   0.15.0     This sniff has been moved from the `XSS` category to the `Security` category.
+ * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
  */
 class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `CSRF` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  */
 class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
 class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
 class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown.
  */
 class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown.
  */
 class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been split into two, with the check for high pagination
+ * @since   1.0.0  This sniff has been split into two, with the check for high pagination
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown
  *                 and that the sniff falls through to the parent correctly.
  */

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown.
  */
 class GlobalVariablesUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
 class CronIntervalUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `Variables` category to the `WP`
+ * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  */
 class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been split into two, with the check for high pagination
+ * @since   1.0.0  This sniff has been split into two, with the check for high pagination
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.8.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 The sniff has been deprecated. This unit test file now
+ * @since   1.0.0  The sniff has been deprecated. This unit test file now
  *                 only tests that the deprecation warnings are correctly thrown.
  */
 class PreparedSQLUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/WP/TimezoneChangeUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.15.0 This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
 class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
- * @since   0.15.0     The sniff has been deprecated. This unit test file now
+ * @since   1.0.0      The sniff has been deprecated. This unit test file now
  *                     only tests that the deprecation warnings are correctly thrown.
  */
 class EscapeOutputUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
As the decision to name the next version `1.0.0` was taken after PR #1242 was pulled & merged, the version numbers used to annotate those changes are not incorrect.

This fixes that.
  