### PR TITLE
ArrayIndentation: fix fixer conflict with multi-line trailing comments

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -184,7 +184,7 @@ class ArrayIndentationSniff extends Sniff {
 				&& $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
 			) {
 				$first_content = $this->phpcsFile->findNext(
-					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE, T_COMMENT ),
 					( $first_content + 1 ),
 					$end_of_this_item,
 					true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -410,3 +410,21 @@ Page 2/3
 Page 3/3
 ',
 			);
+
+// Upstream issue #2060 - multi-line trailing comment.
+$NP = array(
+		'replacemaps' => array(
+				0x41 => array( 0x61 ),
+				0x33C1  => array( 0x6D, 0x3C9 ), /*
+				,0x33C2  => array(0x61, 0x2E, 0x6D, 0x2E) */
+				0x33C3  => array( 0x62, 0x71 ),
+				),
+);
+
+$my_array = [
+	'something' =>
+	apply_filters( '...', true ),// A
+// Multi-line inline comment about something...
+// B
+	'something_else',
+];

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -410,3 +410,21 @@ Page 2/3
 Page 3/3
 ',
 			);
+
+// Upstream issue #2060 - multi-line trailing comment.
+$NP = array(
+	'replacemaps' => array(
+		0x41 => array( 0x61 ),
+		0x33C1  => array( 0x6D, 0x3C9 ), /*
+			,0x33C2  => array(0x61, 0x2E, 0x6D, 0x2E) */
+		0x33C3  => array( 0x62, 0x71 ),
+	),
+);
+
+$my_array = [
+	'something' =>
+	apply_filters( '...', true ),// A
+// Multi-line inline comment about something...
+// B
+	'something_else',
+];

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -411,4 +411,22 @@ Page 3/3
 ',
             );
 
+// Upstream issue #2060 - multi-line trailing comment.
+$NP = array(
+        'replacemaps' => array(
+                0x41 => array( 0x61 ),
+                0x33C1  => array( 0x6D, 0x3C9 ), /*
+                ,0x33C2  => array(0x61, 0x2E, 0x6D, 0x2E) */
+                0x33C3  => array( 0x62, 0x71 ),
+                ),
+);
+
+$my_array = [
+    'something' =>
+    apply_filters( '...', true ),// A
+// Multi-line inline comment about something...
+// B
+    'something_else',
+];
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -411,4 +411,22 @@ Page 3/3
 ',
             );
 
+// Upstream issue #2060 - multi-line trailing comment.
+$NP = array(
+    'replacemaps' => array(
+        0x41 => array( 0x61 ),
+        0x33C1  => array( 0x6D, 0x3C9 ), /*
+            ,0x33C2  => array(0x61, 0x2E, 0x6D, 0x2E) */
+        0x33C3  => array( 0x62, 0x71 ),
+    ),
+);
+
+$my_array = [
+    'something' =>
+    apply_filters( '...', true ),// A
+// Multi-line inline comment about something...
+// B
+    'something_else',
+];
+
 // @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -163,6 +163,11 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 			369 => 1,
 			398 => 1,
 			399 => 1,
+			416 => 1,
+			417 => 2,
+			418 => 1,
+			420 => 1,
+			421 => 1,
 		);
 	}
 


### PR DESCRIPTION
When a trailing comment would stretch over multiple lines, the fixer went into a fixer conflict loop, trying to fix the same token again and again.

See upstream issue https://github.com/squizlabs/PHP_CodeSniffer/issues/2060 for more information.

Includes unit tests.