### PR TITLE
Don't mark `get_template_part()` as safe for output

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -229,7 +229,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		'get_search_form'           => true,
 		'get_search_query'          => true,
 		'get_sidebar'               => true,
-		'get_template_part'         => true,
 		'get_the_author_link'       => true,
 		'get_the_author'            => true,
 		'get_the_date'              => true,


### PR DESCRIPTION
Fixed #1340