### PR TITLE
ArrayIndentation: fix bug when dealing with multi-line string

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -411,13 +411,26 @@ class ArrayIndentationSniff extends Sniff {
 			return true;
 		}
 
-		// If it's a subsequent line of a multi-line sting, it will not start with a quote character.
-		if ( ( T_CONSTANT_ENCAPSED_STRING === $token_code
-			|| T_DOUBLE_QUOTED_STRING === $token_code )
-			&& "'" !== $this->tokens[ $ptr ]['content'][0]
-			&& '"' !== $this->tokens[ $ptr ]['content'][0]
+		/*
+		 * If it's a subsequent line of a multi-line sting, it will not start with a quote
+		 * character, nor just *be* a quote character.
+		 */
+		if ( T_CONSTANT_ENCAPSED_STRING === $token_code
+			|| T_DOUBLE_QUOTED_STRING === $token_code
 		) {
-			return true;
+			// Deal with closing quote of a multi-line string being on its own line.
+			if ( "'" === $this->tokens[ $ptr ]['content']
+				|| '"' === $this->tokens[ $ptr ]['content']
+			) {
+				return true;
+			}
+
+			// Deal with subsequent lines of a multi-line string where the token is broken up per line.
+			if ( "'" !== $this->tokens[ $ptr ]['content'][0]
+				&& '"' !== $this->tokens[ $ptr ]['content'][0]
+			) {
+				return true;
+			}
 		}
 
 		return false;

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -399,3 +399,14 @@ b(
 	2 => false,
 	)
 );
+
+			$a = array(
+				'post_type'    => 'post',
+				'post_content' => '
+Page 1/5
+<!--nextpage-->
+Page 2/3
+<!--nextpage-->
+Page 3/3
+',
+			);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -399,3 +399,14 @@ b(
 		2 => false,
 	)
 );
+
+			$a = array(
+				'post_type'    => 'post',
+				'post_content' => '
+Page 1/5
+<!--nextpage-->
+Page 2/3
+<!--nextpage-->
+Page 3/3
+',
+			);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -400,4 +400,15 @@ b(
     ]
 );
 
+            $a = array(
+                'post_type'    => 'post',
+                'post_content' => '
+Page 1/5
+<!--nextpage-->
+Page 2/3
+<!--nextpage-->
+Page 3/3
+',
+            );
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -400,4 +400,15 @@ b(
     ]
 );
 
+            $a = array(
+                'post_type'    => 'post',
+                'post_content' => '
+Page 1/5
+<!--nextpage-->
+Page 2/3
+<!--nextpage-->
+Page 3/3
+',
+            );
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true


### PR DESCRIPTION
If a multi-line string is broken up across several lines, the indentation of subsequent lines should not be fixed, nor should any warnings/errors be thrown.

This worked perfectly well as long as the closing quote of the multi-line string was not on a line of its own.

Now the sniff will deal correctly with that edge-case as well.

Includes unit test.