### PR TITLE
Composer: add note about why the DealerDirect plugin is suggested

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"suggest" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"minimum-stability" : "RC",
 	"support"    : {


### PR DESCRIPTION
Just suggesting a package does not explain to a user why it would be interesting for them to install it and I've already had question about the suggestion.

The `suggest` entry in the `composer.json` file has a value which is not actually intended for version constraints, but to add a hint to the user about why they should install the package.

Up to now, the value in the WPCS `composer.json` was used for a version constraint. While this is still a good idea to mention in this case as the plugin needs a certain version to be compatible with the same PHP versions WPCS supports, adding the hint on why the package is suggested should help users even more.

Ref: https://getcomposer.org/doc/04-schema.md#suggest