### PR TITLE
PHP.StrictInArray: don't throw an error for no parameters found

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -101,19 +101,4 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
-	/**
-	 * Process the function if no parameters were found.
-	 *
-	 * @since 0.11.0
-	 *
-	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
-	 *
-	 * @return void
-	 */
-	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
-		$this->phpcsFile->addError( 'Missing arguments to %s.', $stackPtr, 'MissingArguments', array( $matched_content ) );
-	}
-
 } // End class.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
@@ -37,3 +37,4 @@ array_keys( $testing, 'my_key', false ); // Warning.
 array_keys( array( '1', 1, true ), 'my_key', false ); // Warning
 in_array( 1, array( '1', 1 ), TRUE ); // Ok.
 
+use function in_array; // OK.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -27,9 +27,7 @@ class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array(
-			17 => 1,
-		);
+		return array();
 	}
 
 	/**

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -314,7 +314,7 @@ comments_popup_script();
 get_comments_popup_template();
 get_currentuserinfo();
 is_comments_popup();
-popuplinks();
+use function popuplinks as something_else; // Related to issue #1306.
 
 /*
  * Warning.


### PR DESCRIPTION
Adds the provided code sample as a unit test.

Also adjusts a unit test in the deprecated function test case file, to make sure when a similar syntax is used with a deprecated function, that an error is correctly thrown.

Fixes 1306