### PR TITLE
Fix deprecated sniff warnings

### DIFF
--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -124,4 +124,101 @@
 	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_safe_redirect-instead-of-wp_redirect -->
 	<rule ref="WordPress.Security.SafeRedirect"/>
 
+	<!--
+	#############################################################################
+	Account for deprecated sniffs.
+	These directives can be removed when the deprecated sniffs are removed.
+	#############################################################################
+	-->
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.DirectDatabaseQuery.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.DirectDatabaseQuery.SchemaChange">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.DirectDatabaseQuery.DirectQuery">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.DirectDatabaseQuery.NoCaching">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.SlowDBQuery.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.SlowDBQuery.slow_db_query_tax_query">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.SlowDBQuery.slow_db_query_meta_query">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.SlowDBQuery.slow_db_query_meta_key">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.SlowDBQuery.slow_db_query_meta_value">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.SlowDBQuery.DeprecatedWhitelistFlagFound">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.PluginMenuSlug.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.PluginMenuSlug.Using__FILE__">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.InputNotValidated">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.InputNotValidatedNotSanitized">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.CronInterval.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.CronInterval.CronSchedulesInterval">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.VIP.CronInterval.ChangeDetected">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<rule ref="WordPress.VIP.TimezoneChange.DeprecatedSniff">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Prevent duplicate messages from deprecated sniff. -->
+	<rule ref="WordPress.VIP.TimezoneChange.timezone_change_date_default_timezone_set">
+		<severity>0</severity>
+	</rule>
+
 </ruleset>

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -50,13 +50,11 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.CSRF.NonceVerification" sniff has been renamed to "WordPress.Security.NonceVerification". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ( $this->customNonceVerificationFunctions !== $this->addedCustomFunctions['nonce']
@@ -64,13 +62,11 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.CSRF.NonceVerification" sniff has been renamed to "WordPress.Security.NonceVerification". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -57,10 +57,10 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 			);
 		}
 
-		if ( ( $this->customNonceVerificationFunctions !== $this->addedCustomFunctions['nonce']
-			|| $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize']
-			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] )
-			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
+		if ( false === $this->thrown['FoundPropertyForDeprecatedSniff']
+			&& ( ( array() !== $this->customNonceVerificationFunctions && $this->customNonceVerificationFunctions !== $this->addedCustomFunctions['nonce'] )
+			|| ( array() !== $this->customSanitizingFunctions && $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize'] )
+			|| ( array() !== $this->customUnslashingSanitizingFunctions && $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] ) )
 		) {
 			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.CSRF.NonceVerification" sniff has been renamed to "WordPress.Security.NonceVerification". Please update your custom ruleset.',

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -65,9 +65,9 @@ class DirectDatabaseQuerySniff extends Sniff {
 	 * @var array
 	 */
 	protected $addedCustomFunctions = array(
-		'cacheget'    => null,
-		'cacheset'    => null,
-		'cachedelete' => null,
+		'cacheget'    => array(),
+		'cacheset'    => array(),
+		'cachedelete' => array(),
 	);
 
 	/**

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -50,25 +50,21 @@ class DontExtractSniff extends \WordPress\Sniffs\PHP\DontExtractSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.Functions.DontExtract" sniff has been renamed to "WordPress.PHP.DontExtract". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ! empty( $this->exclude )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.Functions.DontExtract" sniff has been renamed to "WordPress.PHP.DontExtract". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -93,10 +93,10 @@ class EscapeOutputSniff extends Sniff {
 	 * @var array
 	 */
 	protected $addedCustomFunctions = array(
-		'escape'     => null,
-		'autoescape' => null,
-		'sanitize'   => null,
-		'print'      => null,
+		'escape'     => array(),
+		'autoescape' => array(),
+		'sanitize'   => array(),
+		'print'      => array(),
 	);
 
 	/**

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -105,9 +105,9 @@ class NonceVerificationSniff extends Sniff {
 	 * @var array
 	 */
 	protected $addedCustomFunctions = array(
-		'nonce'           => null,
-		'sanitize'        => null,
-		'unslashsanitize' => null,
+		'nonce'           => array(),
+		'sanitize'        => array(),
+		'unslashsanitize' => array(),
 	);
 
 	/**

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -63,8 +63,8 @@ class ValidatedSanitizedInputSniff extends Sniff {
 	 * @var array
 	 */
 	protected $addedCustomFunctions = array(
-		'sanitize'        => null,
-		'unslashsanitize' => null,
+		'sanitize'        => array(),
+		'unslashsanitize' => array(),
 	);
 
 	/**

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -66,25 +66,21 @@ class CronIntervalSniff extends \WordPress\Sniffs\WP\CronIntervalSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.CronInterval" sniff has been renamed to "WordPress.WP.CronInterval". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( 900 !== (int) $this->min_interval
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.CronInterval" sniff has been renamed to "WordPress.WP.CronInterval". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -54,13 +54,11 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.DirectDatabaseQuery" sniff has been renamed to "WordPress.DB.DirectDatabaseQuery". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ( $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget']
@@ -68,13 +66,11 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 			|| $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.DirectDatabaseQuery" sniff has been renamed to "WordPress.DB.DirectDatabaseQuery". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -61,10 +61,10 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 			);
 		}
 
-		if ( ( $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget']
-			|| $this->customCacheSetFunctions !== $this->addedCustomFunctions['cacheset']
-			|| $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] )
-			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
+		if ( false === $this->thrown['FoundPropertyForDeprecatedSniff']
+			&& ( ( array() !== $this->customCacheGetFunctions && $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget'] )
+			|| ( array() !== $this->customCacheSetFunctions && $this->customCacheSetFunctions !== $this->addedCustomFunctions['cacheset'] )
+			|| ( array() !== $this->customCacheDeleteFunctions && $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] ) )
 		) {
 			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.DirectDatabaseQuery" sniff has been renamed to "WordPress.DB.DirectDatabaseQuery". Please update your custom ruleset.',

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -53,25 +53,21 @@ class SlowDBQuerySniff extends \WordPress\Sniffs\DB\SlowDBQuerySniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.SlowDBQuery" sniff has been renamed to "WordPress.DB.SlowDBQuery". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ! empty( $this->exclude )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.SlowDBQuery" sniff has been renamed to "WordPress.DB.SlowDBQuery". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -52,25 +52,21 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.WP.TimezoneChange". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ! empty( $this->exclude )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.TimezoneChange" sniff has been renamed to "WordPress.WP.TimezoneChange". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -59,10 +59,10 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 			);
 		}
 
-		if ( ( $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize']
-			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize']
+		if ( false === $this->thrown['FoundPropertyForDeprecatedSniff']
+			&& ( ( array() !== $this->customSanitizingFunctions && $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize'] )
+			|| ( array() !== $this->customUnslashingSanitizingFunctions && $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] )
 			|| false !== $this->check_validation_in_scope_only )
-			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
 			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.ValidatedSanitizedInput" sniff has been renamed to "WordPress.Security.ValidatedSanitizedInput". Please update your custom ruleset.',

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -52,13 +52,11 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.ValidatedSanitizedInput" sniff has been renamed to "WordPress.Security.ValidatedSanitizedInput". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ( $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize']
@@ -66,13 +64,11 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 			|| false !== $this->check_validation_in_scope_only )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.VIP.ValidatedSanitizedInput" sniff has been renamed to "WordPress.Security.ValidatedSanitizedInput". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -53,25 +53,21 @@ class GlobalVariablesSniff extends \WordPress\Sniffs\WP\GlobalVariablesOverrideS
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.Variables.GlobalVariables" sniff has been renamed to "WordPress.WP.GlobalVariablesOverride". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ! empty( $this->custom_test_class_whitelist )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.Variables.GlobalVariables" sniff has been renamed to "WordPress.WP.GlobalVariablesOverride". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -56,13 +56,11 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( false === $this->thrown['DeprecatedSniff'] ) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['DeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.Security.EscapeOutput". Please update your custom ruleset.',
 				0,
 				'DeprecatedSniff'
 			);
-
-			$this->thrown['DeprecatedSniff'] = true;
 		}
 
 		if ( ( $this->customEscapingFunctions !== $this->addedCustomFunctions['escape']
@@ -71,13 +69,11 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 			|| $this->customPrintingFunctions !== $this->addedCustomFunctions['print'] )
 			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
 		) {
-			$this->phpcsFile->addWarning(
+			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.Security.EscapeOutput". Please update your custom ruleset.',
 				0,
 				'FoundPropertyForDeprecatedSniff'
 			);
-
-			$this->thrown['FoundPropertyForDeprecatedSniff'] = true;
 		}
 
 		return parent::process_token( $stackPtr );

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -63,11 +63,11 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 			);
 		}
 
-		if ( ( $this->customEscapingFunctions !== $this->addedCustomFunctions['escape']
-			|| $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize']
-			|| $this->customAutoEscapedFunctions !== $this->addedCustomFunctions['autoescape']
-			|| $this->customPrintingFunctions !== $this->addedCustomFunctions['print'] )
-			&& false === $this->thrown['FoundPropertyForDeprecatedSniff']
+		if ( false === $this->thrown['FoundPropertyForDeprecatedSniff']
+			&& ( ( array() !== $this->customEscapingFunctions && $this->customEscapingFunctions !== $this->addedCustomFunctions['escape'] )
+			|| ( array() !== $this->customSanitizingFunctions && $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize'] )
+			|| ( array() !== $this->customAutoEscapedFunctions && $this->customAutoEscapedFunctions !== $this->addedCustomFunctions['autoescape'] )
+			|| ( array() !== $this->customPrintingFunctions && $this->customPrintingFunctions !== $this->addedCustomFunctions['print'] ) )
 		) {
 			$this->thrown['FoundPropertyForDeprecatedSniff'] = $this->phpcsFile->addWarning(
 				'The "WordPress.XSS.EscapeOutput" sniff has been renamed to "WordPress.Security.EscapeOutput". Please update your custom ruleset.',

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheGetFunctions my_cacheget
+// @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheGetFunctions my_cacheget
 $variable = 'abc'; // Warning, deprecated sniff.
 
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheGetFunctions false
+// @codingStandardsChangeSetting WordPress.VIP.DirectDatabaseQuery customCacheGetFunctions false

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.inc
@@ -20,5 +20,5 @@ $query_args['my_posts_per_page'] = -1; // OK.
 
 // Test deprecated property message.
 // @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 50
- $query_args['posts_per_page'] = 50; // OK.
+$query_args['posts_per_page'] = 50; // OK.
 // @codingStandardsChangeSetting WordPress.VIP.PostsPerPage posts_per_page 100

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customPrintingFunctions to_screen,my_print
+// @codingStandardsChangeSetting WordPress.XSS.EscapeOutput customPrintingFunctions to_screen,my_print
 echo 'abc';
 
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customPrintingFunctions false
+// @codingStandardsChangeSetting WordPress.XSS.EscapeOutput customPrintingFunctions false


### PR DESCRIPTION
This PR actually fixes a number of things which I missed in the deprecation PR the first time around.

#### Deprecation messages: Simplify & improve code

The `addWarning()` and `addError()` methods return a boolean value signifying whether or not the notice has been thrown. This will in most cases be `true`, but will return `false` when the notice for whatever reason is being ignored.

Instead of hard-setting the `$this->thrown` value to true, let's use the return value instead so if the message is ignored for one file, it will still be thrown for the next.

#### Deprecation messages: fix messages being thrown when they shouldn't be

* Change the default values for the `$addedCustomFunctions` properties.
* Update the compares for the custom properties within the deprecated sniffs to prevent "deprecated property" messages being thrown unnecessarily.

Includes minor efficiency fix: No need to do the property compares if the message has already been thrown, so compare whether the message has already been thrown first.

To test this:
1. Run with the `WordPresss` ruleset over a project and don't see the superfluous notices anymore.
2. Use a ruleset along the lines of the below and make sure that for the deprecated sniffs, the deprecation messages are actually being thrown.

```xml
<?xml version="1.0"?>
<ruleset name="Test">

	<autoload>path/to/WordPress/PHPCSAliases.php</autoload>

	<rule ref="WordPress-Core"/>

	<rule ref="WordPress.WP.PreparedSQL">
		<type>warning</type>
	</rule>

	<rule ref="WordPress.Functions.DontExtract">
		<type>warning</type>
	</rule>

	<rule ref="WordPress.XSS.EscapeOutput">
		<type>warning</type>
	</rule>
</ruleset>
```


#### VIP ruleset: prevent deprecation messages being thrown when sniffs are not explicitly included through a custom ruleset

This was already done for the `WordPress` ruleset, but not for the `WordPress-VIP` ruleset.

#### Deprecated sniffs: Fix two previously missed typos in the test files
#### Fix minor whitespace issue in test file 



Fixes #1325