### PR TITLE
I18n: minor fix to the unit test file

### DIFF
--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -159,11 +159,10 @@ __( 'String default text domain.', 'default' ); // Warning, text domain can be o
 __( 'String default text domain.', /* Explicitly set for reason. */ 'default' ); // Warning, text domain can be omitted (not auto-fixable).
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true
-
 // Issue #1266.
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
 $mo->translate( $string ); // OK, not a function, but a method call.
 Something\esc_html_e( $string ); // OK, not the WP function, but namespaced function call.
+
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -159,11 +159,10 @@ __( 'String default text domain.' ); // Warning, text domain can be omitted.
 __( 'String default text domain.', /* Explicitly set for reason. */ 'default' ); // Warning, text domain can be omitted (not auto-fixable).
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true
-
 // Issue #1266.
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
 $mo->translate( $string ); // OK, not a function, but a method call.
 Something\esc_html_e( $string ); // OK, not the WP function, but namespaced function call.
+
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
+// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true


### PR DESCRIPTION
Properties always need to be completely reset at the end of the test file to not influence other test files for the same sniff.