### PR TITLE
AlternativeFunctions: only advise alternative if min WP version supports it

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -47,8 +47,9 @@ abstract class Sniff implements PHPCS_Sniff {
 	/**
 	 * Minimum supported WordPress version.
 	 *
-	 * Currently used by the `WordPress.WP.DeprecatedClasses`,
-	 * `WordPress.WP.DeprecatedFunctions` and the `WordPress.WP.DeprecatedParameter` sniff.
+	 * Currently used by the `WordPress.WP.AlternativeFunctions`,
+	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`
+	 * and the `WordPress.WP.DeprecatedParameter` sniff.
 	 *
 	 * These sniffs will throw an error when usage of a deprecated class/function/parameter
 	 * is detected if the class/function/parameter was deprecated before the minimum
@@ -75,6 +76,9 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Ruleset: `<config name="minimum_supported_wp_version" value="4.5"/>`
 	 *
 	 * @since 0.14.0 Previously the individual sniffs each contained this property.
+	 *
+	 * @internal When the value of this property is changed, it will also need
+	 *           to be changed in the `WP/AlternativeFunctionsUnitTest.inc` file.
 	 *
 	 * @var string WordPress version.
 	 */

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -27,3 +27,7 @@ mt_rand(); // Warning.
 srand(); // Warning.
 mt_srand(); // Warning.
 wp_rand(); // OK.
+
+// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
+parse_url( 'http://example.com/' ); // OK.
+// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6


### PR DESCRIPTION
Only show suggestions for WP functions which are recommended as alternative for native PHP functions, when the `minimum_supported_version` allows for it.

Includes unit test.

Note: the unit test file now contains a property setting. This property needs to be reset after use. The reset value has to be in-line with the default value as set in the `Sniff` class.
A note to that end has been added to the property documentation in the `Sniff` class.

- [ ] Once merged, update the customizable properties wiki page.