### PR TITLE
EscapeOutput: fix various bugs

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -262,7 +262,7 @@ class EscapeOutputSniff extends Sniff {
 			return;
 		}
 
-		if ( isset( $end_of_statement, $this->unsafePrintingFunctions[ $function ] ) ) {
+		if ( isset( $this->unsafePrintingFunctions[ $function ] ) ) {
 			$error = $this->phpcsFile->addError(
 				"All output should be run through an escaping function (like %s), found '%s'.",
 				$stackPtr,
@@ -272,7 +272,7 @@ class EscapeOutputSniff extends Sniff {
 
 			// If the error was reported, don't bother checking the function's arguments.
 			if ( $error ) {
-				return $end_of_statement;
+				return isset( $end_of_statement ) ? $end_of_statement : null;
 			}
 		}
 

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -355,6 +355,12 @@ class EscapeOutputSniff extends Sniff {
 				continue;
 			}
 
+			if ( T_OPEN_SHORT_ARRAY === $this->tokens[ $i ]['code']
+				|| T_CLOSE_SHORT_ARRAY === $this->tokens[ $i ]['code']
+			) {
+				continue;
+			}
+
 			if ( in_array( $this->tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ), true ) ) {
 				continue;
 			}

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -233,7 +233,9 @@ class EscapeOutputSniff extends Sniff {
 
 			// These functions only need to have the first argument escaped.
 			if ( in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
-				$end_of_statement = $this->phpcsFile->findEndOfStatement( $open_paren + 1 );
+				$first_param      = $this->get_function_call_parameter( $stackPtr, 1 );
+				$end_of_statement = ( $first_param['end'] + 1 );
+				unset( $first_param );
 			}
 		} elseif ( T_INLINE_HTML === $this->tokens[ $stackPtr ]['code'] ) {
 			// Skip if no PHP short_open_tag is found in the string.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -262,3 +262,6 @@ echo PHP_VERSION_ID, PHP_VERSION, PHP_EOL, PHP_EXTRA_VERSION; // OK.
 
 trigger_error( 'DEBUG INFO - ' . __METHOD__ . '::internal_domains: domain = ' . $domain ); // Bad.
 trigger_error( $domain ); // Bad.
+
+vprintf( 'Hello %s', [ $foo ] ); // Bad.
+vprintf( 'Hello %s', [ esc_html( $foo ) ] ); // Ok.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -259,3 +259,6 @@ echo esc_html_x( $some_nasty_var, 'context' ); // Ok.
 <?php
 
 echo PHP_VERSION_ID, PHP_VERSION, PHP_EOL, PHP_EXTRA_VERSION; // OK.
+
+trigger_error( 'DEBUG INFO - ' . __METHOD__ . '::internal_domains: domain = ' . $domain ); // Bad.
+trigger_error( $domain ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -75,6 +75,8 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			226 => 1,
 			252 => 1,
 			253 => 1,
+			263 => 1,
+			264 => 1,
 		);
 
 	} // end getErrorList()

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -77,6 +77,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			253 => 1,
 			263 => 1,
 			264 => 1,
+			266 => 1,
 		);
 
 	} // end getErrorList()


### PR DESCRIPTION
### EscapeOutput: report correctly on first param of `trigger_error()`

The PHPCS `findEndOfStatement()` method returns the end token òr the last non-whitespace token if the end token is a "bracket", like a closing parenthesis.

In effect, this meant that the last token in a `trigger_error()` function call was never examined and that the sniff would underreport.

Fixed now. Includes unit tests.

### EscapeOutput: correctly report on unsafe printing functions

If `$end_of_statement` had not been determined, the sniff would report on `OutputNotEscaped`, not on `UnsafePrintingFunction`s.
To report on `UnsafePrintingFunction`s, the code in the condition does not actually need the `$end_of_statement`, so this minor logic change allows for the sniff to report the correct error.

### EscapeOutput: allow for short arrays

The sniff would up to now not handle short arrays correctly and would report on the open/close brackets, not on the content of the array.

Includes unit tests.

Related #764