### PR TITLE
Improve recognition of test classes

### DIFF
--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -62,6 +62,18 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'test-sample-phpunit6.inc'                   => 0,
 		'test-sample-wpunit.inc'                     => 0,
 		'test-sample-custom-unit.inc'                => 0,
+		'test-sample-namespaced-declaration.1.inc'   => 0,
+		'test-sample-namespaced-declaration.2.inc'   => 1, // Namespaced vs non-namespaced.
+		'test-sample-namespaced-declaration.3.inc'   => 1, // Wrong namespace.
+		'test-sample-namespaced-declaration.4.inc'   => 1, // Non-namespaced vs namespaced.
+		'test-sample-global-namespace-extends.1.inc' => 0, // Prefixed user input.
+		'test-sample-global-namespace-extends.2.inc' => 1, // Non-namespaced vs namespaced.
+		'test-sample-extends-with-use.inc'           => 0,
+		'test-sample-namespaced-extends.1.inc'       => 0,
+		'test-sample-namespaced-extends.2.inc'       => 1, // Wrong namespace.
+		'test-sample-namespaced-extends.3.inc'       => 1, // Namespaced vs non-namespaced.
+		'test-sample-namespaced-extends.4.inc'       => 1, // Non-namespaced vs namespaced.
+		'test-sample-namespaced-extends.5.inc'       => 0,
 
 		/*
 		 * In /FileNameUnitTests/ThemeExceptions.

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<?php
+
+namespace Some\Name;
+
+class TestCase extends \TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+namespace Some\Name;
+
+class TestCase extends \TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+namespace Some\Name;
+
+class TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<?php
+
+namespace Some\Name;
+
+class TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+namespace Some\Other;
+
+class TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
@@ -1,0 +1,5 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+class TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+namespace Some\Name;
+
+class TestCase extends TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+namespace Some\OtherName;
+
+class TestCase extends TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
@@ -1,0 +1,7 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<?php
+
+namespace Some\Name;
+
+class TestCase extends TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
@@ -1,0 +1,5 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+class TestCase extends TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
@@ -1,0 +1,5 @@
+@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<?php
+
+class TestCase extends \Some\Name\TestSample {}
+/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */


### PR DESCRIPTION
Based on a non-GH report by @GaryJones .

This commit enhances the `Sniff::is_test_class()` method to handle namespaced test classes better.

* Will now correctly recognize whether a class is in a namespace and adjust the response based on that.
    Previously, namespaces classes where the classname was one of the whitelisted global classes would pass, even though they were not the same class.
    The same happened with extended classes.
* The other side of this was that a namespaced custom test class where the name was split between the namespace declaration and the extended class declaration was not correctly recognized as the whitelisted test class. Now it will be.
* Improves handling of FQN used for the extended class name, i.e. prefixed with a `\` to indicate global namespace.
* Adds tolerance for custom unit test classes being passed through a custom ruleset with a `\` prefix.

Included unit tests for all the above mentioned cases.
While the unit tests are all of the `WordPress.Files.FileName` sniff variety, the changes will benefit all sniffs which check for test classes, i.e. as the `PrefixAllGlobals` and the `GlobalVariablesOverride` sniffs.

**N.B.:** `use` statements are explicitly **not** examined for importing of the whitelisted test classes as with the variety of syntaxes, this would get very complicated very quickly.
After all, users can add an `<exclude-pattern>` for a particular sniff to their custom ruleset to selectively exclude the test directory.