### PR TITLE
PrefixAllGlobals: be more tolerant to non-conventional hook name separators

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -833,13 +833,12 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 			// Validate the prefix against characters allowed for function, class, constant names etc.
 			if ( preg_match( '`^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$`', $prefix ) !== 1 ) {
-				$this->phpcsFile->addError(
+				$this->phpcsFile->addWarning(
 					'The "%s" prefix is not a valid function/class/variable/constant prefix in PHP.',
 					0,
 					'InvalidPrefixPassed',
 					array( $prefix )
 				);
-				unset( $this->prefixes[ $key ] );
 				continue;
 			}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -374,4 +374,9 @@ function acronymFunction() {
 define( 'FORCE_SSL_ADMIN', true );
 const SCRIPT_DEBUG = $develop_src;
 
+// Allow for hook name prefixes with less conventional separators.
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes test-this,myplugin\
+do_action( 'test-this-hookname' ); // OK.
+apply_filters( 'myplugin\filtername', $var ); // OK.
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -32,7 +32,8 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
-					1   => 2, // 2 x error for incorrect prefix passed.
+					1   => 1, // 1 x error for blacklisted prefix passed.
+					10  => 1,
 					18  => 1,
 					21  => 1,
 					22  => 1,
@@ -83,6 +84,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
+					1   => 3, // 3 x error for potentially incorrect prefix passed.
 					249 => 1,
 					250 => 1,
 					253 => 1,


### PR DESCRIPTION
In the original sniff, invalid prefixes would be removed from the `$prefixes` array and not be taken into consideration.

However, hook names don't necessarily need to comply with the PHP naming conventions for function/class/variable names etc. While the WP naming conventions are in line with those, userland code may not use underscores as a word separator.

This minor change makes the sniff more tolerant towards less conventional hook word separators and changes the notice about "invalid prefixes" from an `error` to a `warning`.

Includes unit tests.