### PR TITLE
GlobalVariablesOverride: detect WP variable overrides in foreach()

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -186,7 +186,12 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	 */
 	public function maybe_add_error( $stackPtr ) {
 		if ( ! $this->is_token_in_test_method( $stackPtr ) && ! $this->has_whitelist_comment( 'override', $stackPtr ) ) {
-			$this->phpcsFile->addError( 'Overriding WordPress globals is prohibited', $stackPtr, 'OverrideProhibited' );
+			$this->phpcsFile->addError(
+				'Overriding WordPress globals is prohibited. Found assignment to %s',
+				$stackPtr,
+				'OverrideProhibited',
+				array( $this->tokens[ $stackPtr ]['content'] )
+			);
 		}
 	}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -155,6 +155,21 @@ class GlobalVariablesOverrideSniff extends Sniff {
 
 					if ( true === $this->is_assignment( $ptr ) ) {
 						$this->maybe_add_error( $ptr );
+						continue;
+					}
+
+					// Check if this is a variable assignment within a `foreach()` declaration.
+					if ( isset( $this->tokens[ $ptr ]['nested_parenthesis'] ) ) {
+						$nested_parenthesis = $this->tokens[ $ptr ]['nested_parenthesis'];
+						$close_parenthesis  = end( $nested_parenthesis );
+						if ( isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] )
+							&& T_FOREACH === $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
+							&& ( false !== $previous
+								&& ( T_DOUBLE_ARROW === $this->tokens[ $previous ]['code']
+								|| T_AS === $this->tokens[ $previous ]['code'] ) )
+						) {
+							$this->maybe_add_error( $ptr );
+						}
 					}
 				}
 			}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.inc
@@ -131,3 +131,33 @@ add_filter( 'comments_open', new class {
 }, 10, 2 );
 
 $GLOBALS['totals']   ??= 10; // Bad.
+
+// Variant of issue #1236 - detect overriding WP variables in control structure conditions.
+function acronymFunction() {
+	global $pagenow, $menu;
+
+	if ( ( $pagenow = function_call() ) === true ) {}  // Bad.
+	foreach ( $something as $pagenow ) {}  // Bad.
+	foreach ( $something as $pagenow => $menu ) {}  // Bad x 2.
+	while ( ( $pagenow = function_call() ) === true ) {}  // Bad.
+	for ( $pagenow = 0; $pagenow < 10; $pagenow++ ) {}  // Bad.
+
+	switch( true ) {
+		case ($pagenow = 'abc'):  // Bad.
+			break;
+	}
+}
+
+// All OK: Function local variables, not the WP variable.
+function acronymFunction() {
+	if ( ( $pagenow = function_call() ) === true ) {}
+	foreach ( $something as $pagenow ) {}
+	foreach ( $something as $pagenow => $menu ) {}
+	while ( ( $pagenow = function_call() ) === true ) {}
+	for ( $pagenow = 0; $pagenow < 10; $pagenow++ ) {}
+
+	switch( true ) {
+		case ($pagenow = 'abc'):
+			break;
+	}
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -42,6 +42,12 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 			95  => 1,
 			128 => 1,
 			133 => 1,
+			139 => 1,
+			140 => 1,
+			141 => 2,
+			142 => 1,
+			143 => 1,
+			146 => 1,
 		);
 	}
 


### PR DESCRIPTION
Inspired by #1236 / #1279.

This PR adds unit tests to safeguard that variable overrides in control structure conditions are detected properly.

The only two cases which were not yet correctly covered were:
```php
foreach ( $something as $pagenow ) {}  // $pagenow was not detected.
foreach ( $something as $pagenow => $menu ) {}  // $pagenow was detected, but $menu wasn't.
```

This has now been fixed.


This PR also adjusts the error message to improve its usefulness by adding information on which WP variable is detected as being overridden, to it.
This is mostly useful when there are several variables assignments on one line, such as in a `foreach( $array as $key => $value )` statement or a multiple variable assignment `$varA = $varB = $varC = false;`.

