### PR TITLE
AbstractFunctionRestrictions: prevent some typical misidentifications of function calls

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -218,6 +218,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 				$skipped = array(
 					T_FUNCTION        => T_FUNCTION,
 					T_CLASS           => T_CLASS,
+					T_AS              => T_AS, // Use declaration alias.
 					T_DOUBLE_COLON    => T_DOUBLE_COLON,
 					T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
 				);

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -217,6 +217,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 				// Skip sniffing if calling a same-named method, or on function definitions.
 				$skipped = array(
 					T_FUNCTION        => T_FUNCTION,
+					T_CLASS           => T_CLASS,
 					T_DOUBLE_COLON    => T_DOUBLE_COLON,
 					T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
 				);

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.inc
@@ -38,3 +38,7 @@ $process = proc_open( 'php', $descriptorspec, $pipes, $cwd, $env );
 $output = shell_exec( 'ls -lart' );
 $last_line = system( 'ls', $retval );
 $handle = popen( '/bin/ls', 'r' );
+
+// Issue #898.
+class System {}
+class Serialize {}

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.inc
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.inc
@@ -35,3 +35,9 @@ chown();
 chmod();
 lchgrp();
 lchown();
+
+// Issue #956.
+use Fieldmanager_Link as Link;
+
+namespace Fieldmanager\Link\Something;
+namespace Fieldmanager\Link;


### PR DESCRIPTION
Prevent class declarations being confused with function calls

Includes unit test.

Fixes #898

N.B.: I do still intend to pull a much more comprehensive class to correctly analyze `T_STRING` tokens, but that's still a work in progress. In the mean time, this is a simple fix to make.

----

**[Edit]**: I've added a second commit along the same lines for preventing use statement aliases being confused with function call names.

Fixes #956