### PR TITLE
AlternativeFunctions: improve handling of file_get_contents()

### DIFF
--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -11,7 +11,7 @@ parse_url( 'http://example.com/' ); // Warning.
 
 $json = json_encode( $thing ); // Warning, use wp_json_encode instead.
 
-file_get_contents(); // Warning.
+file_get_contents( $url ); // Warning.
 
 readfile(); // Warning.
 fopen(); // Warning.
@@ -39,3 +39,14 @@ parse_url($url, PHP_URL_QUERY); // OK.
 // @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.7
 parse_url($url, PHP_URL_SCHEME); // Warning.
 // @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
+
+file_get_contents( $local_file, true ); // OK.
+file_get_contents( $url, false ); // Warning.
+file_get_contents(); // OK - no params, so nothing to do.
+file_get_contents( 'http://remoteurl.com/file/?w=1' ); // Warning.
+file_get_contents( 'https://wordpress.org' ); // Warning.
+file_get_contents(ABSPATH . 'wp-admin/css/some-file.css'); // OK.
+file_get_contents(MYABSPATH . 'plugin-file.json'); // Warning.
+file_get_contents( MUPLUGINDIR . 'some-file.xml' ); // OK.
+file_get_contents( plugin_dir_path( __FILE__ ) . 'subfolder/*.conf' ); // OK.
+file_get_contents(WP_Upload_Dir()['path'] . 'subdir/file.inc'); // OK.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -45,7 +45,7 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 
 			12 => 1,
 
-			14 => 2,
+			14 => 1,
 
 			16 => 1,
 			17 => 1,
@@ -62,6 +62,11 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			28 => 1,
 
 			40 => 1,
+
+			44 => 1,
+			46 => 1,
+			47 => 1,
+			49 => 1,
 		);
 	}
 


### PR DESCRIPTION
The `AlternativeFunctions` sniff was throwing two different warnings whenever `file_get_contents()` was encountered, one advising to use `wp_remote_get()`, one advising to use the `WP_FileSystem`.

Aside from that, the warning is only really relevant when retrieving a remote URL. Using `file_get_contents()` for local files should not trigger a warning as discussed in #943.

This PR eliminates the notice about using the `WP_FileSystem` in favour of `wp_remote_get()`.
It also adds a parameter check to attempt to determine whether a local or a remote file is being retrieved and eliminates the `warning` when it is clear that `file_get_contents()` is used only to retrieve a local file.

Includes unit tests.

Fixes #943