### PR TITLE
WhiteSpace/ControlStructureSpacing: prevent fixer removing return type declarations

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -360,7 +360,10 @@ class ControlStructureSpacingSniff extends Sniff {
 				}
 			}
 
-			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
+			// Ignore this for function declarations. Handled by the OpeningFunctionBraceKrnighanRitchie sniff.
+			if ( T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
+				&& T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
+				&& isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
 				&& ( isset( $scopeOpener )
 				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
 			) {

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -268,3 +268,9 @@ if ( $foo ) {
 
 
 }
+
+// Issue 1202.
+function hi(): array
+{
+    return [];
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -257,3 +257,9 @@ if ( $foo ) {
 		// Something
 	} // End try/catch <- Bad: "blank line after".
 }
+
+// Issue 1202.
+function hi(): array
+{
+    return [];
+}


### PR DESCRIPTION
While this will be solved better in the future by a dedicated sniff to check function declarations (see #1101) , in the mean time, return type declarations should not be removed by the fixer in this sniff.

And as the placement of the opening brace for function declarations is also checked for by the `Generic.Functions.OpeningFunctionBraceKernighanRitchie` sniff, let's ignore this error for function declarations in this sniff and leave the fixing up to the upstream sniff.

Fixes #1202