### PR TITLE
Add `readonly()` to the list of auto escaped functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -252,6 +252,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'previous_image_link'       => true,
 		'previous_post_link'        => true,
 		'previous_posts_link'       => true,
+		'readonly'                  => true,
 		'selected'                  => true,
 		'single_cat_title'          => true,
 		'single_month_title'        => true,


### PR DESCRIPTION
Fixes #1341