### PR TITLE
Sniff::get_function_call_parameters(): correctly handle closures when passed as param

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2096,7 +2096,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$next_comma  = $opener;
 		$param_start = ( $opener + 1 );
 		$cnt         = 1;
-		while ( $next_comma = $this->phpcsFile->findNext( array( T_COMMA, $this->tokens[ $closer ]['code'], T_OPEN_SHORT_ARRAY ), ( $next_comma + 1 ), ( $closer + 1 ) ) ) {
+		while ( $next_comma = $this->phpcsFile->findNext( array( T_COMMA, $this->tokens[ $closer ]['code'], T_OPEN_SHORT_ARRAY, T_CLOSURE ), ( $next_comma + 1 ), ( $closer + 1 ) ) ) {
 			// Ignore anything within short array definition brackets.
 			if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $next_comma ]['type']
 				&& ( isset( $this->tokens[ $next_comma ]['bracket_opener'] )
@@ -2105,6 +2105,17 @@ abstract class Sniff implements PHPCS_Sniff {
 			) {
 				// Skip forward to the end of the short array definition.
 				$next_comma = $this->tokens[ $next_comma ]['bracket_closer'];
+				continue;
+			}
+
+			// Skip past closures passed as function parameters.
+			if ( 'T_CLOSURE' === $this->tokens[ $next_comma ]['type']
+				&& ( isset( $this->tokens[ $next_comma ]['scope_condition'] )
+					&& $this->tokens[ $next_comma ]['scope_condition'] === $next_comma )
+				&& isset( $this->tokens[ $next_comma ]['scope_closer'] )
+			) {
+				// Skip forward to the end of the closure declaration.
+				$next_comma = $this->tokens[ $next_comma ]['scope_closer'];
 				continue;
 			}
 


### PR DESCRIPTION
Closures can be declared within function calls when the function expects a call-back.
This situation was only partially handled within the `Sniff::get_function_call_parameters()` method.

Most of the time when a comma is encountered within a closure, it will be at a different nesting level than the original function call/array, which meant it would be disregarded and the method would return the correct results.
However, there are some, albeit rare, situations in which the comma would be at the target nesting level, causing the method to split the closure into two or more "parameters".

As far as I know, this bug has not caused any issues for any of the WPCS sniffs so far, but the situation should be handled correctly even so.

I came across this while working on #1371, the PR for which will contain a unit test covering this fix.

Additionally, the same fix has been pulled to the PHPCompatibility standard with dedicated unit tests.
See: https://github.com/wimg/PHPCompatibility/pull/682

Related to #764