### PR TITLE
Fix `posts_per_page` sniff

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -164,6 +164,15 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+
+				// Step back to the actual value.
+				$anyValidValue = array( T_DOUBLE_QUOTED_STRING, T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_TRUE, T_FALSE, T_CONST );
+				$valTrimmedEnd   = $this->phpcsFile->findPrevious( $anyValidValue, $valEnd - 1, $valStart, false, null, false );
+
+				if ( false !== $valTrimmedEnd ) {
+					$valEnd = $valTrimmedEnd + 1;
+				}
+
 				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
 				$val            = $this->strip_quotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
@@ -22,3 +22,10 @@ $query_args['my_posts_per_page'] = -1; // OK.
 // @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 50
  $query_args['posts_per_page'] = 50; // OK.
 // @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 100
+
+$args = array( 'posts_per_page' => -1 ); // Bad
+$args = array( 'posts_per_page' => '-1' ); // Bad
+$args = array(
+	'foobar'         => 'doobar',
+	'posts_per_page' => -1 // With a comment // Bad
+);

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -37,6 +37,9 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			13 => 1,
 			16 => 1,
 			17 => 1,
+			26 => 1,
+			27 => 1,
+			30 => 1,
 		);
 
 	}


### PR DESCRIPTION
This fixes https://github.com/Automattic/VIP-Coding-Standards/issues/29

phpcs is looking for `T_COMMA, T_SEMICOLON` for `$valEnd` - things like comments, spaces and closing parentheses are also included when there is no `T_COMMA`. 

For example, this is not reported:
`
$args = array( 'posts_per_page' => -1 ); // Bad
`

At first I tried to just append closing parentheses and closing square brackets to the tokens to look for, but that didn't work out because in some situations, with a missing comma - it would still include comments and spaces.

This approach is going to find a `$valEnd` (either semicolon or a comma) then try to step back until it finds a valid value (but not further back than `$valStart`). If a string/number/bool/constant is found it'll overwrite existing `$valEnd` with the backtracked position.