### PR TITLE
New "PregQuoteDelimiter" sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -169,6 +169,10 @@
 	<rule ref="WordPress.WP.PostsPerPage"/>
 	<rule ref="WordPress.WP.TimezoneChange"/>
 
+	<!-- Verify some regex best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1371 -->
+	<rule ref="WordPress.PHP.PregQuoteDelimiter"/>
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Flag calling preg_quote() without the second ($delimiter) parameter.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'preg_quote';
+
+	/**
+	 * List of functions this sniff should examine.
+	 *
+	 * @link http://php.net/preg_quote
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array <string function_name> => <bool>
+	 */
+	protected $target_functions = array(
+		'preg_quote' => true,
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		if ( count( $parameters ) > 1 ) {
+			return;
+		}
+
+		$this->phpcsFile->addWarning(
+			'Passing the $delimiter as the second parameter to preg_quote() is strongly recommended.',
+			$stackPtr,
+			'Missing'
+		);
+	}
+
+}

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.inc
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+preg_quote($keywords, '/'); // OK.
+preg_quote( $keywords, '`' ); // OK.
+
+preg_quote($keywords); // Warning.
+$textbody = preg_replace ( "/" . preg_quote($word) . "/", // Warning
+                          "<i>" . $word . "</i>",
+                          $textbody );

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PregQuoteDelimiter sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.0.0
+ */
+class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			6 => 1,
+			7 => 1,
+		);
+	}
+
+}


### PR DESCRIPTION
New sniff to detect calls to `preg_quote()` which don't pass the delimiter parameter.

The sniff has initially been added to the `Extra` ruleset.

Partially fixes #1371

Related #632