### PR TITLE
CronInterval: make the sniff more code style independent

### DIFF
--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -158,9 +158,15 @@ class CronIntervalSniff extends Sniff {
 						return;
 					}
 
-					$valueStart = $this->phpcsFile->findNext( T_WHITESPACE, ( $operator + 1 ), null, true, null, true );
+					$valueStart = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true, null, true );
 					$valueEnd   = $this->phpcsFile->findNext( array( T_COMMA, T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
-					$value      = $this->phpcsFile->getTokensAsString( $valueStart, ( $valueEnd - $valueStart ) );
+					$value = '';
+					for ( $i = $valueStart; $i < $valueEnd; $i++ ) {
+						if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+							continue;
+						}
+						$value .= $this->tokens[ $i ]['content'];
+					}
 
 					if ( is_numeric( $value ) ) {
 						$interval = $value;

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -128,3 +128,14 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 } ); // Ok: > 30 min.
 
 // @codingStandardsChangeSetting WordPress.WP.CronInterval min_interval 900
+
+
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_9_mins'] = array(
+		'interval' =>
+			// phpcs:ignore Standard.Cat.Sniff -- for reasons
+			9 /* minutes */ * 60 /* seconds */,
+		'display' => __( 'Once every 9 minutes' )
+	);
+	return $schedules;
+} ); // Error: 9 min.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -51,6 +51,7 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			85  => 1,
 			108 => 1,
 			115 => 1,
+			133 => 1,
 		);
 	}
 


### PR DESCRIPTION
Allow for comments within the time interval definition.

Includes unit test.

Related to #763