### PR TITLE
Fix PHP 7.3 compatibility

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -315,9 +315,9 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 * @return string Regex escaped function name.
 	 */
 	protected function prepare_name_for_regex( $function ) {
-		$function = str_replace( array( '.*', '*' ), '#', $function ); // Replace wildcards with placeholder.
+		$function = str_replace( array( '.*', '*' ), '@@', $function ); // Replace wildcards with placeholder.
 		$function = preg_quote( $function, '`' );
-		$function = str_replace( '#', '.*', $function ); // Replace placeholder with regex wildcard.
+		$function = str_replace( '@@', '.*', $function ); // Replace placeholder with regex wildcard.
 
 		return $function;
 	}


### PR DESCRIPTION
As of PHP 7.3, the `#` character will also be escaped by `preg_quote()`. This was causing problems for three sniffs which used the `AbstractFunctionRestrictionsSniff::prepare_name_for_regex()` method and was the reason that the unit tests were failing in the [Travis PHP 7.3 builds](https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards/builds/389243319#ember12516).

Ref: https://github.com/php/php-src/blob/600cb4b46755a9170eaa32606528a6908bc98975/UPGRADING#L160