### PR TITLE
PrefixAllGlobals: improve handling of variable created by global foreach()

### DIFF
--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -341,6 +341,9 @@ if ( ( $abc = function_call() ) === true ) {} // Bad.
 $acronym_something = array();
 foreach ( $acronym_something as $acronym_some ) {} // OK.
 foreach ( $acronym_something as $something ) {} // Bad.
+foreach ( $acronym_something as $key => $acronym_something ) {} // Bad.
+foreach ( $acronym_something as $acronym_key => $something ) {} // Bad.
+foreach ( $acronym_something as $key => $something ) {} // Bad x 2.
 
 while ( ( $acronymSomething = function_call() ) === true ) {} // OK.
 while ( ( $something = function_call() ) === true ) {} // Bad.
@@ -361,6 +364,7 @@ switch( true ) {
 function acronymFunction() {
 	if ( ( $abc = function_call() ) === true ) {}
 	foreach ( $acronym_something as $something ) {}
+	foreach ( $acronym_something as $key => $something ) {}
 	while ( ( $something = function_call() ) === true ) {}
 	for ( $i = 0; $i < 10; $i++ ) {}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -59,9 +59,12 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					318 => 1,
 					339 => 1,
 					343 => 1,
-					346 => 1,
+					344 => 1,
+					345 => 1,
+					346 => 2,
 					349 => 1,
-					354 => 1,
+					352 => 1,
+					357 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.2.inc':


### PR DESCRIPTION
_Came across the previous PR while working on the 1.0.0 changelog and realized it was incomplete._

This PR builds onto the previously pulled #1279 which fixed #1236.

The code in the previous PR only took `foreach ( $array as $value )` declarations into account and did not yet cover `foreach ( $array as $key => $value )`.

This has now been fixed.

Includes unit tests.