### PR TITLE
PrefixAllGlobals: allow for defining non-prefixed core globals

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -106,6 +106,58 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
+	 * A list of core constants that are allowed to be defined by plugins and themes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * Source: {@link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/default-constants.php#L0}
+	 * The constants are listed in the order they are found in the source file
+	 * to make life easier for future updates.
+	 * Only overrulable constants are listed, i.e. those defined within core within
+	 * a `if ( ! defined() ) {}` wrapper.
+	 *
+	 * @var array
+	 */
+	protected $whitelisted_core_constants = array(
+		'WP_MEMORY_LIMIT'      => true,
+		'WP_MAX_MEMORY_LIMIT'  => true,
+		'WP_CONTENT_DIR'       => true,
+		'WP_DEBUG'             => true,
+		'WP_DEBUG_DISPLAY'     => true,
+		'WP_DEBUG_LOG'         => true,
+		'WP_CACHE'             => true,
+		'SCRIPT_DEBUG'         => true,
+		'MEDIA_TRASH'          => true,
+		'SHORTINIT'            => true,
+		'WP_CONTENT_URL'       => true,
+		'WP_PLUGIN_DIR'        => true,
+		'WP_PLUGIN_URL'        => true,
+		'PLUGINDIR'            => true,
+		'WPMU_PLUGIN_DIR'      => true,
+		'WPMU_PLUGIN_URL'      => true,
+		'MUPLUGINDIR'          => true,
+		'COOKIEHASH'           => true,
+		'USER_COOKIE'          => true,
+		'PASS_COOKIE'          => true,
+		'AUTH_COOKIE'          => true,
+		'SECURE_AUTH_COOKIE'   => true,
+		'LOGGED_IN_COOKIE'     => true,
+		'TEST_COOKIE'          => true,
+		'COOKIEPATH'           => true,
+		'SITECOOKIEPATH'       => true,
+		'ADMIN_COOKIE_PATH'    => true,
+		'PLUGINS_COOKIE_PATH'  => true,
+		'COOKIE_DOMAIN'        => true,
+		'FORCE_SSL_ADMIN'      => true,
+		'FORCE_SSL_LOGIN'      => true,
+		'AUTOSAVE_INTERVAL'    => true,
+		'EMPTY_TRASH_DAYS'     => true,
+		'WP_POST_REVISIONS'    => true,
+		'WP_CRON_LOCK_TIMEOUT' => true,
+		'WP_DEFAULT_THEME'     => true,
+	);
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @since 0.12.0
@@ -297,6 +349,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					$item_name = $this->tokens[ $constant_name_ptr ]['content'];
 					if ( defined( '\\' . $item_name ) ) {
 						// Backfill for PHP native constant.
+						return;
+					}
+
+					if ( isset( $this->whitelisted_core_constants[ $item_name ] ) ) {
+						// Defining a WP Core constant intended for overruling.
 						return;
 					}
 
@@ -595,9 +652,10 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$is_error    = true;
 		$raw_content = $this->strip_quotes( $parameters[1]['raw'] );
 
-		if (
-			'define' !== $matched_content
-			&& isset( $this->whitelisted_core_hooks[ $raw_content ] )
+		if ( ( 'define' !== $matched_content
+			&& isset( $this->whitelisted_core_hooks[ $raw_content ] ) )
+			|| ( 'define' === $matched_content
+			&& isset( $this->whitelisted_core_constants[ $raw_content ] ) )
 		) {
 			return;
 		}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.inc
@@ -370,4 +370,8 @@ function acronymFunction() {
 	}
 }
 
+// Issue #1311 - allow for overrulable WP Core constants.
+define( 'FORCE_SSL_ADMIN', true );
+const SCRIPT_DEBUG = $develop_src;
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -67,10 +67,8 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 				// Namespaced - all OK, fall through to the default case.
 			default:
 				return array();
-
-		} // End switch().
-
-	} // end getErrorList()
+		}
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -121,9 +119,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
-		} // End switch().
-
+		}
 	}
 
 } // End class.


### PR DESCRIPTION
A large number of the global constants used in WP core are overrulable.
These constants, when they are being defined by plugins/themes, should, of course, not be prefixed.

This adds a list of the overrulable WP core constants to the sniff and prevents the sniff from throwing notices if any of those are being defined/declared.

Includes unit tests.

Fixes #1311

Commit includes minor tidying up of the associated UnitTest file.