### PR TITLE
DeprecatedParameters: fix expected value for `wp_upload_bits()`

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -253,7 +253,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 		),
 		'wp_upload_bits' => array(
 			2 => array(
-				'value'   => '',
+				'value'   => null,
 				'version' => '2.0.0',
 			),
 		),


### PR DESCRIPTION
According to the documentation, the value you are expected to pass for the deprecated parameter of the `wp_upload_bits()` function is `null`.

> $deprecated
>    (null|string) (Required) Never used. Set to null.

Ref: https://developer.wordpress.org/reference/functions/wp_upload_bits/