### PR TITLE
Minor performance optimization

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1467,9 +1467,10 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-		$open_parenthesis = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-		reset( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
+
+		end( $nested_parenthesis );
+		$open_parenthesis = key( $nested_parenthesis );
 
 		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( T_ISSET, T_EMPTY ), true );
 	}
@@ -1557,9 +1558,10 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Get the function that it's in.
-		$function_closer = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-		$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
-		$function        = $this->tokens[ ( $function_opener - 1 ) ];
+		$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
+		$function_closer    = end( $nested_parenthesis );
+		$function_opener    = key( $nested_parenthesis );
+		$function           = $this->tokens[ ( $function_opener - 1 ) ];
 
 		// If it is just being unset, the value isn't used at all, so it's safe.
 		if ( T_UNSET === $function['code'] ) {
@@ -1580,14 +1582,14 @@ abstract class Sniff implements PHPCS_Sniff {
 		if ( 'wp_unslash' === $functionName ) {
 
 			$is_unslashed    = true;
-			$function_closer = prev( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+			$function_closer = prev( $nested_parenthesis );
 
 			// If there is no other function being used, this value is unsanitized.
 			if ( ! $function_closer ) {
 				return false;
 			}
 
-			$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+			$function_opener = key( $nested_parenthesis );
 			$functionName    = $this->tokens[ ( $function_opener - 1 ) ]['content'];
 
 		} else {
@@ -1817,7 +1819,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// We first check if this is a switch statement (switch ( $var )).
 		if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			$close_parenthesis = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+			$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
+			$close_parenthesis  = end( $nested_parenthesis );
 
 			if (
 				isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] )

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -789,7 +789,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return false;
 		}
 
-		$close_parenthesis = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
+		$close_parenthesis  = end( $nested_parenthesis );
 		if ( ! isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
 			return false;
 		}

--- a/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -36,7 +36,8 @@ class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
 
 		// Don't examine semi-colons for empty conditions in `for()` control structures.
 		if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			$close_parenthesis = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
+			$nested_parenthesis = $tokens[ $stackPtr ]['nested_parenthesis'];
+			$close_parenthesis  = end( $nested_parenthesis );
 
 			if ( isset( $tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
 				$owner = $tokens[ $close_parenthesis ]['parenthesis_owner'];


### PR DESCRIPTION
Turns out that using `end()` on a nested array in a (very) large array such as the `$tokens` array can be with large files, is significantly slower than copying the nested array to a local variable and using `end()` on that.

See: https://github.com/squizlabs/PHP_CodeSniffer/commit/6d15547ed874d0061c83e380496162e2ec2020c8#r28189947

@JDGrimes Do you agree ?