### PR TITLE
I18n: hardening of the "no translatable content" check

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -621,7 +621,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 *
 		 * Strip placeholders and surrounding quotes.
 		 */
-		$non_placeholder_content = $this->strip_quotes( $content );
+		$non_placeholder_content = trim( $this->strip_quotes( $content ) );
 		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $non_placeholder_content );
 
 		if ( '' === $non_placeholder_content ) {

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -174,5 +174,8 @@ class Foo {
 // Issue 1355.
 $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 
+$test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
+$test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
+
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -174,5 +174,8 @@ class Foo {
 // Issue 1355.
 $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 
+$test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
+$test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
+
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
 // @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -134,6 +134,7 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					144 => 1,
 					153 => 1,
 					157 => 1,
+					178 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
This builds onto the previously merged fix from PR #1376.

Includes unit tests.