### PR TITLE
New WhitespaceBeforePHPOpenTag sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -425,6 +425,7 @@
 	-->
 	<!-- Important to prevent issues with content being sent before headers. -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
+	<rule ref="WordPress.PHP.WhitespaceBeforePHPOpenTag"/>
 
 	<!-- All line endings should be \n. -->
 	<rule ref="Generic.Files.LineEndings">

--- a/WordPress/Sniffs/PHP/WhitespaceBeforePHPOpenTagSniff.php
+++ b/WordPress/Sniffs/PHP/WhitespaceBeforePHPOpenTagSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
+/**
+ * Checks for whitespace before first open tag in a PHP file.
+ *
+ * Loosely based on the PHPCS native `Generic.PHP.CharacterBeforePHPOpeningTag` sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class WhitespaceBeforePHPOpenTagSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+			T_OPEN_TAG_WITH_ECHO,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Stack pointer to the end of the file.
+	 *             We're only interested in the first PHP open tag.
+	 */
+	public function process_token( $stackPtr ) {
+		$expected = 0;
+		if ( $stackPtr > 0 ) {
+			// Allow for a shebang line.
+			if ( substr( $this->tokens[0]['content'], 0, 2 ) === '#!' ) {
+				$expected = 1;
+			}
+		}
+
+		if ( $stackPtr === $expected ) {
+			return $this->phpcsFile->numTokens;
+		}
+
+		// T_INLINE_HTML are the only tokens which we would expect before the open tag.
+		$unexpected_token = $this->phpcsFile->findPrevious( T_INLINE_HTML, ( $stackPtr - 1 ), null, true );
+		if ( false !== $unexpected_token ) {
+			$this->phpcsFile->addError( 'Unexpected code found before the PHP open tag.', $unexpected_token, 'CodeFound' );
+			return $this->phpcsFile->numTokens;
+		}
+
+		// Check for non-whitespace characters.
+		for ( $i = ( $stackPtr - 1 ); $i >= 0; $i-- ) {
+			if ( preg_match( '`^[\pZ\s]+$`u', $this->tokens[ $i ]['content'] ) !== 1 ) {
+				// Non-whitespace found.
+				return $this->phpcsFile->numTokens;
+			}
+		}
+
+		$fix = $this->phpcsFile->addFixableError( 'Whitespace found before the PHP open tag.', 0, 'Found' );
+		if ( true === $fix ) {
+			$this->phpcsFile->fixer->beginChangeset();
+			for ( $i = 0; $i < $stackPtr; $i++ ) {
+				$this->phpcsFile->fixer->replaceToken( $i, '' );
+			}
+			$this->phpcsFile->fixer->endChangeset();
+		}
+
+		// Skip the rest of the file.
+		return $this->phpcsFile->numTokens;
+	}
+
+}

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.1.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.1.inc
@@ -1,0 +1,3 @@
+<?php
+
+// This is valid.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.1.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.1.inc.fixed
@@ -1,0 +1,3 @@
+<?php
+
+// This is valid.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.2.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.2.inc
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+// This is valid too.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.2.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.2.inc.fixed
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+// This is valid too.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.3.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.3.inc
@@ -1,0 +1,10 @@
+<div>Foo</div>
+<?= $var; ?>
+<?
+// This is fine. View without PHP file docblock.
+?>
+
+
+ <?php
+// Ignore. Not the first PHP tag in the file.
+?>

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.3.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.3.inc.fixed
@@ -1,0 +1,9 @@
+<div>Foo</div>
+<?php
+// This is fine. View without PHP file docblock.
+?>
+
+
+ <?php
+// Ignore. Not the first PHP tag in the file.
+?>

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.4.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.4.inc
@@ -1,0 +1,8 @@
+           
+
+		    	
+
+
+<?php
+
+// This should throw an error - mixed: spaces, tabs, new lines.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.4.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.4.inc.fixed
@@ -1,0 +1,3 @@
+<?php
+
+// This should throw an error - mixed: spaces, tabs, new lines.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.5.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.5.inc
@@ -1,0 +1,3 @@
+ <?php
+
+// This should throw an error - single space before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.5.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.5.inc.fixed
@@ -1,0 +1,3 @@
+<?php
+
+// This should throw an error - single space before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.6.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.6.inc
@@ -1,0 +1,3 @@
+			<?php
+
+// This should throw an error - multiple tabs before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.6.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.6.inc.fixed
@@ -1,0 +1,3 @@
+<?php
+
+// This should throw an error - multiple tabs before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.7.inc
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.7.inc
@@ -1,0 +1,3 @@
+ <?php
+
+// This should throw an error - unicode space before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.7.inc.fixed
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.7.inc.fixed
@@ -1,0 +1,3 @@
+<?php
+
+// This should throw an error - unicode space before tag.

--- a/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.php
+++ b/WordPress/Tests/PHP/WhitespaceBeforePHPOpenTagUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the WhitespaceBeforePHPOpenTag sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class WhitespaceBeforePHPOpenTagUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'WhitespaceBeforePHPOpenTagUnitTest.4.inc':
+			case 'WhitespaceBeforePHPOpenTagUnitTest.5.inc':
+			case 'WhitespaceBeforePHPOpenTagUnitTest.6.inc':
+			case 'WhitespaceBeforePHPOpenTagUnitTest.7.inc':
+				return array(
+					1 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+}


### PR DESCRIPTION
New sniff to detect whitespace before the first PHP open tag to prevent "headers already send" errors.

This sniff has been added to the `Core` ruleset.

Includes auto-fixer.
Includes unit tests.

N.B.: I've also tried to add a unit test with a unicode zero-width space, but haven't managed to get that working, so for now, I've dropped that test.

N.B.2: I've opened an issue upstream to see if there would be interest for this sniff in PHPCS itself - https://github.com/squizlabs/PHP_CodeSniffer/issues/2038