### PR TITLE
AlternativeFunctions: improve handling of strip_tags() and parse_url()

### DIFF
--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -31,3 +31,11 @@ wp_rand(); // OK.
 // @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
 parse_url( 'http://example.com/' ); // OK.
 // @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
+
+strip_tags( $something, '<iframe>' ); // OK.
+
+// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
+parse_url($url, PHP_URL_QUERY); // OK.
+// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.7
+parse_url($url, PHP_URL_SCHEME); // Warning.
+// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -60,6 +60,8 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			26 => 1,
 			27 => 1,
 			28 => 1,
+
+			40 => 1,
 		);
 	}
 


### PR DESCRIPTION
The `wp_strip_all_tags()` function does not allow for passing a list of allowed tags, while the PHP native function does, so the WP alternative is not a valid alternative when the second parameter `$allowable_tags` is passed.

Along the same lines, the `wp_parse_url()` function only added support for the PHP native second parameter `$component` in WP 4.7.0.

The changes now made means the sniff will bow out from throwing an error if either of the above situations is detected.

Includes unit tests.

Refs:
* http://php.net/manual/en/function.strip-tags.php
* https://developer.wordpress.org/reference/functions/wp_strip_all_tags/
* http://php.net/manual/en/function.parse-url.php
* https://developer.wordpress.org/reference/functions/wp_parse_url/