### PR TITLE
PrefixAllGlobals: only recognize PHP native classes, don't try and autoload

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -249,14 +249,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 					switch ( $this->tokens[ $stackPtr ]['type'] ) {
 						case 'T_CLASS':
-							if ( class_exists( '\\' . $item_name ) ) {
+							if ( class_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native class.
 								return;
 							}
 							break;
 
 						case 'T_INTERFACE':
-							if ( interface_exists( '\\' . $item_name ) ) {
+							if ( interface_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native interface.
 								return;
 							}
@@ -266,7 +266,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							break;
 
 						case 'T_TRAIT':
-							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name ) ) {
+							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native trait.
 								return;
 							}


### PR DESCRIPTION
If `class_exists()` and the like are called without the second `$autoload` parameter set to `false`, it could trigger a (Composer) autoload file and in certain circumstances trigger a fatal `class not found` error.
If the class however is found and the file also contains side-effects, such as a typical block found at the top of a WP file (see below), it can also trigger a PHPCS process error with a `headers already send` notice.

As the check is only intended to detect backfills for PHP native functionality, adding the `$autoload` parameter should fix this.

```php
if ( ! function_exists( 'add_filter' ) ) {
	header( 'Status: 403 Forbidden' );
	header( 'HTTP/1.1 403 Forbidden' );
	exit();
}
```

:point_right: As this is a bug which can break PHPCS runs completely, I would like to propose to back-port this fix to the `0.14.x` branch and to release a `0.14.1` version.