### PR TITLE
Clean up: Remove `// end` comments

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -31,4 +31,6 @@
 		</properties>
 	</rule>
 
+	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
+
 </ruleset>

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -77,7 +77,6 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			T_CONSTANT_ENCAPSED_STRING,
 			T_DOUBLE_QUOTED_STRING,
 		);
-
 	}
 
 	/**
@@ -218,8 +217,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				}
 			}
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Callback to process each confirmed key, to check value.
@@ -235,4 +233,4 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 	 */
 	abstract public function callback( $key, $val, $line, $group );
 
-} // End class.
+}

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -74,7 +74,6 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			T_EXTENDS,
 			T_IMPLEMENTS,
 		);
-
 	}
 
 	/**
@@ -157,8 +156,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 
 		$this->classname = $classname;
 		return true;
-
-	} // End is_targetted_token().
+	}
 
 	/**
 	 * Verify if the current token is one of the targetted classes.
@@ -189,8 +187,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		}
 
 		return min( $skip_to );
-
-	} // End is_targetted_token().
+	}
 
 	/**
 	 * Prepare the class name for use in a regular expression.
@@ -245,4 +242,4 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		return $classname;
 	}
 
-} // End class.
+}

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -109,4 +109,4 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 		return;
 	}
 
-} // End class.
+}

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -195,8 +195,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		if ( true === $this->is_targetted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Verify is the current token is a function call.
@@ -240,8 +239,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		return false;
-
-	} // End is_targetted_token().
+	}
 
 	/**
 	 * Verify if the current token is one of the targetted functions.
@@ -277,8 +275,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		return min( $skip_to );
-
-	} // End check_for_matches().
+	}
 
 	/**
 	 * Process a matched token.
@@ -303,7 +300,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		);
 
 		return;
-	} // End process_matched_token().
+	}
 
 	/**
 	 * Prepare the function name for use in a regular expression.
@@ -325,4 +322,4 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		return $function;
 	}
 
-} // End class.
+}

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -80,7 +80,6 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			T_DOUBLE_QUOTED_STRING,
 			T_HEREDOC,
 		);
-
 	}
 
 	/**
@@ -213,10 +212,8 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			);
 
 			return; // Show one error only.
-
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Transform a wildcard pattern to a usable regex pattern.
@@ -234,4 +231,4 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		return $pattern;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2537,7 +2537,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		return true;
-	} // End is_wpdb_method_call().
+	}
 
 	/**
 	 * Determine whether an arbitrary T_STRING token is the use of a global constant.

--- a/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -61,4 +61,4 @@ class ArrayAssignmentRestrictionsSniff extends AbstractArrayAssignmentRestrictio
 		return true;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -58,4 +58,4 @@ class ArrayDeclarationSniff {
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -437,4 +437,4 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -59,7 +59,6 @@ class ArrayIndentationSniff extends Sniff {
 	 */
 	private $ignore_tokens = array();
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
@@ -390,9 +389,7 @@ class ArrayIndentationSniff extends Sniff {
 
 			$end_of_previous_item = $end_of_this_item;
 		}
-
-	} // End process_token().
-
+	}
 
 	/**
 	 * Should the token be ignored ?
@@ -534,4 +531,4 @@ class ArrayIndentationSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -34,7 +34,6 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 		return array(
 			T_OPEN_SQUARE_BRACKET,
 		);
-
 	}
 
 	/**
@@ -86,7 +85,6 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 				}
 			}
 		}
+	}
 
-	} // End process().
-
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -283,4 +283,4 @@ class CommaAfterArrayItemSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -562,7 +562,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				}
 			}
 		}
-	} // End process_multi_line_array().
+	}
 
 	/**
 	 * Validate that a valid value has been received for the alignMultilineItems property.
@@ -606,4 +606,4 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		$this->alignMultilineItems = 'always';
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -76,4 +76,4 @@ class NonceVerificationSniff extends \WordPress\Sniffs\Security\NonceVerificatio
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -199,6 +199,6 @@ class ClassInstantiationSniff extends Sniff {
 				$this->phpcsFile->recordMetric( $stackPtr, 'Space between classname and parenthesis', 0 );
 			}
 		}
-	} // End process_token().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -77,8 +77,7 @@ class AssignmentInConditionSniff extends Sniff {
 			T_WHILE,
 			T_INLINE_THEN,
 		);
-
-	}//end register()
+	}
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -231,7 +230,6 @@ class AssignmentInConditionSniff extends Sniff {
 			$startPos = $hasAssignment;
 
 		} while ( $startPos < $closer );
-
 	}
 
 }

--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -144,7 +144,6 @@ class EmptyStatementSniff extends Sniff {
 				/* Deliberately left empty. */
 				break;
 		}
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -103,7 +103,6 @@ class DirectDatabaseQuerySniff extends Sniff {
 		return array(
 			T_VARIABLE,
 		);
-
 	}
 
 	/**
@@ -221,8 +220,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 		}
 
 		return $endOfStatement;
-
-	} // End process_token().
+	}
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
@@ -264,4 +262,4 @@ class DirectDatabaseQuerySniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -205,7 +205,6 @@ class PreparedSQLSniff extends Sniff {
 		}
 
 		return $this->end;
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -57,4 +57,4 @@ class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -60,8 +60,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'mysql_to_rfc3339' => true,
 				),
 			),
-
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -97,4 +97,4 @@ class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 		return true;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -218,7 +218,6 @@ class FileNameSniff extends Sniff {
 
 		// Only run this sniff once per file, no need to run it again.
 		return ( $this->phpcsFile->numTokens + 1 );
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -74,4 +74,4 @@ class DontExtractSniff extends \WordPress\Sniffs\PHP\DontExtractSniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -86,7 +86,6 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 			// If there is only whitespace between the parenthesis, it will just be the one token.
 			$this->phpcsFile->fixer->replaceToken( ( $openParenthesis + 1 ), '' );
 		}
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -45,4 +45,4 @@ class FunctionRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
 		return array();
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -381,8 +381,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				)
 			);
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Handle variable variables defined in the global namespace.
@@ -622,8 +621,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				'$' . $variable_name,
 			)
 		);
-
-	} // End process_variable_assignment().
+	}
 
 	/**
 	 * Process the parameters of a matched function.
@@ -724,8 +722,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$data[] = $raw_content;
 
 		$this->addMessage( self::ERROR_MSG, $parameters[1]['start'], $is_error, $error_code, $data );
-
-	} // End process_parameters().
+	}
 
 	/**
 	 * Check if a function/class/constant/variable name is prefixed with one of the expected prefixes.
@@ -852,7 +849,6 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		// Set the validated prefixes cache.
 		$this->validated_prefixes = $this->prefixes;
+	}
 
-	} // End validate_prefixes().
-
-} // End class.
+}

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -96,8 +96,7 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid', $errorData );
 		}
-
-	} // End processTokenOutsideScope().
+	}
 
 	/**
 	 * Processes the tokens within the scope.
@@ -164,8 +163,7 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}
-
-	} // End processTokenWithinScope().
+	}
 
 	/**
 	 * Transform the existing function/method name to one which complies with the naming conventions.
@@ -181,4 +179,4 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 		return $suggested;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -157,8 +157,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			$error = 'Words in hook names should be separated using underscores. Expected: %s, but found: %s.';
 			$this->phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
 		}
-
-	} // End process_parameters().
+	}
 
 	/**
 	 * Prepare the punctuation regular expression.
@@ -176,8 +175,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 		}
 
 		return sprintf( $this->punctuation_regex, $extra );
-
-	} // End prepare_regex().
+	}
 
 	/**
 	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
@@ -201,7 +199,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			default:
 				return preg_replace( $regex, '_', strtolower( $string ) );
 		}
-	} // End transform().
+	}
 
 	/**
 	 * Transform a complex string which may contain variable extrapolation.
@@ -253,6 +251,6 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 		}
 
 		return implode( '', $output );
-	} // End transform_complex_string().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -206,7 +206,6 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 				$phpcs_file->addError( $error, $stack_ptr, $error_name, $data );
 			}
 		}
-
 	}
 
 	/**
@@ -240,7 +239,6 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			$error = 'Member variable "%s" is not in valid snake_case format.';
 			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
 		}
-
 	}
 
 	/**
@@ -279,7 +277,6 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -333,4 +330,4 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -60,8 +60,7 @@ class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'phpinfo',
 				),
 			),
-
 		);
-	} // end getGroups()
+	}
 
-} // end class
+}

--- a/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
@@ -47,4 +47,4 @@ class DiscourageGotoSniff extends Sniff {
 		$this->phpcsFile->addWarning( 'Using the "goto" language construct is discouraged', $stackPtr, 'Found' );
 	}
 
-}//end class
+}

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -99,8 +99,7 @@ class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'str_rot13',
 				),
 			),
-
 		);
-	} // end getGroups()
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/DontExtractSniff.php
+++ b/WordPress/Sniffs/PHP/DontExtractSniff.php
@@ -49,6 +49,6 @@ class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
 			),
 
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -70,6 +70,6 @@ class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			),
 
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -42,8 +42,7 @@ class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'create_function',
 				),
 			),
-
 		);
-	} // end getGroups()
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -36,7 +36,6 @@ class StrictComparisonsSniff extends Sniff {
 			T_IS_EQUAL,
 			T_IS_NOT_EQUAL,
 		);
-
 	}
 
 	/**
@@ -52,7 +51,6 @@ class StrictComparisonsSniff extends Sniff {
 			$error = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
 			$this->phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
 		}
-
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -101,4 +101,4 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -58,7 +58,6 @@ class YodaConditionsSniff extends Sniff {
 			T_IS_IDENTICAL,
 			T_IS_NOT_IDENTICAL,
 		);
-
 	}
 
 	/**
@@ -121,7 +120,6 @@ class YodaConditionsSniff extends Sniff {
 		}
 
 		$this->phpcsFile->addError( 'Use Yoda Condition checks, you must.', $stackPtr, 'NotYoda' );
+	}
 
-	} // End process().
-
-} // End class.
+}

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -483,8 +483,7 @@ class EscapeOutputSniff extends Sniff {
 		}
 
 		return $end_of_statement;
-
-	} // End process_token().
+	}
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
@@ -542,4 +541,4 @@ class EscapeOutputSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -162,8 +162,7 @@ class NonceVerificationSniff extends Sniff {
 			$this->superglobals[ $instance['content'] ],
 			'NoNonceVerification'
 		);
-
-	} // End process_token().
+	}
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
@@ -201,4 +200,4 @@ class NonceVerificationSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -85,4 +85,4 @@ class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -43,6 +43,6 @@ class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -152,8 +152,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
 			$this->phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
@@ -182,4 +181,4 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -200,8 +200,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		} else {
 			return parent::process_token( $stackPtr );
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Process the parameters of a matched function.
@@ -428,4 +427,4 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -90,4 +90,4 @@ class CronIntervalSniff extends \WordPress\Sniffs\WP\CronIntervalSniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -80,4 +80,4 @@ class DirectDatabaseQuerySniff extends \WordPress\Sniffs\DB\DirectDatabaseQueryS
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -100,7 +100,6 @@ class FileSystemWritesDisallowSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		return $groups;
+	}
 
-	} // End getGroups().
-
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -57,4 +57,4 @@ class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -62,4 +62,4 @@ class PluginMenuSlugSniff extends \WordPress\Sniffs\Security\PluginMenuSlugSniff
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -102,4 +102,4 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 		return false;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -222,8 +222,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'wp_is_mobile',
 				),
 			),
-
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -65,4 +65,4 @@ class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -73,6 +73,6 @@ class SessionFunctionsUsageSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -36,7 +36,6 @@ class SessionVariableUsageSniff extends Sniff {
 		return array(
 			T_VARIABLE,
 		);
-
 	}
 
 	/**
@@ -56,4 +55,4 @@ class SessionVariableUsageSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -77,4 +77,4 @@ class SlowDBQuerySniff extends \WordPress\Sniffs\DB\SlowDBQuerySniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -33,7 +33,6 @@ class SuperGlobalInputUsageSniff extends Sniff {
 		return array(
 			T_VARIABLE,
 		);
-
 	}
 
 	/**
@@ -60,7 +59,6 @@ class SuperGlobalInputUsageSniff extends Sniff {
 		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
 			$this->phpcsFile->addWarning( 'Detected access of super global var %s, probably needs manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
 		}
-
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -76,4 +76,4 @@ class TimezoneChangeSniff extends \WordPress\Sniffs\WP\TimezoneChangeSniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -78,4 +78,4 @@ class ValidatedSanitizedInputSniff extends \WordPress\Sniffs\Security\ValidatedS
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -77,4 +77,4 @@ class GlobalVariablesSniff extends \WordPress\Sniffs\WP\GlobalVariablesOverrideS
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -48,4 +48,4 @@ class VariableRestrictionsSniff extends AbstractVariableRestrictionsSniff {
 		return array();
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -121,9 +121,8 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'mt_rand',
 				),
 			),
-
 		);
-	} // End getGroups().
+	}
 
 	/**
 	 * Process a matched token.
@@ -149,4 +148,4 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -260,8 +260,7 @@ class CapitalPDangitSniff extends Sniff {
 				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
 			}
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Retrieve a list of misspellings based on an array of matched variations on the target word.
@@ -285,4 +284,4 @@ class CapitalPDangitSniff extends Sniff {
 		return $mispelled;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -65,7 +65,6 @@ class CronIntervalSniff extends Sniff {
 			T_CONSTANT_ENCAPSED_STRING,
 			T_DOUBLE_QUOTED_STRING,
 		);
-
 	}
 
 	/**
@@ -198,8 +197,7 @@ class CronIntervalSniff extends Sniff {
 			);
 			return;
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Add warning about unclear cron schedule change.
@@ -214,4 +212,4 @@ class CronIntervalSniff extends Sniff {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -67,8 +67,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 				'classes' => $keys,
 			),
 		);
-
-	} // End getGroups().
+	}
 
 	/**
 	 * Process a matched token.
@@ -104,7 +103,6 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 			$this->string_to_errorcode( $matched_content . 'Found' ),
 			$data
 		);
+	}
 
-	} // End process_matched_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1348,8 +1348,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'functions' => $keys,
 			),
 		);
-
-	} // End getGroups().
+	}
 
 	/**
 	 * Process a matched token.
@@ -1385,7 +1384,6 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			$this->string_to_errorcode( $matched_content . 'Found' ),
 			$data
 		);
-
-	} // End process_matched_token().
+	}
 
 }

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -263,8 +263,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '2.5.0',
 			),
 		),
-
-	); // End $target_functions.
+	);
 
 	/**
 	 * Process the parameters of a matched function.

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -218,4 +218,4 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -51,8 +51,7 @@ class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'wp_reset_query',
 				),
 			),
-
 		);
-	} // end getGroups()
+	}
 
-} // end class
+}

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -59,7 +59,6 @@ class EnqueuedResourcesSniff extends Sniff {
 				'NonEnqueuedScript'
 			);
 		}
+	}
 
-	} // End process().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -159,8 +159,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				}
 			}
 		}
-
-	} // End process_token().
+	}
 
 	/**
 	 * Add the error if there is no whitelist comment present and the assignment
@@ -176,4 +175,4 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -170,7 +170,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 		);
-	} // End getGroups().
+	}
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -627,7 +627,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		if ( empty( $non_placeholder_content ) ) {
 			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
 		}
-	} // End check_text().
+	}
 
 	/**
 	 * Check for the presence of a translators comment if one of the text strings contains a placeholder.
@@ -725,8 +725,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 				return;
 			}
 		}
-
-	} // End check_for_translator_comment().
+	}
 
 	/**
 	 * Check if a (collated) comment string starts with 'translators:'.

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -76,4 +76,4 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 		return false;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -64,4 +64,4 @@ class PreparedSQLSniff extends \WordPress\Sniffs\DB\PreparedSQLSniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/WP/TimezoneChangeSniff.php
@@ -49,6 +49,6 @@ class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 		);
-	} // End getGroups().
+	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -250,7 +250,6 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 				}
 			}
 		}
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -62,4 +62,4 @@ class CastStructureSpacingSniff extends Sniff {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -101,7 +101,6 @@ class ControlStructureSpacingSniff extends Sniff {
 			T_TRY,
 			T_CATCH,
 		);
-
 	}
 
 	/**
@@ -552,7 +551,6 @@ class ControlStructureSpacingSniff extends Sniff {
 				}
 			}
 		}
+	}
 
-	} // End process_token().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -99,7 +99,6 @@ class DisallowInlineTabsSniff extends Sniff {
 
 		// Ignore the rest of the file.
 		return ( $this->phpcsFile->numTokens + 1 );
+	}
 
-	} // End process().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -60,4 +60,4 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 		return $tokens + $logical_operators;
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -176,7 +176,6 @@ class PrecisionAlignmentSniff extends Sniff {
 
 		// Ignore the rest of the file.
 		return ( $this->phpcsFile->numTokens + 1 );
+	}
 
-	} // End process().
-
-} // End class.
+}

--- a/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -63,4 +63,4 @@ class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
 		return parent::process( $phpcsFile, $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -83,4 +83,4 @@ class EscapeOutputSniff extends \WordPress\Sniffs\Security\EscapeOutputSniff {
 		return parent::process_token( $stackPtr );
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayAssignmentRestrictionsUnitTest.php
@@ -60,7 +60,6 @@ class ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest {
 			7  => 2,
 			20 => 1,
 		);
-
 	}
 
 	/**
@@ -70,7 +69,6 @@ class ArrayAssignmentRestrictionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -105,7 +105,6 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -65,7 +65,6 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 
-
 	/**
 	 * Returns the lines where errors should occur.
 	 *
@@ -174,7 +173,6 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -51,7 +51,6 @@ class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -72,7 +72,6 @@ class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -189,4 +189,4 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/CSRF/NonceVerificationUnitTest.php
@@ -45,7 +45,6 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
@@ -68,7 +68,6 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
 		}
 	}
 
@@ -79,7 +78,6 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -27,7 +27,6 @@ class AssignmentInConditionUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -92,7 +91,6 @@ class AssignmentInConditionUnitTest extends AbstractSniffUnitTest {
 			149 => 1,
 			150 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -64,4 +64,4 @@ class EmptyStatementUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -29,7 +29,6 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -57,7 +56,6 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			257 => 1,
 			274 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -92,7 +92,6 @@ class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			161 => 2,
 			177 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -58,7 +58,6 @@ class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -135,10 +135,8 @@ class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
-		} // End switch().
-
-	} // End getErrorList().
+		}
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -147,7 +145,6 @@ class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -75,8 +75,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			75 => 1,
 			76 => 1,
 		);
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -85,7 +84,6 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -29,7 +29,6 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -47,7 +46,6 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			30 => 1,
 			32 => 1, // Warning about deprecated whitelist comment.
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -121,8 +121,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		}
 
 		return array( $testFileBase . '.inc' );
-
-	} // End getTestFiles().
+	}
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -164,4 +163,4 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Functions/DontExtractUnitTest.php
+++ b/WordPress/Tests/Functions/DontExtractUnitTest.php
@@ -33,7 +33,6 @@ class DontExtractUnitTest extends AbstractSniffUnitTest {
 		return array(
 			4 => 1,
 		);
-
 	}
 
 	/**
@@ -45,7 +44,6 @@ class DontExtractUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
+++ b/WordPress/Tests/Functions/FunctionCallSignatureNoParamsUnitTest.php
@@ -40,7 +40,6 @@ class FunctionCallSignatureNoParamsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -124,4 +124,4 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -45,7 +45,6 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			89  => 2,
 			106 => 2,
 		);
-
 	}
 
 	/**
@@ -55,7 +54,6 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -74,10 +74,8 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 			case 'ValidHookNameUnitTest.2.inc':
 			default:
 				return array();
-
-		} // End switch().
-
-	} // End getErrorList().
+		}
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -110,9 +108,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
 		}
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -74,8 +74,7 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 		);
 
 		return $errors;
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -84,7 +83,6 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -28,7 +28,6 @@ class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -54,7 +53,6 @@ class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 			33 => 1,
 			34 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -28,7 +28,6 @@ class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -64,7 +63,6 @@ class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 			39 => 1,
 			40 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -31,7 +31,6 @@ class DontExtractUnitTest extends AbstractSniffUnitTest {
 		return array(
 			3 => 1,
 		);
-
 	}
 
 	/**
@@ -41,7 +40,6 @@ class DontExtractUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -36,7 +36,6 @@ class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			26 => 1,
 		);
-
 	}
 
 	/**
@@ -46,7 +45,6 @@ class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -38,7 +38,6 @@ class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -28,7 +28,6 @@ class StrictComparisonsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -44,7 +43,6 @@ class StrictComparisonsUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			29 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -51,4 +51,4 @@ class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -47,7 +47,6 @@ class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 			125 => 1,
 			135 => 1,
 		);
-
 	}
 
 	/**
@@ -57,7 +56,6 @@ class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -79,8 +79,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			264 => 1,
 			266 => 1,
 		);
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -89,7 +88,6 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -56,7 +56,6 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -29,7 +29,6 @@ class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -43,7 +42,6 @@ class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 			5 => 1,
 			9 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -27,8 +27,7 @@ class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
-	} // End getErrorList().
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -39,7 +38,6 @@ class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 		return array(
 			3 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -55,7 +55,6 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			150 => 2,
 			160 => 2,
 		);
-
 	}
 
 	/**
@@ -65,7 +64,6 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
+++ b/WordPress/Tests/VIP/AdminBarRemovalUnitTest.php
@@ -79,8 +79,7 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
-		} // End switch().
+		}
 	}
 
 	/**
@@ -90,7 +89,6 @@ class AdminBarRemovalUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/VIP/CronIntervalUnitTest.php
@@ -43,7 +43,6 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			1 => 2,
 			4 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/VIP/DirectDatabaseQueryUnitTest.php
@@ -41,7 +41,6 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
+++ b/WordPress/Tests/VIP/FileSystemWritesDisallowUnitTest.php
@@ -52,7 +52,6 @@ class FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
 			36 => 1,
 			37 => 1,
 		);
-
 	}
 
 	/**
@@ -62,7 +61,6 @@ class FileSystemWritesDisallowUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/OrderByRandUnitTest.php
+++ b/WordPress/Tests/VIP/OrderByRandUnitTest.php
@@ -34,7 +34,6 @@ class OrderByRandUnitTest extends AbstractSniffUnitTest {
 			9  => 1,
 			11 => 1,
 		);
-
 	}
 
 	/**
@@ -44,7 +43,6 @@ class OrderByRandUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/VIP/PluginMenuSlugUnitTest.php
@@ -41,7 +41,6 @@ class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/VIP/PostsPerPageUnitTest.php
@@ -38,7 +38,6 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			17 => 1,
 		);
-
 	}
 
 	/**
@@ -50,7 +49,6 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedFunctionsUnitTest.php
@@ -54,8 +54,7 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			83 => 1,
 			84 => 1,
 		);
-
-	} // End getErrorList().
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -72,7 +71,6 @@ class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			57 => 1,
 			79 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
+++ b/WordPress/Tests/VIP/RestrictedVariablesUnitTest.php
@@ -34,7 +34,6 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 			9  => 1,
 			23 => 1,
 		);
-
 	}
 
 	/**
@@ -49,7 +48,6 @@ class RestrictedVariablesUnitTest extends AbstractSniffUnitTest {
 			17 => 1,
 			28 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionFunctionsUsageUnitTest.php
@@ -37,7 +37,6 @@ class SessionFunctionsUsageUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SessionVariableUsageUnitTest.php
@@ -31,7 +31,6 @@ class SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
 			3 => 1,
 			4 => 1,
 		);
-
 	}
 
 	/**
@@ -41,7 +40,6 @@ class SessionVariableUsageUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/VIP/SlowDBQueryUnitTest.php
@@ -31,7 +31,6 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -44,7 +43,6 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			1 => 2,
 			4 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
+++ b/WordPress/Tests/VIP/SuperGlobalInputUsageUnitTest.php
@@ -28,7 +28,6 @@ class SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -44,4 +43,4 @@ class SuperGlobalInputUsageUnitTest extends AbstractSniffUnitTest {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/VIP/TimezoneChangeUnitTest.php
@@ -33,7 +33,6 @@ class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 		return array(
 			4 => 1,
 		);
-
 	}
 
 	/**
@@ -45,7 +44,6 @@ class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -33,7 +33,6 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 		return array(
 			4 => 3,
 		);
-
 	}
 
 	/**
@@ -45,7 +44,6 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
+++ b/WordPress/Tests/Variables/GlobalVariablesUnitTest.php
@@ -30,7 +30,6 @@ class GlobalVariablesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -42,7 +41,6 @@ class GlobalVariablesUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
+++ b/WordPress/Tests/Variables/VariableRestrictionsUnitTest.php
@@ -99,7 +99,6 @@ class VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 			61 => 1,
 			62 => 1,
 		);
-
 	}
 
 	/**
@@ -109,7 +108,6 @@ class VariableRestrictionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -28,7 +28,6 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -62,7 +61,6 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			27 => 1,
 			28 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -28,8 +28,7 @@ class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -63,7 +62,6 @@ class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 			173 => 1,
 			181 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -29,7 +29,6 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -53,7 +52,6 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			108 => 1,
 			115 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -28,8 +28,7 @@ class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array_fill( 9, 7, 1 );
-
-	} // End getErrorList().
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -38,7 +37,6 @@ class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -60,4 +60,4 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 		return $warnings;
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -52,4 +52,4 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -56,4 +56,4 @@ class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 		);
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -28,7 +28,6 @@ class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
 	}
 
 	/**
@@ -41,7 +40,6 @@ class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 			3 => 1,
 			5 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -45,7 +45,6 @@ class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 			30 => 1,
 			31 => 1,
 		);
-
 	}
 
 	/**
@@ -55,7 +54,6 @@ class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -43,7 +43,6 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 			128 => 1,
 			133 => 1,
 		);
-
 	}
 
 	/**
@@ -53,7 +52,6 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -157,10 +157,8 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
-		} // End switch().
-
-	} // end getErrorList()
+		}
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -195,8 +193,7 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 
 			default:
 				return array();
-
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -49,7 +49,6 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			29 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/WP/PreparedSQLUnitTest.php
@@ -45,7 +45,6 @@ class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/WP/TimezoneChangeUnitTest.php
@@ -31,7 +31,6 @@ class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 		return array(
 			3 => 1,
 		);
-
 	}
 
 	/**
@@ -41,7 +40,6 @@ class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -70,7 +70,6 @@ class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest {
 			55 => 1,
 			56 => 1,
 		);
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -36,7 +36,6 @@ class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 			18 => 2,
 			21 => 2,
 		);
-
 	}
 
 	/**
@@ -46,7 +45,6 @@ class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -77,8 +77,7 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 		 */
 
 		return $ret;
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -87,7 +86,6 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -83,7 +83,6 @@ class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -43,7 +43,6 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 			50 => 2,
 			51 => 2,
 		);
-
 	}
 
 	/**
@@ -53,7 +52,6 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -110,4 +110,4 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 		}
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -32,7 +32,6 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest {
 		return array(
 			12 => 1,
 		);
-
 	}
 
 	/**
@@ -42,7 +41,6 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
-
 	}
 
-} // End class.
+}

--- a/WordPress/Tests/XSS/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/XSS/EscapeOutputUnitTest.php
@@ -30,8 +30,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array();
-
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
@@ -42,7 +41,6 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 		return array(
 			1 => 2,
 		);
-
 	}
 
-} // End class.
+}


### PR DESCRIPTION
The upstream `CommentedOutCode` sniff has been updated and become more accurate and now throws a number of warnings for `// End ...` comments.

As the rule regarding end comments has been removed from the handbook anyway, we may as well remove them all and get rid of the warnings.

Related:
A large number of functions had a blank line at the end of the function for readability what with the end comment after the function closing brace. Those are now superfluous and have been removed as well.

A sniff has been added to the WPCS native ruleset to prevent these from coming back.

Additionally some other stray blank lines have been removed.