### PR TITLE
Travis: speed up build times by disabling Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
     - php: hhvm
 
 before_install:
+    # Speed up build time by disabling Xdebug.
+    # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
+    - if [[ $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
     - export XMLLINT_INDENT="	"
     - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit


### PR DESCRIPTION
As suggested by @johnbillion in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/

This looks like it makes the total builds approximately 30% faster.