### PR TITLE
Travis/Build: validate the composer.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,3 +101,6 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml"); fi
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-VIP/ruleset.xml <(xmllint --format "./WordPress-VIP/ruleset.xml"); fi
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample"); fi
+    # Validate the composer.json file.
+    # @link https://getcomposer.org/doc/03-cli.md#validate
+    - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all --strict; fi


### PR DESCRIPTION
Validate the composer.json file on each build.
Ref: https://getcomposer.org/doc/03-cli.md#validate

Notes:
* This check has not been restricted to a specific PHP version as there may be different versions of Composer being run on different Travis PHP images, so validating the file once against each PHP/Composer combi should make sure the file is properly validated.