### PR TITLE
Performance: use FQN for global constants

### DIFF
--- a/Test/Standards/AbstractSniffUnitTest.php
+++ b/Test/Standards/AbstractSniffUnitTest.php
@@ -100,7 +100,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
     {
         $testFiles = array();
 
-        $dir = substr($testFileBase, 0, strrpos($testFileBase, DIRECTORY_SEPARATOR));
+        $dir = substr($testFileBase, 0, strrpos($testFileBase, \DIRECTORY_SEPARATOR));
         $di  = new DirectoryIterator($dir);
 
         foreach ($di as $file) {
@@ -169,7 +169,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
         $parts     = explode('_', $basename);
         $sniffCode = $parts[0].'.'.$parts[2].'.'.$parts[3];
 
-        $testFileBase = $this->standardsDir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $basename).'UnitTest.';
+        $testFileBase = $this->standardsDir.\DIRECTORY_SEPARATOR.str_replace('_', \DIRECTORY_SEPARATOR, $basename).'UnitTest.';
 
         // Get a list of all test files to check.
         $testFiles = $this->getTestFiles($testFileBase);
@@ -214,7 +214,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
         }//end foreach
 
         if (empty($failureMessages) === false) {
-            $this->fail(implode(PHP_EOL, $failureMessages));
+            $this->fail(implode(\PHP_EOL, $failureMessages));
         }
 
     }//end runTest()
@@ -380,7 +380,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
                     $foundMessage    .= "$numErrors error(s)";
                     if ($numErrors !== 0) {
                         $foundString .= 'error(s)';
-                        $errors      .= implode(PHP_EOL.' -> ', $problems['found_errors']);
+                        $errors      .= implode(\PHP_EOL.' -> ', $problems['found_errors']);
                     }
 
                     if ($expectedWarnings !== $numWarnings) {
@@ -400,16 +400,16 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
                     if ($numWarnings !== 0) {
                         $foundString .= 'warning(s)';
                         if (empty($errors) === false) {
-                            $errors .= PHP_EOL.' -> ';
+                            $errors .= \PHP_EOL.' -> ';
                         }
 
-                        $errors .= implode(PHP_EOL.' -> ', $problems['found_warnings']);
+                        $errors .= implode(\PHP_EOL.' -> ', $problems['found_warnings']);
                     }
                 }
 
                 $fullMessage = "$lineMessage $expectedMessage $foundMessage.";
                 if ($errors !== '') {
-                    $fullMessage .= " The $foundString found were:".PHP_EOL." -> $errors";
+                    $fullMessage .= " The $foundString found were:".\PHP_EOL." -> $errors";
                 }
 
                 $failureMessages[] = $fullMessage;

--- a/Test/Standards/AllSniffs.php
+++ b/Test/Standards/AllSniffs.php
@@ -59,7 +59,7 @@ class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
 
         /* Start of WPCS adjustment */
         // Set the correct path to PHPCS.
-        $isInstalled = !is_file(PHPCS_DIR.'/CodeSniffer.php');
+        $isInstalled = !is_file(\PHPCS_DIR.'/CodeSniffer.php');
         /* End of WPCS adjustment */
 
         // Optionally allow for ignoring the tests for one or more standards.
@@ -80,7 +80,7 @@ class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
             // are split into different directories; one for the sniffs and
             // a different file system location for tests.
             if ($isInstalled === true
-                && is_dir($path.DIRECTORY_SEPARATOR.'Generic') === true
+                && is_dir($path.\DIRECTORY_SEPARATOR.'Generic') === true
             ) {
                 $path = dirname(__FILE__);
             }
@@ -90,7 +90,7 @@ class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
                     continue;
                 }
 
-                $testsDir = $path.DIRECTORY_SEPARATOR.$standard.DIRECTORY_SEPARATOR.'Tests'.DIRECTORY_SEPARATOR;
+                $testsDir = $path.\DIRECTORY_SEPARATOR.$standard.\DIRECTORY_SEPARATOR.'Tests'.\DIRECTORY_SEPARATOR;
 
                 if (is_dir($testsDir) === false) {
                     // No tests for this standard.
@@ -113,14 +113,14 @@ class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
                     }
 
                     $filePath  = $file->getPathname();
-                    $className = str_replace($path.DIRECTORY_SEPARATOR, '', $filePath);
+                    $className = str_replace($path.\DIRECTORY_SEPARATOR, '', $filePath);
                     $className = substr($className, 0, -4);
-                    $className = str_replace(DIRECTORY_SEPARATOR, '_', $className);
+                    $className = str_replace(\DIRECTORY_SEPARATOR, '_', $className);
 
                     // Include the sniff here so tests can use it in their setup() methods.
                     $parts = explode('_', $className);
                     if (isset($parts[0],$parts[2],$parts[3]) === true) {
-                        $sniffPath = $origPath.DIRECTORY_SEPARATOR.$parts[0].DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR.$parts[2].DIRECTORY_SEPARATOR.$parts[3];
+                        $sniffPath = $origPath.\DIRECTORY_SEPARATOR.$parts[0].\DIRECTORY_SEPARATOR.'Sniffs'.\DIRECTORY_SEPARATOR.$parts[2].\DIRECTORY_SEPARATOR.$parts[3];
                         $sniffPath = substr($sniffPath, 0, -8).'Sniff.php';
 
                         if (file_exists($sniffPath) === true) {

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -76,10 +76,10 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		}
 
 		return array(
-			T_DOUBLE_ARROW,
-			T_CLOSE_SQUARE_BRACKET,
-			T_CONSTANT_ENCAPSED_STRING,
-			T_DOUBLE_QUOTED_STRING,
+			\T_DOUBLE_ARROW,
+			\T_CLOSE_SQUARE_BRACKET,
+			\T_CONSTANT_ENCAPSED_STRING,
+			\T_DOUBLE_QUOTED_STRING,
 		);
 	}
 
@@ -141,9 +141,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 		$token = $this->tokens[ $stackPtr ];
 
-		if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-			$equal = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			if ( T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
+		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
+			$equal = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( \T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
 				return; // This is not an assignment!
 			}
 		}
@@ -156,22 +156,22 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		 * $foo = array( 'bar' => 'taz' );
 		 * $foo['bar'] = $taz;
 		 */
-		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
+		if ( in_array( $token['code'], array( \T_CLOSE_SQUARE_BRACKET, \T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
-			if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-				$operator = $this->phpcsFile->findNext( T_EQUAL, ( $stackPtr + 1 ) );
+			if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
+				$operator = $this->phpcsFile->findNext( \T_EQUAL, ( $stackPtr + 1 ) );
 			}
 
-			$keyIdx = $this->phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			$keyIdx = $this->phpcsFile->findPrevious( array( \T_WHITESPACE, \T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
 			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
 				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
-				$valStart       = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
-				$valEnd         = $this->phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+				$valStart       = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
 				$val            = $this->strip_quotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
-		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+		} elseif ( in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 			// $foo = 'bar=taz&other=thing';
 			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', $this->strip_quotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -69,10 +69,10 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		}
 
 		return array(
-			T_DOUBLE_COLON,
-			T_NEW,
-			T_EXTENDS,
-			T_IMPLEMENTS,
+			\T_DOUBLE_COLON,
+			\T_NEW,
+			\T_EXTENDS,
+			\T_IMPLEMENTS,
 		);
 	}
 
@@ -118,28 +118,28 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		$token     = $this->tokens[ $stackPtr ];
 		$classname = '';
 
-		if ( in_array( $token['code'], array( T_NEW, T_EXTENDS, T_IMPLEMENTS ), true ) ) {
-			if ( T_NEW === $token['code'] ) {
-				$nameEnd = ( $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS, T_WHITESPACE, T_SEMICOLON, T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
+		if ( in_array( $token['code'], array( \T_NEW, \T_EXTENDS, \T_IMPLEMENTS ), true ) ) {
+			if ( \T_NEW === $token['code'] ) {
+				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_PARENTHESIS, \T_WHITESPACE, \T_SEMICOLON, \T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
-				$nameEnd = ( $this->phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
+				$nameEnd = ( $this->phpcsFile->findNext( array( \T_CLOSE_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
 			}
 
 			$length    = ( $nameEnd - ( $stackPtr + 1 ) );
 			$classname = $this->phpcsFile->getTokensAsString( ( $stackPtr + 2 ), $length );
 
-			if ( T_NS_SEPARATOR !== $this->tokens[ ( $stackPtr + 2 ) ]['code'] ) {
+			if ( \T_NS_SEPARATOR !== $this->tokens[ ( $stackPtr + 2 ) ]['code'] ) {
 				$classname = $this->get_namespaced_classname( $classname, ( $stackPtr - 1 ) );
 			}
 		}
 
-		if ( T_DOUBLE_COLON === $token['code'] ) {
-			$nameEnd   = $this->phpcsFile->findPrevious( T_STRING, ( $stackPtr - 1 ) );
-			$nameStart = ( $this->phpcsFile->findPrevious( array( T_STRING, T_NS_SEPARATOR, T_NAMESPACE ), ( $nameEnd - 1 ), null, true, null, true ) + 1 );
+		if ( \T_DOUBLE_COLON === $token['code'] ) {
+			$nameEnd   = $this->phpcsFile->findPrevious( \T_STRING, ( $stackPtr - 1 ) );
+			$nameStart = ( $this->phpcsFile->findPrevious( array( \T_STRING, \T_NS_SEPARATOR, \T_NAMESPACE ), ( $nameEnd - 1 ), null, true, null, true ) + 1 );
 			$length    = ( $nameEnd - ( $nameStart - 1 ) );
 			$classname = $this->phpcsFile->getTokensAsString( $nameStart, $length );
 
-			if ( T_NS_SEPARATOR !== $this->tokens[ $nameStart ]['code'] ) {
+			if ( \T_NS_SEPARATOR !== $this->tokens[ $nameStart ]['code'] ) {
 				$classname = $this->get_namespaced_classname( $classname, ( $nameStart - 1 ) );
 			}
 		}
@@ -224,7 +224,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			$classname = substr( $classname, 10 );
 		}
 
-		$namespace_keyword = $this->phpcsFile->findPrevious( T_NAMESPACE, $search_from );
+		$namespace_keyword = $this->phpcsFile->findPrevious( \T_NAMESPACE, $search_from );
 		if ( false === $namespace_keyword ) {
 			// No namespace keyword found at all, so global namespace.
 			$classname = '\\' . $classname;

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -122,7 +122,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		return array(
-			T_STRING,
+			\T_STRING,
 		);
 	}
 
@@ -213,17 +213,17 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	public function is_targetted_token( $stackPtr ) {
 
 		// Exclude function definitions, class methods, and namespaced calls.
-		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
 			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 			if ( false !== $prev ) {
 				// Skip sniffing if calling a same-named method, or on function definitions.
 				$skipped = array(
-					T_FUNCTION        => T_FUNCTION,
-					T_CLASS           => T_CLASS,
-					T_AS              => T_AS, // Use declaration alias.
-					T_DOUBLE_COLON    => T_DOUBLE_COLON,
-					T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
+					\T_FUNCTION        => \T_FUNCTION,
+					\T_CLASS           => \T_CLASS,
+					\T_AS              => \T_AS, // Use declaration alias.
+					\T_DOUBLE_COLON    => \T_DOUBLE_COLON,
+					\T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
 				);
 
 				if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
@@ -231,9 +231,9 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 				}
 
 				// Skip namespaced functions, ie: \foo\bar() not \bar().
-				if ( T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
+				if ( \T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
 					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
-					if ( false !== $pprev && T_STRING === $this->tokens[ $pprev ]['code'] ) {
+					if ( false !== $pprev && \T_STRING === $this->tokens[ $pprev ]['code'] ) {
 						return false;
 					}
 				}

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -77,12 +77,12 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		}
 
 		return array(
-			T_VARIABLE,
-			T_OBJECT_OPERATOR,
-			T_DOUBLE_COLON,
-			T_OPEN_SQUARE_BRACKET,
-			T_DOUBLE_QUOTED_STRING,
-			T_HEREDOC,
+			\T_VARIABLE,
+			\T_OBJECT_OPERATOR,
+			\T_DOUBLE_COLON,
+			\T_OPEN_SQUARE_BRACKET,
+			\T_DOUBLE_QUOTED_STRING,
+			\T_HEREDOC,
 		);
 	}
 
@@ -147,10 +147,10 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		}
 
 		// Check if it is a function not a variable.
-		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
-			$method               = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
-			$possible_parenthesis = $this->phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
-			if ( T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
+		if ( in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
+			$method               = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$possible_parenthesis = $this->phpcsFile->findNext( \T_WHITESPACE, ( $method + 1 ), null, true );
+			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
 				return; // So .. it is a function after all !
 			}
 		}
@@ -164,28 +164,28 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			$patterns = array();
 
 			// Simple variable.
-			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
+			if ( in_array( $token['code'], array( \T_VARIABLE, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
 				$patterns = array_merge( $patterns, $group['variables'] );
 				$var      = $token['content'];
 
 			}
 
-			if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
+			if ( in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
 				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
-				$owner = $this->phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
-				$child = $this->phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
+				$owner = $this->phpcsFile->findPrevious( array( \T_VARIABLE, \T_STRING ), $stackPtr );
+				$child = $this->phpcsFile->findNext( array( \T_STRING, \T_VAR, \T_VARIABLE ), $stackPtr );
 				$var   = implode( '', array( $this->tokens[ $owner ]['content'], $token['content'], $this->tokens[ $child ]['content'] ) );
 
 			}
 
-			if ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
+			if ( in_array( $token['code'], array( \T_OPEN_SQUARE_BRACKET, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 
 				if ( isset( $token['bracket_closer'] ) ) {
-					$owner  = $this->phpcsFile->findPrevious( T_VARIABLE, $stackPtr );
+					$owner  = $this->phpcsFile->findPrevious( \T_VARIABLE, $stackPtr );
 					$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
 					$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
 				}
@@ -197,9 +197,9 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
 			$pattern  = implode( '|', $patterns );
-			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] && T_HEREDOC !== $token['code'] ) ? '\b' : '';
+			$delim    = ( \T_OPEN_SQUARE_BRACKET !== $token['code'] && \T_HEREDOC !== $token['code'] ) ? '\b' : '';
 
-			if ( T_DOUBLE_QUOTED_STRING === $token['code'] || T_HEREDOC === $token['code'] ) {
+			if ( \T_DOUBLE_QUOTED_STRING === $token['code'] || \T_HEREDOC === $token['code'] ) {
 				$var = $token['content'];
 			}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1133,7 +1133,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function get_wp_version_from_cl() {
 		$cl_supported_version = trim( PHPCSHelper::get_config_data( 'minimum_supported_wp_version' ) );
 		if ( ! empty( $cl_supported_version )
-			&& filter_var( $cl_supported_version, FILTER_VALIDATE_FLOAT ) !== false
+			&& filter_var( $cl_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
 		) {
 			$this->minimum_supported_version = $cl_supported_version;
 		}
@@ -1174,18 +1174,18 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// There is a findEndOfStatement() method, but it considers more tokens than
 		// we need to here.
-		$end_of_statement = $this->phpcsFile->findNext( array( T_CLOSE_TAG, T_SEMICOLON ), $stackPtr );
+		$end_of_statement = $this->phpcsFile->findNext( array( \T_CLOSE_TAG, \T_SEMICOLON ), $stackPtr );
 
 		if ( false !== $end_of_statement ) {
 			// If the statement was ended by a semicolon, check if there is a whitelist comment directly after it.
-			if ( T_SEMICOLON === $this->tokens[ $end_of_statement ]['code'] ) {
-				$lastPtr = $this->phpcsFile->findNext( T_WHITESPACE, ( $end_of_statement + 1 ), null, true );
-			} elseif ( T_CLOSE_TAG === $this->tokens[ $end_of_statement ]['code'] ) {
+			if ( \T_SEMICOLON === $this->tokens[ $end_of_statement ]['code'] ) {
+				$lastPtr = $this->phpcsFile->findNext( \T_WHITESPACE, ( $end_of_statement + 1 ), null, true );
+			} elseif ( \T_CLOSE_TAG === $this->tokens[ $end_of_statement ]['code'] ) {
 				// If the semicolon was left out and it was terminated by an ending tag, we need to look backwards.
-				$lastPtr = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $end_of_statement - 1 ), null, true );
+				$lastPtr = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $end_of_statement - 1 ), null, true );
 			}
 
-			if ( ( T_COMMENT === $this->tokens[ $lastPtr ]['code']
+			if ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 					|| isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] ) )
 				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
 				&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
@@ -1197,9 +1197,9 @@ abstract class Sniff implements PHPCS_Sniff {
 		// No whitelist comment found so far. Check at the end of the stackPtr line.
 		// Note: a T_COMMENT includes the new line character, so may be the last token on the line!
 		$end_of_line = $this->get_last_ptr_on_line( $stackPtr );
-		$lastPtr     = $this->phpcsFile->findPrevious( T_WHITESPACE, $end_of_line, null, true );
+		$lastPtr     = $this->phpcsFile->findPrevious( \T_WHITESPACE, $end_of_line, null, true );
 
-		if ( ( T_COMMENT === $this->tokens[ $lastPtr ]['code']
+		if ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 				|| isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] ) )
 			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']
 			&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
@@ -1225,14 +1225,14 @@ abstract class Sniff implements PHPCS_Sniff {
 	 */
 	protected function is_token_in_test_method( $stackPtr ) {
 		// Is the token inside of a function definition ?
-		$functionToken = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+		$functionToken = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 		if ( false === $functionToken ) {
 			return false;
 		}
 
 		// Is this a method inside of a class or a trait ?
-		$classToken = $this->phpcsFile->getCondition( $functionToken, T_CLASS );
-		$traitToken = $this->phpcsFile->getCondition( $functionToken, T_TRAIT );
+		$classToken = $this->phpcsFile->getCondition( $functionToken, \T_CLASS );
+		$traitToken = $this->phpcsFile->getCondition( $functionToken, \T_TRAIT );
 		if ( false === $classToken && false === $traitToken ) {
 			return false;
 		}
@@ -1336,8 +1336,8 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function is_assignment( $stackPtr ) {
 
 		static $valid = array(
-			T_VARIABLE             => true,
-			T_CLOSE_SQUARE_BRACKET => true,
+			\T_VARIABLE             => true,
+			\T_CLOSE_SQUARE_BRACKET => true,
 		);
 
 		// Must be a variable, constant or closing square bracket (see below).
@@ -1365,7 +1365,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Check if this is an array assignment, e.g., `$var['key'] = 'val';` .
-		if ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_non_empty ]['code'] ) {
+		if ( \T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_non_empty ]['code'] ) {
 			return $this->is_assignment( $this->tokens[ $next_non_empty ]['bracket_closer'] );
 		}
 
@@ -1402,11 +1402,11 @@ abstract class Sniff implements PHPCS_Sniff {
 		$tokens = $this->phpcsFile->getTokens();
 
 		// If we're in a function, only look inside of it.
-		$f = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+		$f = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 		if ( false !== $f ) {
 			$start = $tokens[ $f ]['scope_opener'];
 		} else {
-			$f = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			$f = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
 			if ( false !== $f ) {
 				$start = $tokens[ $f ]['scope_opener'];
 			}
@@ -1455,7 +1455,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		for ( $i = $start; $i < $end; $i++ ) {
 
 			// If this isn't a function name, skip it.
-			if ( T_STRING !== $tokens[ $i ]['code'] ) {
+			if ( \T_STRING !== $tokens[ $i ]['code'] ) {
 				continue;
 			}
 
@@ -1492,7 +1492,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		end( $nested_parenthesis );
 		$open_parenthesis = key( $nested_parenthesis );
 
-		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( T_ISSET, T_EMPTY ), true );
+		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( \T_ISSET, \T_EMPTY ), true );
 	}
 
 	/**
@@ -1548,7 +1548,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		);
 
 		// Check if it is a safe cast.
-		return in_array( $this->tokens[ $prev ]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ), true );
+		return in_array( $this->tokens[ $prev ]['code'], array( \T_INT_CAST, \T_DOUBLE_CAST, \T_BOOL_CAST ), true );
 	}
 
 	/**
@@ -1584,12 +1584,12 @@ abstract class Sniff implements PHPCS_Sniff {
 		$function           = $this->tokens[ ( $function_opener - 1 ) ];
 
 		// If it is just being unset, the value isn't used at all, so it's safe.
-		if ( T_UNSET === $function['code'] ) {
+		if ( \T_UNSET === $function['code'] ) {
 			return true;
 		}
 
 		// If this isn't a call to a function, it sure isn't sanitizing function.
-		if ( T_STRING !== $function['code'] ) {
+		if ( \T_STRING !== $function['code'] ) {
 			if ( $require_unslash ) {
 				$this->add_unslash_error( $stackPtr );
 			}
@@ -1635,7 +1635,7 @@ abstract class Sniff implements PHPCS_Sniff {
 					true
 				);
 
-				if ( false !== $first_non_empty && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
+				if ( false !== $first_non_empty && \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
 					$functionName = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
 				}
 			}
@@ -1693,7 +1693,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		);
 
 		// If it isn't a bracket, this isn't an array-access.
-		if ( false === $open_bracket || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $open_bracket ]['code'] ) {
+		if ( false === $open_bracket || \T_OPEN_SQUARE_BRACKET !== $this->tokens[ $open_bracket ]['code'] ) {
 			return false;
 		}
 
@@ -1774,14 +1774,14 @@ abstract class Sniff implements PHPCS_Sniff {
 			$scope_start = 0;
 
 			// Check if we are in a function.
-			$function = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			$function = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 
 			// If so, we check only within the function, otherwise the whole file.
 			if ( false !== $function ) {
 				$scope_start = $this->tokens[ $function ]['scope_opener'];
 			} else {
 				// Check if we are in a closure.
-				$closure = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+				$closure = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
 
 				// If so, we check only within the closure.
 				if ( false !== $closure ) {
@@ -1795,17 +1795,17 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
-			if ( ! in_array( $this->tokens[ $i ]['code'], array( T_ISSET, T_EMPTY, T_UNSET ), true ) ) {
+			if ( ! in_array( $this->tokens[ $i ]['code'], array( \T_ISSET, \T_EMPTY, \T_UNSET ), true ) ) {
 				continue;
 			}
 
-			$issetOpener = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, $i );
+			$issetOpener = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, $i );
 			$issetCloser = $this->tokens[ $issetOpener ]['parenthesis_closer'];
 
 			// Look for this variable. We purposely stomp $i from the parent loop.
 			for ( $i = ( $issetOpener + 1 ); $i < $issetCloser; $i++ ) {
 
-				if ( T_VARIABLE !== $this->tokens[ $i ]['code'] ) {
+				if ( \T_VARIABLE !== $this->tokens[ $i ]['code'] ) {
 					continue;
 				}
 
@@ -1844,7 +1844,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 			if (
 				isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] )
-				&& T_SWITCH === $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
+				&& \T_SWITCH === $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
 			) {
 				return true;
 			}
@@ -1872,7 +1872,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		);
 
 		// This might be an opening square bracket in the case of arrays ($var['a']).
-		while ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_token ]['code'] ) {
+		while ( \T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_token ]['code'] ) {
 
 			$next_token = $this->phpcsFile->findNext(
 				Tokens::$emptyTokens,
@@ -1910,9 +1910,9 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function get_use_type( $stackPtr ) {
 
 		// USE keywords inside closures.
-		$next = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+		$next = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 
-		if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
+		if ( \T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
 			return 'closure';
 		}
 
@@ -1943,7 +1943,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 */
 	protected function get_interpolated_variables( $string ) {
 		$variables = array();
-		if ( preg_match_all( '/(?P<backslashes>\\\\*)\$(?P<symbol>\w+)/', $string, $match_sets, PREG_SET_ORDER ) ) {
+		if ( preg_match_all( '/(?P<backslashes>\\\\*)\$(?P<symbol>\w+)/', $string, $match_sets, \PREG_SET_ORDER ) ) {
 			foreach ( $match_sets as $matches ) {
 				if ( ! isset( $matches['backslashes'] ) || ( strlen( $matches['backslashes'] ) % 2 ) === 0 ) {
 					$variables[] = $matches['symbol'];
@@ -1998,7 +1998,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Is this one of the tokens this function handles ?
-		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], array( T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY ), true ) ) {
+		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], array( \T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY ), true ) ) {
 			return false;
 		}
 
@@ -2020,7 +2020,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Deal with function calls & long arrays.
 		// Next non-empty token should be the open parenthesis.
-		if ( false === $next_non_empty && T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty ]['code'] ) {
+		if ( false === $next_non_empty && \T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty ]['code'] ) {
 			return false;
 		}
 
@@ -2120,7 +2120,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$next_comma  = $opener;
 		$param_start = ( $opener + 1 );
 		$cnt         = 1;
-		while ( $next_comma = $this->phpcsFile->findNext( array( T_COMMA, $this->tokens[ $closer ]['code'], T_OPEN_SHORT_ARRAY, T_CLOSURE ), ( $next_comma + 1 ), ( $closer + 1 ) ) ) {
+		while ( $next_comma = $this->phpcsFile->findNext( array( \T_COMMA, $this->tokens[ $closer ]['code'], \T_OPEN_SHORT_ARRAY, \T_CLOSURE ), ( $next_comma + 1 ), ( $closer + 1 ) ) ) {
 			// Ignore anything within short array definition brackets.
 			if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $next_comma ]['type']
 				&& ( isset( $this->tokens[ $next_comma ]['bracket_opener'] )
@@ -2144,7 +2144,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			}
 
 			// Ignore comma's at a lower nesting level.
-			if ( T_COMMA === $this->tokens[ $next_comma ]['code']
+			if ( \T_COMMA === $this->tokens[ $next_comma ]['code']
 				&& isset( $this->tokens[ $next_comma ]['nested_parenthesis'] )
 				&& count( $this->tokens[ $next_comma ]['nested_parenthesis'] ) !== $nestedParenthesisCount
 			) {
@@ -2220,7 +2220,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		/*
 		 * Determine the array opener & closer.
 		 */
-		if ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
 			if ( isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
 				$opener = $this->tokens[ $stackPtr ]['parenthesis_opener'];
 
@@ -2266,7 +2266,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Check for scoped namespace {}.
 		if ( ! empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
-			$namespacePtr = $this->phpcsFile->getCondition( $stackPtr, T_NAMESPACE );
+			$namespacePtr = $this->phpcsFile->getCondition( $stackPtr, \T_NAMESPACE );
 			if ( false !== $namespacePtr ) {
 				$namespace = $this->get_declared_namespace_name( $namespacePtr );
 				if ( false !== $namespace ) {
@@ -2289,7 +2289,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$previousNSToken = $stackPtr;
 		$namespace       = false;
 		do {
-			$previousNSToken = $this->phpcsFile->findPrevious( T_NAMESPACE, ( $previousNSToken - 1 ) );
+			$previousNSToken = $this->phpcsFile->findPrevious( \T_NAMESPACE, ( $previousNSToken - 1 ) );
 
 			// Stop if we encounter a scoped namespace declaration as we already know we're not in one.
 			if ( ! empty( $this->tokens[ $previousNSToken ]['scope_condition'] )
@@ -2331,17 +2331,17 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		if ( T_NAMESPACE !== $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_NAMESPACE !== $this->tokens[ $stackPtr ]['code'] ) {
 			return false;
 		}
 
-		if ( T_NS_SEPARATOR === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+		if ( \T_NS_SEPARATOR === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 			// Not a namespace declaration, but use of, i.e. `namespace\someFunction();`.
 			return false;
 		}
 
 		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
-		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
+		if ( \T_OPEN_CURLY_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
 			// Declaration for global namespace when using multiple namespaces in a file.
 			// I.e.: `namespace {}`.
 			return '';
@@ -2349,9 +2349,9 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Ok, this should be a namespace declaration, so get all the parts together.
 		$validTokens = array(
-			T_STRING       => true,
-			T_NS_SEPARATOR => true,
-			T_WHITESPACE   => true,
+			\T_STRING       => true,
+			\T_NS_SEPARATOR => true,
+			\T_WHITESPACE   => true,
 		);
 
 		$namespaceName = '';
@@ -2407,7 +2407,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @return bool
 	 */
 	public function is_class_constant( $stackPtr ) {
-		if ( ! isset( $this->tokens[ $stackPtr ] ) || T_CONST !== $this->tokens[ $stackPtr ]['code'] ) {
+		if ( ! isset( $this->tokens[ $stackPtr ] ) || \T_CONST !== $this->tokens[ $stackPtr ]['code'] ) {
 			return false;
 		}
 
@@ -2431,7 +2431,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @return bool
 	 */
 	public function is_class_property( $stackPtr ) {
-		if ( ! isset( $this->tokens[ $stackPtr ] ) || T_VARIABLE !== $this->tokens[ $stackPtr ]['code'] ) {
+		if ( ! isset( $this->tokens[ $stackPtr ] ) || \T_VARIABLE !== $this->tokens[ $stackPtr ]['code'] ) {
 			return false;
 		}
 
@@ -2509,15 +2509,15 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function is_wpdb_method_call( $stackPtr, $target_methods ) {
 
 		// Check for wpdb.
-		if ( ( T_VARIABLE === $this->tokens[ $stackPtr ]['code'] && '$wpdb' !== $this->tokens[ $stackPtr ]['content'] )
-			|| ( T_STRING === $this->tokens[ $stackPtr ]['code'] && 'wpdb' !== $this->tokens[ $stackPtr ]['content'] )
+		if ( ( \T_VARIABLE === $this->tokens[ $stackPtr ]['code'] && '$wpdb' !== $this->tokens[ $stackPtr ]['content'] )
+			|| ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && 'wpdb' !== $this->tokens[ $stackPtr ]['content'] )
 		) {
 			return false;
 		}
 
 		// Check that this is a method call.
 		$is_object_call = $this->phpcsFile->findNext(
-			array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ),
+			array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ),
 			( $stackPtr + 1 ),
 			null,
 			false,
@@ -2528,17 +2528,17 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		$methodPtr = $this->phpcsFile->findNext( T_WHITESPACE, ( $is_object_call + 1 ), null, true, null, true );
+		$methodPtr = $this->phpcsFile->findNext( \T_WHITESPACE, ( $is_object_call + 1 ), null, true, null, true );
 		if ( false === $methodPtr ) {
 			return false;
 		}
 
-		if ( T_STRING === $this->tokens[ $methodPtr ]['code'] && property_exists( $this, 'methodPtr' ) ) {
+		if ( \T_STRING === $this->tokens[ $methodPtr ]['code'] && property_exists( $this, 'methodPtr' ) ) {
 			$this->methodPtr = $methodPtr;
 		}
 
 		// Find the opening parenthesis.
-		$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, ( $methodPtr + 1 ), null, true, null, true );
+		$opening_paren = $this->phpcsFile->findNext( \T_WHITESPACE, ( $methodPtr + 1 ), null, true, null, true );
 
 		if ( false === $opening_paren ) {
 			return false;
@@ -2548,7 +2548,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			$this->i = $opening_paren;
 		}
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $opening_paren ]['code']
+		if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $opening_paren ]['code']
 			|| ! isset( $this->tokens[ $opening_paren ]['parenthesis_closer'] )
 		) {
 			return false;
@@ -2562,7 +2562,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		// Find the end of the first parameter.
 		$end = $this->phpcsFile->findEndOfStatement( $opening_paren + 1 );
 
-		if ( T_COMMA !== $this->tokens[ $end ]['code'] ) {
+		if ( \T_COMMA !== $this->tokens[ $end ]['code'] ) {
 			++$end;
 		}
 
@@ -2589,14 +2589,14 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Is this one of the tokens this function handles ?
-		if ( T_STRING !== $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_STRING !== $this->tokens[ $stackPtr ]['code'] ) {
 			return false;
 		}
 
 		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 		if ( false !== $next
-			&& ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code']
-				|| T_DOUBLE_COLON === $this->tokens[ $next ]['code'] )
+			&& ( \T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code']
+				|| \T_DOUBLE_COLON === $this->tokens[ $next ]['code'] )
 		) {
 			// Function call or declaration.
 			return false;
@@ -2633,15 +2633,15 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		if ( false !== $prev
-			&& T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
-			&& T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
+			&& \T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
+			&& \T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
 		) {
 			// Namespaced constant of the same name.
 			return false;
 		}
 
 		if ( false !== $prev
-			&& T_CONST === $this->tokens[ $prev ]['code']
+			&& \T_CONST === $this->tokens[ $prev ]['code']
 			&& $this->is_class_constant( $prev )
 		) {
 			// Class constant declaration of the same name.
@@ -2658,13 +2658,13 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		$firstOnLine = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
-		if ( false !== $firstOnLine && T_USE === $this->tokens[ $firstOnLine ]['code'] ) {
+		if ( false !== $firstOnLine && \T_USE === $this->tokens[ $firstOnLine ]['code'] ) {
 			$nextOnLine = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $firstOnLine + 1 ), null, true );
 			if ( false !== $nextOnLine ) {
-				if ( T_STRING === $this->tokens[ $nextOnLine ]['code']
+				if ( \T_STRING === $this->tokens[ $nextOnLine ]['code']
 					&& 'const' === $this->tokens[ $nextOnLine ]['content']
 				) {
-					$hasNsSep = $this->phpcsFile->findNext( T_NS_SEPARATOR, ( $nextOnLine + 1 ), $stackPtr );
+					$hasNsSep = $this->phpcsFile->findNext( \T_NS_SEPARATOR, ( $nextOnLine + 1 ), $stackPtr );
 					if ( false !== $hasNsSep ) {
 						// Namespaced const (group) use statement.
 						return false;

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -62,8 +62,8 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 	 * @var array
 	 */
 	private $targets = array(
-		T_ARRAY            => T_ARRAY,
-		T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
+		\T_ARRAY            => \T_ARRAY,
+		\T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
 	);
 
 	/**
@@ -104,13 +104,13 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Long arrays only: Check for space between the array keyword and the open parenthesis.
 		 */
-		if ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
 
 			if ( ( $stackPtr + 1 ) !== $opener ) {
 				$error      = 'There must be no space between the "array" keyword and the opening parenthesis';
 				$error_code = 'SpaceAfterKeyword';
 
-				$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), ( $opener + 1 ), true );
+				$nextNonWhitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), ( $opener + 1 ), true );
 				if ( $nextNonWhitespace !== $opener ) {
 					// Don't auto-fix: Something other than whitespace found between keyword and open parenthesis.
 					$this->phpcsFile->addError( $error, $stackPtr, $error_code );
@@ -134,7 +134,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Check for empty arrays.
 		 */
-		$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $opener + 1 ), ( $closer + 1 ), true );
+		$nextNonWhitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $opener + 1 ), ( $closer + 1 ), true );
 		if ( $nextNonWhitespace === $closer ) {
 
 			if ( ( $opener + 1 ) !== $closer ) {
@@ -183,7 +183,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Check that associative arrays are always multi-line.
 		 */
-		$array_has_keys = $this->phpcsFile->findNext( T_DOUBLE_ARROW, $opener, $closer );
+		$array_has_keys = $this->phpcsFile->findNext( \T_DOUBLE_ARROW, $opener, $closer );
 		if ( false !== $array_has_keys ) {
 
 			$array_items = $this->get_function_call_parameters( $stackPtr );
@@ -199,7 +199,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 				$array_has_keys = false; // Reset before doing more detailed check.
 				foreach ( $array_items as $item ) {
 					for ( $ptr = $item['start']; $ptr <= $item['end']; $ptr++ ) {
-						if ( T_DOUBLE_ARROW === $this->tokens[ $ptr ]['code'] ) {
+						if ( \T_DOUBLE_ARROW === $this->tokens[ $ptr ]['code'] ) {
 							$array_has_keys = true;
 							break 2;
 						}
@@ -251,7 +251,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 							}
 
 							if ( $item['start'] <= ( $first_non_empty - 1 )
-								&& T_WHITESPACE === $this->tokens[ ( $first_non_empty - 1 ) ]['code']
+								&& \T_WHITESPACE === $this->tokens[ ( $first_non_empty - 1 ) ]['code']
 							) {
 								// Remove whitespace which would otherwise becoming trailing
 								// (as it gives problems with the fixed file).
@@ -273,7 +273,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Check that there is a single space after the array opener and before the array closer.
 		 */
-		if ( T_WHITESPACE !== $this->tokens[ ( $opener + 1 ) ]['code'] ) {
+		if ( \T_WHITESPACE !== $this->tokens[ ( $opener + 1 ) ]['code'] ) {
 
 			$fix = $this->phpcsFile->addFixableError(
 				'Missing space after array opener.',
@@ -298,7 +298,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 			}
 		}
 
-		if ( T_WHITESPACE !== $this->tokens[ ( $closer - 1 ) ]['code'] ) {
+		if ( \T_WHITESPACE !== $this->tokens[ ( $closer - 1 ) ]['code'] ) {
 
 			$fix = $this->phpcsFile->addFixableError(
 				'Missing space before array closer.',
@@ -340,7 +340,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Check that the closing bracket is on a new line.
 		 */
-		$last_content = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $closer - 1 ), $opener, true );
+		$last_content = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $closer - 1 ), $opener, true );
 		if ( false !== $last_content
 			&& $this->tokens[ $last_content ]['line'] === $this->tokens[ $closer ]['line']
 		) {
@@ -353,7 +353,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 				$this->phpcsFile->fixer->beginChangeset();
 
 				if ( $last_content < ( $closer - 1 )
-					&& T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
+					&& \T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
 				) {
 					// Remove whitespace which would otherwise becoming trailing
 					// (as it gives problems with the fixed file).
@@ -376,18 +376,18 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 
 			// Find the line on which the item starts.
 			$first_content = $this->phpcsFile->findNext(
-				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),
 				$item['start'],
 				$end_of_this_item,
 				true
 			);
 
 			// Ignore comments after array items if the next real content starts on a new line.
-			if ( T_COMMENT === $this->tokens[ $first_content ]['code']
+			if ( \T_COMMENT === $this->tokens[ $first_content ]['code']
 				|| isset( $this->phpcsCommentTokens[ $this->tokens[ $first_content ]['type'] ] )
 			) {
 				$next = $this->phpcsFile->findNext(
-					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+					array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),
 					( $first_content + 1 ),
 					$end_of_this_item,
 					true
@@ -423,7 +423,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 					$this->phpcsFile->fixer->beginChangeset();
 
 					if ( $item['start'] <= ( $first_content - 1 )
-						&& T_WHITESPACE === $this->tokens[ ( $first_content - 1 ) ]['code']
+						&& \T_WHITESPACE === $this->tokens[ ( $first_content - 1 ) ]['code']
 					) {
 						// Remove whitespace which would otherwise becoming trailing
 						// (as it gives problems with the fixed file).

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -71,12 +71,12 @@ class ArrayIndentationSniff extends Sniff {
 		 * Existing heredoc, nowdoc and inline HTML indentation should be respected at all times.
 		 */
 		$this->ignore_tokens = Tokens::$heredocTokens;
-		unset( $this->ignore_tokens[ T_START_HEREDOC ], $this->ignore_tokens[ T_START_NOWDOC ] );
-		$this->ignore_tokens[ T_INLINE_HTML ] = T_INLINE_HTML;
+		unset( $this->ignore_tokens[ \T_START_HEREDOC ], $this->ignore_tokens[ \T_START_NOWDOC ] );
+		$this->ignore_tokens[ \T_INLINE_HTML ] = \T_INLINE_HTML;
 
 		return array(
-			T_ARRAY,
-			T_OPEN_SHORT_ARRAY,
+			\T_ARRAY,
+			\T_OPEN_SHORT_ARRAY,
 		);
 	}
 
@@ -125,7 +125,7 @@ class ArrayIndentationSniff extends Sniff {
 			 * nothing or only indentation whitespace before it.
 			 */
 			if ( 0 === $closer_line_spaces
-				|| ( T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
+				|| ( \T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
 					&& 1 === $this->tokens[ ( $closer - 1 ) ]['column'] )
 			) {
 				$this->add_array_alignment_error(
@@ -172,7 +172,7 @@ class ArrayIndentationSniff extends Sniff {
 
 			// Find the line on which the item starts.
 			$first_content = $this->phpcsFile->findNext(
-				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),
 				$item['start'],
 				$end_of_this_item,
 				true
@@ -180,11 +180,11 @@ class ArrayIndentationSniff extends Sniff {
 
 			// Deal with trailing comments.
 			if ( false !== $first_content
-				&& T_COMMENT === $this->tokens[ $first_content ]['code']
+				&& \T_COMMENT === $this->tokens[ $first_content ]['code']
 				&& $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
 			) {
 				$first_content = $this->phpcsFile->findNext(
-					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE, T_COMMENT ),
+					array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE, \T_COMMENT ),
 					( $first_content + 1 ),
 					$end_of_this_item,
 					true
@@ -200,7 +200,7 @@ class ArrayIndentationSniff extends Sniff {
 			// That is handled by the ArrayDeclarationSpacingSniff.
 			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
 				|| ( 1 !== $this->tokens[ $first_content ]['column']
-					&& T_WHITESPACE !== $this->tokens[ ( $first_content - 1 ) ]['code'] )
+					&& \T_WHITESPACE !== $this->tokens[ ( $first_content - 1 ) ]['code'] )
 			) {
 				return $closer;
 			}
@@ -247,7 +247,7 @@ class ArrayIndentationSniff extends Sniff {
 			}
 
 			$first_content_on_line2 = $this->phpcsFile->findNext(
-				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),
 				$ptr,
 				$end_of_this_item,
 				true
@@ -261,7 +261,7 @@ class ArrayIndentationSniff extends Sniff {
 				 * so check its placement.
 				 */
 				if ( $this->tokens[ $item['end'] ]['line'] !== $this->tokens[ $end_of_this_item ]['line']
-					&& T_COMMA === $this->tokens[ $end_of_this_item ]['code']
+					&& \T_COMMA === $this->tokens[ $end_of_this_item ]['code']
 					&& ( $this->tokens[ $end_of_this_item ]['column'] - 1 ) !== $expected_spaces
 				) {
 					$this->add_array_alignment_error(
@@ -304,7 +304,7 @@ class ArrayIndentationSniff extends Sniff {
 
 					// Fix second line for the array item.
 					if ( 1 === $this->tokens[ $first_content_on_line2 ]['column']
-						&& T_COMMENT === $this->tokens[ $first_content_on_line2 ]['code']
+						&& \T_COMMENT === $this->tokens[ $first_content_on_line2 ]['code']
 					) {
 						$actual_comment = ltrim( $this->tokens[ $first_content_on_line2 ]['content'] );
 						$replacement    = $expected_indent_on_line2 . $actual_comment;
@@ -327,7 +327,7 @@ class ArrayIndentationSniff extends Sniff {
 						}
 
 						$first_content_on_line = $this->phpcsFile->findNext(
-							array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+							array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),
 							$i,
 							$end_of_this_item,
 							true
@@ -350,7 +350,7 @@ class ArrayIndentationSniff extends Sniff {
 
 						if ( $found_spaces_on_line !== $expected_spaces_on_line ) {
 							if ( 1 === $this->tokens[ $first_content_on_line ]['column']
-								&& T_COMMENT === $this->tokens[ $first_content_on_line ]['code']
+								&& \T_COMMENT === $this->tokens[ $first_content_on_line ]['code']
 							) {
 								$actual_comment = ltrim( $this->tokens[ $first_content_on_line ]['content'] );
 								$replacement    = $expected_indent_on_line . $actual_comment;
@@ -370,7 +370,7 @@ class ArrayIndentationSniff extends Sniff {
 					 * Check the placement of the comma after the array item as it might be on a line by itself.
 					 */
 					if ( $this->tokens[ $item['end'] ]['line'] !== $this->tokens[ $end_of_this_item ]['line']
-						&& T_COMMA === $this->tokens[ $end_of_this_item ]['code']
+						&& \T_COMMA === $this->tokens[ $end_of_this_item ]['code']
 						&& ( $this->tokens[ $end_of_this_item ]['column'] - 1 ) !== $expected_spaces
 					) {
 						$this->add_array_alignment_error(
@@ -412,8 +412,8 @@ class ArrayIndentationSniff extends Sniff {
 		 * If it's a subsequent line of a multi-line sting, it will not start with a quote
 		 * character, nor just *be* a quote character.
 		 */
-		if ( T_CONSTANT_ENCAPSED_STRING === $token_code
-			|| T_DOUBLE_QUOTED_STRING === $token_code
+		if ( \T_CONSTANT_ENCAPSED_STRING === $token_code
+			|| \T_DOUBLE_QUOTED_STRING === $token_code
 		) {
 			// Deal with closing quote of a multi-line string being on its own line.
 			if ( "'" === $this->tokens[ $ptr ]['content']
@@ -451,8 +451,8 @@ class ArrayIndentationSniff extends Sniff {
 
 		$whitespace = '';
 
-		if ( T_WHITESPACE === $this->tokens[ $ptr ]['code']
-			|| T_DOC_COMMENT_WHITESPACE === $this->tokens[ $ptr ]['code']
+		if ( \T_WHITESPACE === $this->tokens[ $ptr ]['code']
+			|| \T_DOC_COMMENT_WHITESPACE === $this->tokens[ $ptr ]['code']
 		) {
 			return $this->tokens[ $ptr ]['length'];
 		}
@@ -464,7 +464,7 @@ class ArrayIndentationSniff extends Sniff {
 		 * First/Single line is tokenized as T_WHITESPACE + T_COMMENT
 		 * Subsequent lines are tokenized as T_COMMENT including the indentation whitespace.
 		 */
-		if ( T_COMMENT === $this->tokens[ $ptr ]['code'] ) {
+		if ( \T_COMMENT === $this->tokens[ $ptr ]['code'] ) {
 			$content        = $this->tokens[ $ptr ]['content'];
 			$actual_comment = ltrim( $content );
 			$whitespace     = str_replace( $actual_comment, '', $content );

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -32,7 +32,7 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_OPEN_SQUARE_BRACKET,
+			\T_OPEN_SQUARE_BRACKET,
 		);
 	}
 
@@ -52,14 +52,14 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 		}
 
 		$need_spaces = $this->phpcsFile->findNext(
-			array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_WHITESPACE, T_MINUS ),
+			array( \T_CONSTANT_ENCAPSED_STRING, \T_LNUMBER, \T_WHITESPACE, \T_MINUS ),
 			( $stackPtr + 1 ),
 			$token['bracket_closer'],
 			true
 		);
 
-		$spaced1 = ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] );
-		$spaced2 = ( T_WHITESPACE === $this->tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
+		$spaced1 = ( \T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] );
+		$spaced2 = ( \T_WHITESPACE === $this->tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
 
 		// It should have spaces unless if it only has strings or numbers as the key.
 		if ( false !== $need_spaces && ! ( $spaced1 && $spaced2 ) ) {

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -38,8 +38,8 @@ class CommaAfterArrayItemSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_ARRAY,
-			T_OPEN_SHORT_ARRAY,
+			\T_ARRAY,
+			\T_OPEN_SHORT_ARRAY,
 		);
 	}
 
@@ -86,7 +86,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 		foreach ( $array_items as $item_index => $item ) {
 			$maybe_comma = ( $item['end'] + 1 );
 			$is_comma    = false;
-			if ( isset( $this->tokens[ $maybe_comma ] ) && T_COMMA === $this->tokens[ $maybe_comma ]['code'] ) {
+			if ( isset( $this->tokens[ $maybe_comma ] ) && \T_COMMA === $this->tokens[ $maybe_comma ]['code'] ) {
 				$is_comma = true;
 			}
 
@@ -162,13 +162,13 @@ class CommaAfterArrayItemSniff extends Sniff {
 				$spaces   = 0;
 				for ( $i = $item['end']; $i > $last_content; $i-- ) {
 
-					if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+					if ( \T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
 						if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
 							$newlines++;
 						} else {
 							$spaces += $this->tokens[ $i ]['length'];
 						}
-					} elseif ( T_COMMENT === $this->tokens[ $i ]['code']
+					} elseif ( \T_COMMENT === $this->tokens[ $i ]['code']
 						|| isset( $this->phpcsCommentTokens[ $this->tokens[ $i ]['type'] ] )
 					) {
 						break;
@@ -198,10 +198,10 @@ class CommaAfterArrayItemSniff extends Sniff {
 					$this->phpcsFile->fixer->beginChangeset();
 					for ( $i = $item['end']; $i > $last_content; $i-- ) {
 
-						if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+						if ( \T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
 							$this->phpcsFile->fixer->replaceToken( $i, '' );
 
-						} elseif ( T_COMMENT === $this->tokens[ $i ]['code']
+						} elseif ( \T_COMMENT === $this->tokens[ $i ]['code']
 							|| isset( $this->phpcsCommentTokens[ $this->tokens[ $i ]['type'] ] )
 						) {
 							// We need to move the comma to before the comment.
@@ -231,14 +231,14 @@ class CommaAfterArrayItemSniff extends Sniff {
 			 */
 			$next_token = $this->tokens[ ( $maybe_comma + 1 ) ];
 
-			if ( T_WHITESPACE === $next_token['code'] ) {
+			if ( \T_WHITESPACE === $next_token['code'] ) {
 
 				if ( false === $single_line && $this->phpcsFile->eolChar === $next_token['content'] ) {
 					continue;
 				}
 
 				$next_non_whitespace = $this->phpcsFile->findNext(
-					T_WHITESPACE,
+					\T_WHITESPACE,
 					( $maybe_comma + 1 ),
 					$closer,
 					true
@@ -247,7 +247,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 				if ( false === $next_non_whitespace
 					|| ( false === $single_line
 						&& $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $maybe_comma ]['line']
-						&& ( T_COMMENT === $this->tokens[ $next_non_whitespace ]['code']
+						&& ( \T_COMMENT === $this->tokens[ $next_non_whitespace ]['code']
 							|| isset( $this->phpcsCommentTokens[ $this->tokens[ $next_non_whitespace ]['type'] ] ) ) )
 				) {
 					continue;

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -148,8 +148,8 @@ class MultipleStatementAlignmentSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_ARRAY,
-			T_OPEN_SHORT_ARRAY,
+			\T_ARRAY,
+			\T_OPEN_SHORT_ARRAY,
 		);
 	}
 
@@ -216,13 +216,13 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		 * Just find and fix them all.
 		 */
 		$next_arrow = $this->phpcsFile->findNext(
-			T_DOUBLE_ARROW,
+			\T_DOUBLE_ARROW,
 			( $opener + 1 ),
 			$closer
 		);
 
 		while ( false !== $next_arrow ) {
-			if ( T_WHITESPACE === $this->tokens[ ( $next_arrow - 1 ) ]['code'] ) {
+			if ( \T_WHITESPACE === $this->tokens[ ( $next_arrow - 1 ) ]['code'] ) {
 				$space_length = $this->tokens[ ( $next_arrow - 1 ) ]['length'];
 				if ( 1 !== $space_length ) {
 					$error = 'Expected 1 space between "%s" and double arrow; %s found';
@@ -240,7 +240,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 
 			// Find the position of the next double arrow.
 			$next_arrow = $this->phpcsFile->findNext(
-				T_DOUBLE_ARROW,
+				\T_DOUBLE_ARROW,
 				( $next_arrow + 1 ),
 				$closer
 			);
@@ -293,7 +293,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 
 			// Find the position of the first double arrow.
 			$double_arrow = $this->phpcsFile->findNext(
-				T_DOUBLE_ARROW,
+				\T_DOUBLE_ARROW,
 				$item['start'],
 				( $item['end'] + 1 )
 			);
@@ -319,7 +319,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 
 			// Find the end of the array key.
 			$last_index_token = $this->phpcsFile->findPrevious(
-				T_WHITESPACE,
+				\T_WHITESPACE,
 				( $double_arrow - 1 ),
 				$item['start'],
 				true
@@ -424,7 +424,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 			 * If the alignment does not have to be exact, see if a majority
 			 * group of the arrows is already at an acceptable position.
 			 */
-			arsort( $double_arrow_cols, SORT_NUMERIC );
+			arsort( $double_arrow_cols, \SORT_NUMERIC );
 			reset( $double_arrow_cols );
 			$count = current( $double_arrow_cols );
 
@@ -453,7 +453,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				continue;
 			}
 
-			if ( T_WHITESPACE !== $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['code'] ) {
+			if ( \T_WHITESPACE !== $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['code'] ) {
 				$before = 0;
 			} else {
 				if ( $this->tokens[ $item['last_index_token'] ]['line'] !== $this->tokens[ $item['operatorPtr'] ]['line'] ) {

--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -59,26 +59,26 @@ class ClassInstantiationSniff extends Sniff {
 		 *
 		 * Currently does not account for classnames passed as a variable variable.
 		 */
-		$this->classname_tokens                   = Tokens::$emptyTokens;
-		$this->classname_tokens[ T_NS_SEPARATOR ] = T_NS_SEPARATOR;
-		$this->classname_tokens[ T_STRING ]       = T_STRING;
-		$this->classname_tokens[ T_SELF ]         = T_SELF;
-		$this->classname_tokens[ T_STATIC ]       = T_STATIC;
-		$this->classname_tokens[ T_PARENT ]       = T_PARENT;
-		$this->classname_tokens[ T_ANON_CLASS ]   = T_ANON_CLASS;
+		$this->classname_tokens                    = Tokens::$emptyTokens;
+		$this->classname_tokens[ \T_NS_SEPARATOR ] = \T_NS_SEPARATOR;
+		$this->classname_tokens[ \T_STRING ]       = \T_STRING;
+		$this->classname_tokens[ \T_SELF ]         = \T_SELF;
+		$this->classname_tokens[ \T_STATIC ]       = \T_STATIC;
+		$this->classname_tokens[ \T_PARENT ]       = \T_PARENT;
+		$this->classname_tokens[ \T_ANON_CLASS ]   = \T_ANON_CLASS;
 
 		// Classname in a variable.
-		$this->classname_tokens[ T_VARIABLE ]                 = T_VARIABLE;
-		$this->classname_tokens[ T_DOUBLE_COLON ]             = T_DOUBLE_COLON;
-		$this->classname_tokens[ T_OBJECT_OPERATOR ]          = T_OBJECT_OPERATOR;
-		$this->classname_tokens[ T_OPEN_SQUARE_BRACKET ]      = T_OPEN_SQUARE_BRACKET;
-		$this->classname_tokens[ T_CLOSE_SQUARE_BRACKET ]     = T_CLOSE_SQUARE_BRACKET;
-		$this->classname_tokens[ T_CONSTANT_ENCAPSED_STRING ] = T_CONSTANT_ENCAPSED_STRING;
-		$this->classname_tokens[ T_LNUMBER ]                  = T_LNUMBER;
+		$this->classname_tokens[ \T_VARIABLE ]                 = \T_VARIABLE;
+		$this->classname_tokens[ \T_DOUBLE_COLON ]             = \T_DOUBLE_COLON;
+		$this->classname_tokens[ \T_OBJECT_OPERATOR ]          = \T_OBJECT_OPERATOR;
+		$this->classname_tokens[ \T_OPEN_SQUARE_BRACKET ]      = \T_OPEN_SQUARE_BRACKET;
+		$this->classname_tokens[ \T_CLOSE_SQUARE_BRACKET ]     = \T_CLOSE_SQUARE_BRACKET;
+		$this->classname_tokens[ \T_CONSTANT_ENCAPSED_STRING ] = \T_CONSTANT_ENCAPSED_STRING;
+		$this->classname_tokens[ \T_LNUMBER ]                  = \T_LNUMBER;
 
 		return array(
-			T_NEW,
-			T_STRING, // JS.
+			\T_NEW,
+			\T_STRING, // JS.
 		);
 	}
 
@@ -91,9 +91,9 @@ class ClassInstantiationSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		// Make sure we have the right token, JS vs PHP.
-		if ( ( 'PHP' === $this->phpcsFile->tokenizerType && T_NEW !== $this->tokens[ $stackPtr ]['code'] )
+		if ( ( 'PHP' === $this->phpcsFile->tokenizerType && \T_NEW !== $this->tokens[ $stackPtr ]['code'] )
 			|| ( 'JS' === $this->phpcsFile->tokenizerType
-				&& ( T_STRING !== $this->tokens[ $stackPtr ]['code']
+				&& ( \T_STRING !== $this->tokens[ $stackPtr ]['code']
 				|| 'new' !== strtolower( $this->tokens[ $stackPtr ]['content'] ) ) )
 		) {
 			return;
@@ -152,12 +152,12 @@ class ClassInstantiationSniff extends Sniff {
 				break;
 			}
 
-			if ( T_WHITESPACE !== $this->tokens[ $classname_ptr ]['code'] ) {
+			if ( \T_WHITESPACE !== $this->tokens[ $classname_ptr ]['code'] ) {
 				$has_comment = true;
 			}
 		}
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty_after_class_name ]['code'] ) {
+		if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty_after_class_name ]['code'] ) {
 			$this->phpcsFile->recordMetric( $stackPtr, 'Object instantiation with parenthesis', 'no' );
 
 			$fix = $this->phpcsFile->addFixableError(

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -59,23 +59,23 @@ class AssignmentInConditionSniff extends Sniff {
 	 */
 	public function register() {
 		$this->assignment_tokens = Tokens::$assignmentTokens;
-		unset( $this->assignment_tokens[ T_DOUBLE_ARROW ] );
+		unset( $this->assignment_tokens[ \T_DOUBLE_ARROW ] );
 
-		$starters                       = Tokens::$booleanOperators;
-		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
-		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
-		$starters[ T_INLINE_ELSE ]      = T_INLINE_ELSE;
+		$starters                        = Tokens::$booleanOperators;
+		$starters[ \T_SEMICOLON ]        = \T_SEMICOLON;
+		$starters[ \T_OPEN_PARENTHESIS ] = \T_OPEN_PARENTHESIS;
+		$starters[ \T_INLINE_ELSE ]      = \T_INLINE_ELSE;
 
 		$this->condition_start_tokens = $starters;
 
 		return array(
-			T_IF,
-			T_ELSEIF,
-			T_FOR,
-			T_SWITCH,
-			T_CASE,
-			T_WHILE,
-			T_INLINE_THEN,
+			\T_IF,
+			\T_ELSEIF,
+			\T_FOR,
+			\T_SWITCH,
+			\T_CASE,
+			\T_WHILE,
+			\T_INLINE_THEN,
 		);
 	}
 
@@ -93,18 +93,18 @@ class AssignmentInConditionSniff extends Sniff {
 		$token = $this->tokens[ $stackPtr ];
 
 		// Find the condition opener/closer.
-		if ( T_FOR === $token['code'] ) {
+		if ( \T_FOR === $token['code'] ) {
 			if ( isset( $token['parenthesis_opener'], $token['parenthesis_closer'] ) === false ) {
 				return;
 			}
 
-			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $token['parenthesis_opener'] + 1 ), $token['parenthesis_closer'] );
+			$semicolon = $this->phpcsFile->findNext( \T_SEMICOLON, ( $token['parenthesis_opener'] + 1 ), $token['parenthesis_closer'] );
 			if ( false === $semicolon ) {
 				return;
 			}
 
 			$opener    = $semicolon;
-			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $opener + 1 ), $token['parenthesis_closer'] );
+			$semicolon = $this->phpcsFile->findNext( \T_SEMICOLON, ( $opener + 1 ), $token['parenthesis_closer'] );
 			if ( false === $semicolon ) {
 				return;
 			}
@@ -112,7 +112,7 @@ class AssignmentInConditionSniff extends Sniff {
 			$closer = $semicolon;
 			unset( $semicolon );
 
-		} elseif ( T_CASE === $token['code'] ) {
+		} elseif ( \T_CASE === $token['code'] ) {
 			if ( isset( $token['scope_opener'] ) === false ) {
 				return;
 			}
@@ -120,7 +120,7 @@ class AssignmentInConditionSniff extends Sniff {
 			$opener = $stackPtr;
 			$closer = $token['scope_opener'];
 
-		} elseif ( T_INLINE_THEN === $token['code'] ) {
+		} elseif ( \T_INLINE_THEN === $token['code'] ) {
 			// Check if the condition for the ternary is bracketed.
 			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 			if ( false === $prev ) {
@@ -128,7 +128,7 @@ class AssignmentInConditionSniff extends Sniff {
 				return;
 			}
 
-			if ( T_CLOSE_PARENTHESIS === $this->tokens[ $prev ]['code'] ) {
+			if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $prev ]['code'] ) {
 				if ( ! isset( $this->tokens[ $prev ]['parenthesis_opener'] ) ) {
 					return;
 				}
@@ -139,13 +139,13 @@ class AssignmentInConditionSniff extends Sniff {
 				$closer = end( $token['nested_parenthesis'] );
 				$opener = key( $token['nested_parenthesis'] );
 
-				$next_statement_closer = $this->phpcsFile->findEndOfStatement( $stackPtr, array( T_COLON, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET ) );
+				$next_statement_closer = $this->phpcsFile->findEndOfStatement( $stackPtr, array( \T_COLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_SQUARE_BRACKET ) );
 				if ( false !== $next_statement_closer && $next_statement_closer < $closer ) {
 					// Parentheses are unrelated to the ternary.
 					return;
 				}
 
-				$prev_statement_closer = $this->phpcsFile->findStartOfStatement( $stackPtr, array( T_COLON, T_OPEN_PARENTHESIS, T_OPEN_SQUARE_BRACKET ) );
+				$prev_statement_closer = $this->phpcsFile->findStartOfStatement( $stackPtr, array( \T_COLON, \T_OPEN_PARENTHESIS, \T_OPEN_SQUARE_BRACKET ) );
 				if ( false !== $prev_statement_closer && $opener < $prev_statement_closer ) {
 					// Parentheses are unrelated to the ternary.
 					return;
@@ -193,24 +193,24 @@ class AssignmentInConditionSniff extends Sniff {
 				}
 
 				// If this is a variable or array, we've seen all we need to see.
-				if ( T_VARIABLE === $this->tokens[ $i ]['code']
-					|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+				if ( \T_VARIABLE === $this->tokens[ $i ]['code']
+					|| \T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
 				) {
 					$hasVariable = true;
 					break;
 				}
 
 				// If this is a function call or something, we are OK.
-				if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+				if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 					break;
 				}
 			}
 
 			if ( true === $hasVariable ) {
 				$errorCode = 'Found';
-				if ( T_WHILE === $token['code'] ) {
+				if ( \T_WHILE === $token['code'] ) {
 					$errorCode = 'FoundInWhileCondition';
-				} elseif ( T_INLINE_THEN === $token['code'] ) {
+				} elseif ( \T_INLINE_THEN === $token['code'] ) {
 					$errorCode = 'FoundInTernaryCondition';
 				}
 

--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -38,8 +38,8 @@ class EmptyStatementSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_SEMICOLON,
-			T_CLOSE_TAG,
+			\T_SEMICOLON,
+			\T_CLOSE_TAG,
 		);
 	}
 
@@ -65,9 +65,9 @@ class EmptyStatementSniff extends Sniff {
 				);
 
 				if ( false === $prevNonEmpty
-					|| ( T_SEMICOLON !== $this->tokens[ $prevNonEmpty ]['code']
-						&& T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code']
-						&& T_OPEN_TAG_WITH_ECHO !== $this->tokens[ $prevNonEmpty ]['code'] )
+					|| ( \T_SEMICOLON !== $this->tokens[ $prevNonEmpty ]['code']
+						&& \T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code']
+						&& \T_OPEN_TAG_WITH_ECHO !== $this->tokens[ $prevNonEmpty ]['code'] )
 				) {
 					return;
 				}
@@ -80,8 +80,8 @@ class EmptyStatementSniff extends Sniff {
 				if ( true === $fix ) {
 					$this->phpcsFile->fixer->beginChangeset();
 
-					if ( T_OPEN_TAG === $this->tokens[ $prevNonEmpty ]['code']
-						|| T_OPEN_TAG_WITH_ECHO === $this->tokens[ $prevNonEmpty ]['code']
+					if ( \T_OPEN_TAG === $this->tokens[ $prevNonEmpty ]['code']
+						|| \T_OPEN_TAG_WITH_ECHO === $this->tokens[ $prevNonEmpty ]['code']
 					) {
 						/*
 						 * Check for superfluous whitespace after the semi-colon which will be
@@ -89,15 +89,15 @@ class EmptyStatementSniff extends Sniff {
 						 * either a space or a new line and in case of a new line, the indentation
 						 * should be done via tabs, so spaces can be safely removed.
 						 */
-						if ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+						if ( \T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 							$replacement = str_replace( ' ', '', $this->tokens[ ( $stackPtr + 1 ) ]['content'] );
 							$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $replacement );
 						}
 					}
 
 					for ( $i = $stackPtr; $i > $prevNonEmpty; $i-- ) {
-						if ( T_SEMICOLON !== $this->tokens[ $i ]['code']
-							&& T_WHITESPACE !== $this->tokens[ $i ]['code']
+						if ( \T_SEMICOLON !== $this->tokens[ $i ]['code']
+							&& \T_WHITESPACE !== $this->tokens[ $i ]['code']
 						) {
 							break;
 						}
@@ -113,15 +113,15 @@ class EmptyStatementSniff extends Sniff {
 			 */
 			case 'T_CLOSE_TAG':
 				$prevNonEmpty = $this->phpcsFile->findPrevious(
-					T_WHITESPACE,
+					\T_WHITESPACE,
 					( $stackPtr - 1 ),
 					null,
 					true
 				);
 
 				if ( false === $prevNonEmpty
-					|| ( T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code']
-						&& T_OPEN_TAG_WITH_ECHO !== $this->tokens[ $prevNonEmpty ]['code'] )
+					|| ( \T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code']
+						&& \T_OPEN_TAG_WITH_ECHO !== $this->tokens[ $prevNonEmpty ]['code'] )
 				) {
 					return;
 				}

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -101,7 +101,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_VARIABLE,
+			\T_VARIABLE,
 		);
 	}
 
@@ -119,12 +119,12 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$is_object_call = $this->phpcsFile->findNext( T_OBJECT_OPERATOR, ( $stackPtr + 1 ), null, false, null, true );
+		$is_object_call = $this->phpcsFile->findNext( \T_OBJECT_OPERATOR, ( $stackPtr + 1 ), null, false, null, true );
 		if ( false === $is_object_call ) {
 			return; // This is not a call to the wpdb object.
 		}
 
-		$methodPtr = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
+		$methodPtr = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
 		$method    = $this->tokens[ $methodPtr ]['content'];
 
 		$this->mergeFunctionLists();
@@ -133,7 +133,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$endOfStatement   = $this->phpcsFile->findNext( T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
+		$endOfStatement   = $this->phpcsFile->findNext( \T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
 		$endOfLineComment = '';
 		for ( $i = ( $endOfStatement + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
 
@@ -141,7 +141,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 				break;
 			}
 
-			if ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+			if ( \T_COMMENT === $this->tokens[ $i ]['code'] ) {
 				$endOfLineComment .= $this->tokens[ $i ]['content'];
 			}
 		}
@@ -179,10 +179,10 @@ class DirectDatabaseQuerySniff extends Sniff {
 			$whitelisted_cache = true;
 		}
 		if ( ! $whitelisted_cache && ! empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
-			$scope_function = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			$scope_function = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 
 			if ( false === $scope_function ) {
-				$scope_function = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+				$scope_function = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
 			}
 
 			if ( false !== $scope_function ) {
@@ -190,7 +190,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 				$scopeEnd   = $this->tokens[ $scope_function ]['scope_closer'];
 
 				for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
-					if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+					if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 
 						if ( isset( $this->cacheDeleteFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
 

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -154,8 +154,8 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_VARIABLE,
-			T_STRING,
+			\T_VARIABLE,
+			\T_STRING,
 		);
 	}
 
@@ -199,7 +199,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			if ( ! isset( Tokens::$textStringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
-				if ( T_VARIABLE === $this->tokens[ $i ]['code'] ) {
+				if ( \T_VARIABLE === $this->tokens[ $i ]['code'] ) {
 					if ( '$wpdb' !== $this->tokens[ $i ]['content'] ) {
 						$variable_found = true;
 					}
@@ -207,7 +207,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				}
 
 				// Detect a specific pattern for variable replacements in combination with `IN`.
-				if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+				if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 
 					if ( 'sprintf' === strtolower( $this->tokens[ $i ]['content'] ) ) {
 						$sprintf_parameters = $this->get_function_call_parameters( $i );
@@ -248,7 +248,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 								++$valid_in_clauses['implode_fill'];
 
 								$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
-								if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code']
+								if ( \T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code']
 									&& isset( $this->tokens[ $next ]['parenthesis_closer'] )
 								) {
 									$skip_from = ( $i + 1 );
@@ -272,8 +272,8 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				$regex_quote = $this->get_regex_quote_snippet( $content, $this->tokens[ $i ]['content'] );
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code']
-				|| T_HEREDOC === $this->tokens[ $i ]['code']
+			if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code']
+				|| \T_HEREDOC === $this->tokens[ $i ]['code']
 			) {
 				// Only interested in actual query text, so strip out variables.
 				$stripped_content = $this->strip_interpolated_variables( $content );
@@ -503,8 +503,8 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			);
 
 			if ( false !== $next
-				&& ( T_ARRAY === $this->tokens[ $next ]['code']
-					|| T_OPEN_SHORT_ARRAY === $this->tokens[ $next ]['code'] )
+				&& ( \T_ARRAY === $this->tokens[ $next ]['code']
+					|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $next ]['code'] )
 			) {
 				$replacements = $this->get_function_call_parameters( $next );
 			}
@@ -594,7 +594,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				$sprintf_param['end'],
 				true
 			);
-			if ( T_STRING === $this->tokens[ $implode ]['code']
+			if ( \T_STRING === $this->tokens[ $implode ]['code']
 				&& 'implode' === strtolower( $this->tokens[ $implode ]['content'] )
 			) {
 				if ( $this->analyse_implode( $implode ) === true ) {
@@ -643,7 +643,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			true
 		);
 
-		if ( T_STRING !== $this->tokens[ $array_fill ]['code']
+		if ( \T_STRING !== $this->tokens[ $array_fill ]['code']
 			|| 'array_fill' !== strtolower( $this->tokens[ $array_fill ]['content'] )
 		) {
 			return false;

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -52,23 +52,23 @@ class PreparedSQLSniff extends Sniff {
 	 * @var array
 	 */
 	protected $ignored_tokens = array(
-		T_OBJECT_OPERATOR          => true,
-		T_OPEN_PARENTHESIS         => true,
-		T_CLOSE_PARENTHESIS        => true,
-		T_STRING_CONCAT            => true,
-		T_CONSTANT_ENCAPSED_STRING => true,
-		T_OPEN_SQUARE_BRACKET      => true,
-		T_CLOSE_SQUARE_BRACKET     => true,
-		T_COMMA                    => true,
-		T_LNUMBER                  => true,
-		T_START_HEREDOC            => true,
-		T_END_HEREDOC              => true,
-		T_START_NOWDOC             => true,
-		T_NOWDOC                   => true,
-		T_END_NOWDOC               => true,
-		T_INT_CAST                 => true,
-		T_DOUBLE_CAST              => true,
-		T_BOOL_CAST                => true,
+		\T_OBJECT_OPERATOR          => true,
+		\T_OPEN_PARENTHESIS         => true,
+		\T_CLOSE_PARENTHESIS        => true,
+		\T_STRING_CONCAT            => true,
+		\T_CONSTANT_ENCAPSED_STRING => true,
+		\T_OPEN_SQUARE_BRACKET      => true,
+		\T_CLOSE_SQUARE_BRACKET     => true,
+		\T_COMMA                    => true,
+		\T_LNUMBER                  => true,
+		\T_START_HEREDOC            => true,
+		\T_END_HEREDOC              => true,
+		\T_START_NOWDOC             => true,
+		\T_NOWDOC                   => true,
+		\T_END_NOWDOC               => true,
+		\T_INT_CAST                 => true,
+		\T_DOUBLE_CAST              => true,
+		\T_BOOL_CAST                => true,
 	);
 
 	/**
@@ -105,8 +105,8 @@ class PreparedSQLSniff extends Sniff {
 		$this->ignored_tokens = $this->ignored_tokens + Tokens::$emptyTokens;
 
 		return array(
-			T_VARIABLE,
-			T_STRING,
+			\T_VARIABLE,
+			\T_STRING,
 		);
 	}
 
@@ -136,8 +136,8 @@ class PreparedSQLSniff extends Sniff {
 				continue;
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code']
-				|| T_HEREDOC === $this->tokens[ $this->i ]['code']
+			if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code']
+				|| \T_HEREDOC === $this->tokens[ $this->i ]['code']
 			) {
 
 				$bad_variables = array_filter(
@@ -161,7 +161,7 @@ class PreparedSQLSniff extends Sniff {
 				continue;
 			}
 
-			if ( T_VARIABLE === $this->tokens[ $this->i ]['code'] ) {
+			if ( \T_VARIABLE === $this->tokens[ $this->i ]['code'] ) {
 				if ( '$wpdb' === $this->tokens[ $this->i ]['content'] ) {
 					$this->is_wpdb_method_call( $this->i, $this->methods );
 					continue;
@@ -172,7 +172,7 @@ class PreparedSQLSniff extends Sniff {
 				}
 			}
 
-			if ( T_STRING === $this->tokens[ $this->i ]['code'] ) {
+			if ( \T_STRING === $this->tokens[ $this->i ]['code'] ) {
 
 				if (
 					isset( $this->SQLEscapingFunctions[ $this->tokens[ $this->i ]['content'] ] )
@@ -183,7 +183,7 @@ class PreparedSQLSniff extends Sniff {
 					$opening_paren = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $this->i + 1 ), null, true, null, true );
 
 					if ( false !== $opening_paren
-						&& T_OPEN_PARENTHESIS === $this->tokens[ $opening_paren ]['code']
+						&& \T_OPEN_PARENTHESIS === $this->tokens[ $opening_paren ]['code']
 						&& isset( $this->tokens[ $opening_paren ]['parenthesis_closer'] )
 					) {
 						// Skip past the end of the function.

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -68,7 +68,7 @@ class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			 * Only throw the warning about a deprecated comment when the sniff would otherwise
 			 * have been triggered on the array key.
 			 */
-			if ( in_array( $this->tokens[ $stackPtr ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( in_array( $this->tokens[ $stackPtr ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				$this->phpcsFile->addWarning(
 					'The "tax_query" whitelist comment is deprecated in favor of the "slow query" whitelist comment.',
 					$stackPtr,

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -123,8 +123,8 @@ class FileNameSniff extends Sniff {
 		}
 
 		return array(
-			T_OPEN_TAG,
-			T_OPEN_TAG_WITH_ECHO,
+			\T_OPEN_TAG,
+			\T_OPEN_TAG_WITH_ECHO,
 		);
 	}
 
@@ -145,16 +145,16 @@ class FileNameSniff extends Sniff {
 		}
 
 		// Respect phpcs:disable comments as long as they are not accompanied by an enable (PHPCS 3.2+).
-		if ( defined( 'T_PHPCS_DISABLE' ) && defined( 'T_PHPCS_ENABLE' ) ) {
+		if ( defined( '\T_PHPCS_DISABLE' ) && defined( '\T_PHPCS_ENABLE' ) ) {
 			$i = -1;
-			while ( $i = $this->phpcsFile->findNext( T_PHPCS_DISABLE, ( $i + 1 ) ) ) {
+			while ( $i = $this->phpcsFile->findNext( \T_PHPCS_DISABLE, ( $i + 1 ) ) ) {
 				if ( empty( $this->tokens[ $i ]['sniffCodes'] )
 					|| isset( $this->tokens[ $i ]['sniffCodes']['WordPress'] )
 					|| isset( $this->tokens[ $i ]['sniffCodes']['WordPress.Files'] )
 					|| isset( $this->tokens[ $i ]['sniffCodes']['WordPress.Files.FileName'] )
 				) {
 					do {
-						$i = $this->phpcsFile->findNext( T_PHPCS_ENABLE, ( $i + 1 ) );
+						$i = $this->phpcsFile->findNext( \T_PHPCS_ENABLE, ( $i + 1 ) );
 					} while ( false !== $i
 						&& ! empty( $this->tokens[ $i ]['sniffCodes'] )
 						&& ! isset( $this->tokens[ $i ]['sniffCodes']['WordPress'] )
@@ -190,7 +190,7 @@ class FileNameSniff extends Sniff {
 		 * the file name reflects the class name.
 		 */
 		if ( true === $this->strict_class_file_names ) {
-			$has_class = $this->phpcsFile->findNext( T_CLASS, $stackPtr );
+			$has_class = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
 			if ( false !== $has_class && false === $this->is_test_class( $has_class ) ) {
 				$class_name = $this->phpcsFile->getDeclarationName( $has_class );
 				$expected   = 'class-' . strtolower( str_replace( '_', '-', $class_name ) );
@@ -213,13 +213,13 @@ class FileNameSniff extends Sniff {
 		/*
 		 * Check non-class files in "wp-includes" with a "@subpackage Template" tag for a "-template" suffix.
 		 */
-		if ( false !== strpos( $file, DIRECTORY_SEPARATOR . 'wp-includes' . DIRECTORY_SEPARATOR ) ) {
-			$subpackage_tag = $this->phpcsFile->findNext( T_DOC_COMMENT_TAG, $stackPtr, null, false, '@subpackage' );
+		if ( false !== strpos( $file, \DIRECTORY_SEPARATOR . 'wp-includes' . \DIRECTORY_SEPARATOR ) ) {
+			$subpackage_tag = $this->phpcsFile->findNext( \T_DOC_COMMENT_TAG, $stackPtr, null, false, '@subpackage' );
 			if ( false !== $subpackage_tag ) {
-				$subpackage = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, $subpackage_tag );
+				$subpackage = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, $subpackage_tag );
 				if ( false !== $subpackage ) {
 					$fileName_end = substr( $fileName, -13 );
-					$has_class    = $this->phpcsFile->findNext( T_CLASS, $stackPtr );
+					$has_class    = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
 
 					if ( ( 'Template' === trim( $this->tokens[ $subpackage ]['content'] )
 						&& $this->tokens[ $subpackage_tag ]['line'] === $this->tokens[ $subpackage ]['line'] )

--- a/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -45,7 +45,7 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 		// Find the next non-empty token.
 		$openParenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openParenthesis ]['code'] ) {
+		if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $openParenthesis ]['code'] ) {
 			// Not a function call.
 			return;
 		}
@@ -57,9 +57,9 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 
 		// Find the previous non-empty token.
 		$search   = Tokens::$emptyTokens;
-		$search[] = T_BITWISE_AND;
+		$search[] = \T_BITWISE_AND;
 		$previous = $this->phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
-		if ( T_FUNCTION === $this->tokens[ $previous ]['code'] ) {
+		if ( \T_FUNCTION === $this->tokens[ $previous ]['code'] ) {
 			// It's a function definition, not a function call.
 			return;
 		}
@@ -70,7 +70,7 @@ class FunctionCallSignatureNoParamsSniff extends Sniff {
 			return;
 		}
 
-		$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $openParenthesis + 1 ), null, true );
+		$nextNonWhitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $openParenthesis + 1 ), null, true );
 
 		if ( $nextNonWhitespace !== $closer ) {
 			// Function has params or comment between parenthesis.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -166,19 +166,19 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function register() {
 		$targets = array(
-			T_FUNCTION  => T_FUNCTION,
-			T_CLASS     => T_CLASS,
-			T_INTERFACE => T_INTERFACE,
-			T_TRAIT     => T_TRAIT,
-			T_CONST     => T_CONST,
-			T_VARIABLE  => T_VARIABLE,
-			T_DOLLAR    => T_DOLLAR, // Variable variables.
+			\T_FUNCTION  => \T_FUNCTION,
+			\T_CLASS     => \T_CLASS,
+			\T_INTERFACE => \T_INTERFACE,
+			\T_TRAIT     => \T_TRAIT,
+			\T_CONST     => \T_CONST,
+			\T_VARIABLE  => \T_VARIABLE,
+			\T_DOLLAR    => \T_DOLLAR, // Variable variables.
 		);
 
 		// Add function call target for hook names and constants defined using define().
 		$parent = parent::register();
 		if ( ! empty( $parent ) ) {
-			$targets[] = T_STRING;
+			$targets[] = \T_STRING;
 		}
 
 		return $targets;
@@ -241,7 +241,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Ignore test classes.
-		if ( T_CLASS === $this->tokens[ $stackPtr ]['code'] && true === $this->is_test_class( $stackPtr ) ) {
+		if ( \T_CLASS === $this->tokens[ $stackPtr ]['code'] && true === $this->is_test_class( $stackPtr ) ) {
 			if ( $this->tokens[ $stackPtr ]['scope_condition'] === $stackPtr && isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 				// Skip forward to end of test class.
 				return $this->tokens[ $stackPtr ]['scope_closer'];
@@ -249,17 +249,17 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
 			// Disallow excluding function groups for this sniff.
 			$this->exclude = array();
 
 			return parent::process_token( $stackPtr );
 
-		} elseif ( T_DOLLAR === $this->tokens[ $stackPtr ]['code'] ) {
+		} elseif ( \T_DOLLAR === $this->tokens[ $stackPtr ]['code'] ) {
 
 			return $this->process_variable_variable( $stackPtr );
 
-		} elseif ( T_VARIABLE === $this->tokens[ $stackPtr ]['code'] ) {
+		} elseif ( \T_VARIABLE === $this->tokens[ $stackPtr ]['code'] ) {
 
 			return $this->process_variable_assignment( $stackPtr );
 
@@ -278,7 +278,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			switch ( $this->tokens[ $stackPtr ]['type'] ) {
 				case 'T_FUNCTION':
 					// Methods in a class do not need to be prefixed.
-					if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ) ) === true ) {
+					if ( $this->phpcsFile->hasCondition( $stackPtr, array( \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ) ) === true ) {
 						return;
 					}
 
@@ -395,8 +395,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 */
 	protected function process_variable_variable( $stackPtr ) {
 		static $indicators = array(
-			T_OPEN_CURLY_BRACKET => true,
-			T_VARIABLE           => true,
+			\T_OPEN_CURLY_BRACKET => true,
+			\T_VARIABLE           => true,
 		);
 
 		// Is this a variable variable ?
@@ -406,7 +406,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $next_non_empty ]['code']
+		if ( \T_OPEN_CURLY_BRACKET === $this->tokens[ $next_non_empty ]['code']
 			&& isset( $this->tokens[ $next_non_empty ]['bracket_closer'] )
 		) {
 			// Skip over the variable part.
@@ -416,7 +416,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$maybe_assignment = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
 
 		while ( false !== $maybe_assignment
-			&& T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
+			&& \T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
 			&& isset( $this->tokens[ $maybe_assignment ]['bracket_closer'] )
 		) {
 			$maybe_assignment = $this->phpcsFile->findNext(
@@ -448,13 +448,13 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		 * forbidden since PHP 7.0. Presuming cross-version code and if not, that
 		 * is for the PHPCompatibility standard to detect.
 		 */
-		if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_FUNCTION, T_CLOSURE ) ) === true ) {
-			$condition = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+		if ( $this->phpcsFile->hasCondition( $stackPtr, array( \T_FUNCTION, \T_CLOSURE ) ) === true ) {
+			$condition = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 			if ( false === $condition ) {
-				$condition = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+				$condition = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
 			}
 
-			$has_global = $this->phpcsFile->findPrevious( T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
+			$has_global = $this->phpcsFile->findPrevious( \T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
 			if ( false === $has_global ) {
 				// No variable import happening.
 				return;
@@ -513,7 +513,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		if ( 'GLOBALS' === $variable_name ) {
 			$array_open = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
-			if ( false === $array_open || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $array_open ]['code'] ) {
+			if ( false === $array_open || \T_OPEN_SQUARE_BRACKET !== $this->tokens[ $array_open ]['code'] ) {
 				// Live coding or something very silly.
 				return;
 			}
@@ -534,7 +534,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				return;
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $array_key ]['code'] ) {
+			if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $array_key ]['code'] ) {
 				// If the array key is a double quoted string, try again with only
 				// the part before the first variable (if any).
 				$exploded = explode( '$', $variable_name );
@@ -556,8 +556,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 				foreach ( $this->tokens[ $stackPtr ]['nested_parenthesis'] as $opener => $closer ) {
 					if ( isset( $this->tokens[ $opener ]['parenthesis_owner'] )
-						&& ( T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code']
-							|| T_CLOSURE === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code'] )
+						&& ( \T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code']
+							|| \T_CLOSURE === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code'] )
 					) {
 						return;
 					}
@@ -571,20 +571,20 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 
 			// Local variables in a function do not need to be prefixed unless they are being imported.
-			if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_FUNCTION, T_CLOSURE ) ) === true ) {
-				$condition = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			if ( $this->phpcsFile->hasCondition( $stackPtr, array( \T_FUNCTION, \T_CLOSURE ) ) === true ) {
+				$condition = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
 				if ( false === $condition ) {
-					$condition = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+					$condition = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
 				}
 
-				$has_global = $this->phpcsFile->findPrevious( T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
+				$has_global = $this->phpcsFile->findPrevious( \T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
 				if ( false === $has_global ) {
 					// No variable import happening.
 					return;
 				}
 
 				// Ok, this may be an imported global variable.
-				$end_of_statement = $this->phpcsFile->findNext( T_SEMICOLON, ( $has_global + 1 ) );
+				$end_of_statement = $this->phpcsFile->findNext( \T_SEMICOLON, ( $has_global + 1 ) );
 				if ( false === $end_of_statement ) {
 					// No semi-colon - live coding.
 					return;
@@ -592,7 +592,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 				for ( $ptr = ( $has_global + 1 ); $ptr <= $end_of_statement; $ptr++ ) {
 					// Move the stack pointer to the next variable.
-					$ptr = $this->phpcsFile->findNext( T_VARIABLE, $ptr, $end_of_statement, false, null, true );
+					$ptr = $this->phpcsFile->findNext( \T_VARIABLE, $ptr, $end_of_statement, false, null, true );
 
 					if ( false === $ptr ) {
 						// Reached the end of the global statement without finding the variable,
@@ -682,7 +682,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				return;
 			}
 
-			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
+			if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
 				// If the first part of the parameter is a double quoted string, try again with only
 				// the part before the first variable (if any).
 				$exploded = explode( '$', $first_non_empty_content );
@@ -788,11 +788,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return false;
 		}
 
-		if ( T_FOREACH !== $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code'] ) {
+		if ( \T_FOREACH !== $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code'] ) {
 			return false;
 		}
 
-		$as_ptr = $this->phpcsFile->findNext( T_AS, ( $open_parenthesis + 1 ), $close_parenthesis );
+		$as_ptr = $this->phpcsFile->findNext( \T_AS, ( $open_parenthesis + 1 ), $close_parenthesis );
 		if ( false === $as_ptr ) {
 			// Should ever happen.
 			return false;

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -108,14 +108,14 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			$content[ $i ]  = $this->tokens[ $i ]['content'];
 			$expected[ $i ] = $this->tokens[ $i ]['content'];
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				$string = $this->strip_quotes( $this->tokens[ $i ]['content'] );
 
 				/*
 				 * Here be dragons - a double quoted string can contain extrapolated variables
 				 * which don't have to comply with these rules.
 				 */
-				if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
+				if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
 					$transform       = $this->transform_complex_string( $string, $regex );
 					$case_transform  = $this->transform_complex_string( $string, $regex, 'case' );
 					$punct_transform = $this->transform_complex_string( $string, $regex, 'punctuation' );
@@ -129,7 +129,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 					continue;
 				}
 
-				if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
+				if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
 					$expected[ $i ] = '"' . $transform . '"';
 				} else {
 					$expected[ $i ] = '\'' . $transform . '\'';
@@ -211,7 +211,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 * @return string
 	 */
 	protected function transform_complex_string( $string, $regex, $transform_type = 'full' ) {
-		$output = preg_split( '`([\{\}\$\[\] ])`', $string, -1, PREG_SPLIT_DELIM_CAPTURE );
+		$output = preg_split( '`([\{\}\$\[\] ])`', $string, -1, \PREG_SPLIT_DELIM_CAPTURE );
 
 		$is_variable = false;
 		$has_braces  = false;

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -154,12 +154,12 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		$obj_operator = $phpcs_file->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
-		if ( T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+		if ( \T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
 			// Check to see if we are using a variable from an object.
 			$var = $phpcs_file->findNext( Tokens::$emptyTokens, ( $obj_operator + 1 ), null, true );
-			if ( T_STRING === $tokens[ $var ]['code'] ) {
+			if ( \T_STRING === $tokens[ $var ]['code'] ) {
 				$bracket = $phpcs_file->findNext( Tokens::$emptyTokens, ( $var + 1 ), null, true );
-				if ( T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] ) {
+				if ( \T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] ) {
 					$obj_var_name = $tokens[ $var ]['content'];
 
 					// There is no way for us to know if the var is public or
@@ -181,7 +181,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 		$in_class     = false;
 		$obj_operator = $phpcs_file->findPrevious( Tokens::$emptyTokens, ( $stack_ptr - 1 ), null, true );
-		if ( T_DOUBLE_COLON === $tokens[ $obj_operator ]['code'] || T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+		if ( \T_DOUBLE_COLON === $tokens[ $obj_operator ]['code'] || \T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
 			// The variable lives within a class, and is referenced like
 			// this: MyClass::$_variable or $class->variable.
 			$in_class = true;

--- a/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
@@ -32,8 +32,8 @@ class DiscourageGotoSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_GOTO,
-			T_GOTO_LABEL,
+			\T_GOTO,
+			\T_GOTO_LABEL,
 		);
 	}
 

--- a/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -33,8 +33,8 @@ class StrictComparisonsSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_IS_EQUAL,
-			T_IS_NOT_EQUAL,
+			\T_IS_EQUAL,
+			\T_IS_NOT_EQUAL,
 		);
 	}
 

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -41,22 +41,22 @@ class YodaConditionsSniff extends Sniff {
 	 */
 	public function register() {
 
-		$starters                       = Tokens::$booleanOperators;
-		$starters                      += Tokens::$assignmentTokens;
-		$starters[ T_CASE ]             = T_CASE;
-		$starters[ T_RETURN ]           = T_RETURN;
-		$starters[ T_INLINE_THEN ]      = T_INLINE_THEN;
-		$starters[ T_INLINE_ELSE ]      = T_INLINE_ELSE;
-		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
-		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+		$starters                        = Tokens::$booleanOperators;
+		$starters                       += Tokens::$assignmentTokens;
+		$starters[ \T_CASE ]             = \T_CASE;
+		$starters[ \T_RETURN ]           = \T_RETURN;
+		$starters[ \T_INLINE_THEN ]      = \T_INLINE_THEN;
+		$starters[ \T_INLINE_ELSE ]      = \T_INLINE_ELSE;
+		$starters[ \T_SEMICOLON ]        = \T_SEMICOLON;
+		$starters[ \T_OPEN_PARENTHESIS ] = \T_OPEN_PARENTHESIS;
 
 		$this->condition_start_tokens = $starters;
 
 		return array(
-			T_IS_EQUAL,
-			T_IS_NOT_EQUAL,
-			T_IS_IDENTICAL,
-			T_IS_NOT_IDENTICAL,
+			\T_IS_EQUAL,
+			\T_IS_NOT_EQUAL,
+			\T_IS_IDENTICAL,
+			\T_IS_NOT_IDENTICAL,
 		);
 	}
 
@@ -82,15 +82,15 @@ class YodaConditionsSniff extends Sniff {
 			}
 
 			// If this is a variable or array, we've seen all we need to see.
-			if ( T_VARIABLE === $this->tokens[ $i ]['code']
-				|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+			if ( \T_VARIABLE === $this->tokens[ $i ]['code']
+				|| \T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
 			) {
 				$needs_yoda = true;
 				break;
 			}
 
 			// If this is a function call or something, we are OK.
-			if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+			if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 				return;
 			}
 		}
@@ -106,16 +106,16 @@ class YodaConditionsSniff extends Sniff {
 			$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
 		}
 
-		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
+		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( \T_SELF, \T_PARENT, \T_STATIC ), true ) ) {
 			$next_non_empty = $this->phpcsFile->findNext(
-				array_merge( Tokens::$emptyTokens, array( T_DOUBLE_COLON ) ),
+				array_merge( Tokens::$emptyTokens, array( \T_DOUBLE_COLON ) ),
 				( $next_non_empty + 1 ),
 				null,
 				true
 			);
 		}
 
-		if ( T_VARIABLE === $this->tokens[ $next_non_empty ]['code'] ) {
+		if ( \T_VARIABLE === $this->tokens[ $next_non_empty ]['code'] ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -181,11 +181,11 @@ class EscapeOutputSniff extends Sniff {
 	public function register() {
 
 		$tokens = array(
-			T_ECHO,
-			T_PRINT,
-			T_EXIT,
-			T_STRING,
-			T_OPEN_TAG_WITH_ECHO,
+			\T_ECHO,
+			\T_PRINT,
+			\T_EXIT,
+			\T_STRING,
+			\T_OPEN_TAG_WITH_ECHO,
 		);
 
 		/*
@@ -197,8 +197,8 @@ class EscapeOutputSniff extends Sniff {
 		 * For PHP >= 5.4, the `short_open_tag` no longer affects the short open
 		 * echo tags and these are now always enabled.
 		 */
-		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
-			$tokens[] = T_INLINE_HTML;
+		if ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
+			$tokens[] = \T_INLINE_HTML;
 		}
 		return $tokens;
 	}
@@ -221,7 +221,7 @@ class EscapeOutputSniff extends Sniff {
 		$open_paren = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If function, not T_ECHO nor T_PRINT.
-		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
 			// Skip if it is a function but is not one of the printing functions.
 			if ( ! isset( $this->printingFunctions[ $this->tokens[ $stackPtr ]['content'] ] ) ) {
 				return;
@@ -237,7 +237,7 @@ class EscapeOutputSniff extends Sniff {
 				$end_of_statement = ( $first_param['end'] + 1 );
 				unset( $first_param );
 			}
-		} elseif ( T_INLINE_HTML === $this->tokens[ $stackPtr ]['code'] ) {
+		} elseif ( \T_INLINE_HTML === $this->tokens[ $stackPtr ]['code'] ) {
 			// Skip if no PHP short_open_tag is found in the string.
 			if ( false === strpos( $this->tokens[ $stackPtr ]['content'], '<?=' ) ) {
 				return;
@@ -281,14 +281,14 @@ class EscapeOutputSniff extends Sniff {
 		// This is already determined if this is a function and not T_ECHO.
 		if ( ! isset( $end_of_statement ) ) {
 
-			$end_of_statement = $this->phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
+			$end_of_statement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), $stackPtr );
 			$last_token       = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
 
 			// Check for the ternary operator. We only need to do this here if this
 			// echo is lacking parenthesis. Otherwise it will be handled below.
-			if ( T_OPEN_PARENTHESIS !== $this->tokens[ $open_paren ]['code'] || T_CLOSE_PARENTHESIS !== $this->tokens[ $last_token ]['code'] ) {
+			if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $open_paren ]['code'] || \T_CLOSE_PARENTHESIS !== $this->tokens[ $last_token ]['code'] ) {
 
-				$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );
+				$ternary = $this->phpcsFile->findNext( \T_INLINE_THEN, $stackPtr, $end_of_statement );
 
 				// If there is a ternary skip over the part before the ?. However, if
 				// the ternary is within parentheses, it will be handled in the loop.
@@ -313,11 +313,11 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// Ignore namespace separators.
-			if ( T_NS_SEPARATOR === $this->tokens[ $i ]['code'] ) {
+			if ( \T_NS_SEPARATOR === $this->tokens[ $i ]['code'] ) {
 				continue;
 			}
 
-			if ( T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
 
 				if ( ! isset( $this->tokens[ $i ]['parenthesis_closer'] ) ) {
 					// Live coding or parse error.
@@ -333,11 +333,11 @@ class EscapeOutputSniff extends Sniff {
 				} else {
 
 					// Skip over the condition part of a ternary (i.e., to after the ?).
-					$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
+					$ternary = $this->phpcsFile->findNext( \T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
 
 					if ( false !== $ternary ) {
 
-						$next_paren = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
+						$next_paren = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
 
 						// We only do it if the ternary isn't within a subset of parentheses.
 						if ( false === $next_paren || ( isset( $this->tokens[ $next_paren ]['parenthesis_closer'] ) && $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) ) {
@@ -350,18 +350,18 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// Handle arrays for those functions that accept them.
-			if ( T_ARRAY === $this->tokens[ $i ]['code'] ) {
+			if ( \T_ARRAY === $this->tokens[ $i ]['code'] ) {
 				$i++; // Skip the opening parenthesis.
 				continue;
 			}
 
-			if ( T_OPEN_SHORT_ARRAY === $this->tokens[ $i ]['code']
-				|| T_CLOSE_SHORT_ARRAY === $this->tokens[ $i ]['code']
+			if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $i ]['code']
+				|| \T_CLOSE_SHORT_ARRAY === $this->tokens[ $i ]['code']
 			) {
 				continue;
 			}
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ), true ) ) {
+			if ( in_array( $this->tokens[ $i ]['code'], array( \T_DOUBLE_ARROW, \T_CLOSE_PARENTHESIS ), true ) ) {
 				continue;
 			}
 
@@ -371,7 +371,7 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// Handle safe PHP native constants.
-			if ( T_STRING === $this->tokens[ $i ]['code']
+			if ( \T_STRING === $this->tokens[ $i ]['code']
 				&& isset( $this->safe_php_constants[ $this->tokens[ $i ]['content'] ] )
 				&& $this->is_use_of_global_constant( $i )
 			) {
@@ -379,19 +379,19 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// Wake up on concatenation characters, another part to check.
-			if ( T_STRING_CONCAT === $this->tokens[ $i ]['code'] ) {
+			if ( \T_STRING_CONCAT === $this->tokens[ $i ]['code'] ) {
 				$watch = true;
 				continue;
 			}
 
 			// Wake up after a ternary else (:).
-			if ( false !== $ternary && T_INLINE_ELSE === $this->tokens[ $i ]['code'] ) {
+			if ( false !== $ternary && \T_INLINE_ELSE === $this->tokens[ $i ]['code'] ) {
 				$watch = true;
 				continue;
 			}
 
 			// Wake up for commas.
-			if ( T_COMMA === $this->tokens[ $i ]['code'] ) {
+			if ( \T_COMMA === $this->tokens[ $i ]['code'] ) {
 				$in_cast = false;
 				$watch   = true;
 				continue;
@@ -416,11 +416,11 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// Now check that next token is a function call.
-			if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+			if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 
 				$ptr                    = $i;
 				$functionName           = $this->tokens[ $i ]['content'];
-				$function_opener        = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), null, false, null, true );
+				$function_opener        = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, ( $i + 1 ), null, false, null, true );
 				$is_formatting_function = isset( $this->formattingFunctions[ $functionName ] );
 
 				if ( false !== $function_opener ) {
@@ -436,7 +436,7 @@ class EscapeOutputSniff extends Sniff {
 						);
 
 						// If we're able to resolve the function name, do so.
-						if ( $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
+						if ( $mapped_function && \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
 							$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
 							$ptr          = $mapped_function;
 						}

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -118,7 +118,7 @@ class NonceVerificationSniff extends Sniff {
 	public function register() {
 
 		return array(
-			T_VARIABLE,
+			\T_VARIABLE,
 		);
 	}
 

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -76,7 +76,7 @@ class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		foreach ( $this->target_functions[ $matched_content ] as $position ) {
 			if ( isset( $parameters[ $position ] ) ) {
-				$file_constant = $this->phpcsFile->findNext( T_FILE, $parameters[ $position ]['start'], ( $parameters[ $position ]['end'] + 1 ) );
+				$file_constant = $this->phpcsFile->findNext( \T_FILE, $parameters[ $position ]['start'], ( $parameters[ $position ]['end'] + 1 ) );
 
 				if ( false !== $file_constant ) {
 					$this->phpcsFile->addWarning( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -74,9 +74,9 @@ class ValidatedSanitizedInputSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_VARIABLE,
-			T_DOUBLE_QUOTED_STRING,
-			T_HEREDOC,
+			\T_VARIABLE,
+			\T_DOUBLE_QUOTED_STRING,
+			\T_HEREDOC,
 		);
 	}
 
@@ -92,8 +92,8 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		$superglobals = $this->input_superglobals;
 
 		// Handling string interpolation.
-		if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $stackPtr ]['code']
-			|| T_HEREDOC === $this->tokens[ $stackPtr ]['code']
+		if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $stackPtr ]['code']
+			|| \T_HEREDOC === $this->tokens[ $stackPtr ]['code']
 		) {
 			$interpolated_variables = array_map(
 				function ( $symbol ) {

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -146,7 +146,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$targets = $this->string_tokens;
 
 		// Add CSS style target.
-		$targets[] = T_STYLE;
+		$targets[] = \T_STYLE;
 
 		// Set the target selectors regex only once.
 		$selectors = array_map(
@@ -160,7 +160,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		// Add function call targets.
 		$parent = parent::register();
 		if ( ! empty( $parent ) ) {
-			$targets[] = T_STRING;
+			$targets[] = \T_STRING;
 		}
 
 		return $targets;
@@ -180,7 +180,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
 
 		if ( 'css' === $file_extension ) {
-			if ( T_STYLE === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( \T_STYLE === $this->tokens[ $stackPtr ]['code'] ) {
 				return $this->process_css_style( $stackPtr );
 			}
 		} elseif ( isset( $this->string_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
@@ -363,11 +363,11 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$css_property = $this->target_css_properties[ $this->tokens[ $stackPtr ]['content'] ];
 
 		// Check if the CSS selector matches.
-		$opener = $this->phpcsFile->findPrevious( T_OPEN_CURLY_BRACKET, $stackPtr );
+		$opener = $this->phpcsFile->findPrevious( \T_OPEN_CURLY_BRACKET, $stackPtr );
 		if ( false !== $opener ) {
 			for ( $i = ( $opener - 1 ); $i >= 0; $i-- ) {
 				if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] )
-					|| T_CLOSE_CURLY_BRACKET === $this->tokens[ $i ]['code']
+					|| \T_CLOSE_CURLY_BRACKET === $this->tokens[ $i ]['code']
 				) {
 					break;
 				}
@@ -382,7 +382,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 
 					if ( true === $this->remove_only ) {
 						// Check the value of the CSS property.
-						$valuePtr = $this->phpcsFile->findNext( array( T_COLON, T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
+						$valuePtr = $this->phpcsFile->findNext( array( \T_COLON, \T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
 						$value    = $this->tokens[ $valuePtr ]['content'];
 						$valid    = $this->validate_css_property_value( $value, $css_property['type'], $css_property['value'] );
 						if ( true === $valid ) {

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -34,7 +34,7 @@ class SessionVariableUsageSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_VARIABLE,
+			\T_VARIABLE,
 		);
 	}
 

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -31,7 +31,7 @@ class SuperGlobalInputUsageSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_VARIABLE,
+			\T_VARIABLE,
 		);
 	}
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -57,11 +57,11 @@ class CapitalPDangitSniff extends Sniff {
 	 * @var array
 	 */
 	private $text_string_tokens = array(
-		T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
-		T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
-		T_HEREDOC                  => T_HEREDOC,
-		T_NOWDOC                   => T_NOWDOC,
-		T_INLINE_HTML              => T_INLINE_HTML,
+		\T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+		\T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
+		\T_HEREDOC                  => \T_HEREDOC,
+		\T_NOWDOC                   => \T_NOWDOC,
+		\T_INLINE_HTML              => \T_INLINE_HTML,
 	);
 
 	/**
@@ -70,9 +70,9 @@ class CapitalPDangitSniff extends Sniff {
 	 * @var array
 	 */
 	private $comment_text_tokens = array(
-		T_DOC_COMMENT        => T_DOC_COMMENT,
-		T_DOC_COMMENT_STRING => T_DOC_COMMENT_STRING,
-		T_COMMENT            => T_COMMENT,
+		\T_DOC_COMMENT        => \T_DOC_COMMENT,
+		\T_DOC_COMMENT_STRING => \T_DOC_COMMENT_STRING,
+		\T_COMMENT            => \T_COMMENT,
 	);
 
 	/**
@@ -83,9 +83,9 @@ class CapitalPDangitSniff extends Sniff {
 	 * @var array
 	 */
 	private $class_tokens = array(
-		T_CLASS     => T_CLASS,
-		T_INTERFACE => T_INTERFACE,
-		T_TRAIT     => T_TRAIT,
+		\T_CLASS     => \T_CLASS,
+		\T_INTERFACE => \T_INTERFACE,
+		\T_TRAIT     => \T_TRAIT,
 	);
 
 	/**
@@ -111,8 +111,8 @@ class CapitalPDangitSniff extends Sniff {
 		$targets = ( $this->text_and_comment_tokens + $this->class_tokens );
 
 		// Also sniff for array tokens to make skipping anything within those more efficient.
-		$targets[ T_ARRAY ]            = T_ARRAY;
-		$targets[ T_OPEN_SHORT_ARRAY ] = T_OPEN_SHORT_ARRAY;
+		$targets[ \T_ARRAY ]            = \T_ARRAY;
+		$targets[ \T_OPEN_SHORT_ARRAY ] = \T_OPEN_SHORT_ARRAY;
 
 		return $targets;
 	}
@@ -139,9 +139,9 @@ class CapitalPDangitSniff extends Sniff {
 		 * The return values skip to the end of the array.
 		 * This prevents the sniff "hanging" on very long configuration arrays.
 		 */
-		if ( T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
 			return $this->tokens[ $stackPtr ]['bracket_closer'];
-		} elseif ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] ) ) {
+		} elseif ( \T_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] ) ) {
 			return $this->tokens[ $stackPtr ]['parenthesis_closer'];
 		}
 
@@ -155,7 +155,7 @@ class CapitalPDangitSniff extends Sniff {
 				return;
 			}
 
-			if ( preg_match_all( self::WP_CLASSNAME_REGEX, $classname, $matches, PREG_PATTERN_ORDER ) > 0 ) {
+			if ( preg_match_all( self::WP_CLASSNAME_REGEX, $classname, $matches, \PREG_PATTERN_ORDER ) > 0 ) {
 				$mispelled = $this->retrieve_misspellings( $matches[1] );
 
 				if ( ! empty( $mispelled ) ) {
@@ -176,13 +176,13 @@ class CapitalPDangitSniff extends Sniff {
 		 */
 
 		// Ignore content of docblock @link tags.
-		if ( T_DOC_COMMENT_STRING === $this->tokens[ $stackPtr ]['code']
-			|| T_DOC_COMMENT === $this->tokens[ $stackPtr ]['code']
+		if ( \T_DOC_COMMENT_STRING === $this->tokens[ $stackPtr ]['code']
+			|| \T_DOC_COMMENT === $this->tokens[ $stackPtr ]['code']
 		) {
 
-			$comment_start = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $stackPtr - 1 ) );
+			$comment_start = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_OPEN_TAG, ( $stackPtr - 1 ) );
 			if ( false !== $comment_start ) {
-				$comment_tag = $this->phpcsFile->findPrevious( T_DOC_COMMENT_TAG, ( $stackPtr - 1 ), $comment_start );
+				$comment_tag = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_TAG, ( $stackPtr - 1 ), $comment_start );
 				if ( false !== $comment_tag && '@link' === $this->tokens[ $comment_tag ]['content'] ) {
 					// @link tag, so ignore.
 					return;
@@ -191,11 +191,11 @@ class CapitalPDangitSniff extends Sniff {
 		}
 
 		// Ignore any text strings which are array keys `$var['key']` as this is a false positive in 80% of all cases.
-		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
 			$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
-			if ( false !== $prevToken && T_OPEN_SQUARE_BRACKET === $this->tokens[ $prevToken ]['code'] ) {
+			if ( false !== $prevToken && \T_OPEN_SQUARE_BRACKET === $this->tokens[ $prevToken ]['code'] ) {
 				$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
-				if ( false !== $nextToken && T_CLOSE_SQUARE_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
+				if ( false !== $nextToken && \T_CLOSE_SQUARE_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
 					return;
 				}
 			}
@@ -203,7 +203,7 @@ class CapitalPDangitSniff extends Sniff {
 
 		$content = $this->tokens[ $stackPtr ]['content'];
 
-		if ( preg_match_all( self::WP_REGEX, $content, $matches, ( PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE ) ) > 0 ) {
+		if ( preg_match_all( self::WP_REGEX, $content, $matches, ( \PREG_PATTERN_ORDER | \PREG_OFFSET_CAPTURE ) ) > 0 ) {
 			/*
 			 * Prevent some typical false positives.
 			 */

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -62,8 +62,8 @@ class CronIntervalSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_CONSTANT_ENCAPSED_STRING,
-			T_DOUBLE_QUOTED_STRING,
+			\T_CONSTANT_ENCAPSED_STRING,
+			\T_DOUBLE_QUOTED_STRING,
 		);
 	}
 
@@ -82,7 +82,7 @@ class CronIntervalSniff extends Sniff {
 		}
 
 		// If within add_filter.
-		$functionPtr = $this->phpcsFile->findPrevious( T_STRING, key( $token['nested_parenthesis'] ) );
+		$functionPtr = $this->phpcsFile->findPrevious( \T_STRING, key( $token['nested_parenthesis'] ) );
 		if ( false === $functionPtr || 'add_filter' !== $this->tokens[ $functionPtr ]['content'] ) {
 			return;
 		}
@@ -97,8 +97,8 @@ class CronIntervalSniff extends Sniff {
 
 		// If callback is array, get second element.
 		if ( false !== $callbackArrayPtr
-			&& ( T_ARRAY === $this->tokens[ $callbackArrayPtr ]['code']
-				|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackArrayPtr ]['code'] )
+			&& ( \T_ARRAY === $this->tokens[ $callbackArrayPtr ]['code']
+				|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackArrayPtr ]['code'] )
 		) {
 			$callback = $this->get_function_call_parameter( $callbackArrayPtr, 2 );
 
@@ -111,20 +111,20 @@ class CronIntervalSniff extends Sniff {
 		unset( $functionPtr );
 
 		// Search for the function in tokens.
-		$callbackFunctionPtr = $this->phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING, T_CLOSURE ), $callback['start'], ( $callback['end'] + 1 ) );
+		$callbackFunctionPtr = $this->phpcsFile->findNext( array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING, \T_CLOSURE ), $callback['start'], ( $callback['end'] + 1 ) );
 
 		if ( false === $callbackFunctionPtr ) {
 			$this->confused( $stackPtr );
 			return;
 		}
 
-		if ( T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code'] ) {
+		if ( \T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code'] ) {
 			$functionPtr = $callbackFunctionPtr;
 		} else {
 			$functionName = $this->strip_quotes( $this->tokens[ $callbackFunctionPtr ]['content'] );
 
 			for ( $ptr = 0; $ptr < $this->phpcsFile->numTokens; $ptr++ ) {
-				if ( T_FUNCTION === $this->tokens[ $ptr ]['code'] ) {
+				if ( \T_FUNCTION === $this->tokens[ $ptr ]['code'] ) {
 					$foundName = $this->phpcsFile->getDeclarationName( $ptr );
 					if ( $foundName === $functionName ) {
 						$functionPtr = $ptr;
@@ -150,17 +150,17 @@ class CronIntervalSniff extends Sniff {
 		$closing = $this->tokens[ $functionPtr ]['scope_closer'];
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				if ( 'interval' === $this->strip_quotes( $this->tokens[ $i ]['content'] ) ) {
-					$operator = $this->phpcsFile->findNext( T_DOUBLE_ARROW, $i, null, false, null, true );
+					$operator = $this->phpcsFile->findNext( \T_DOUBLE_ARROW, $i, null, false, null, true );
 					if ( false === $operator ) {
 						$this->confused( $stackPtr );
 						return;
 					}
 
 					$valueStart = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true, null, true );
-					$valueEnd   = $this->phpcsFile->findNext( array( T_COMMA, T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
-					$value = '';
+					$valueEnd   = $this->phpcsFile->findNext( array( \T_COMMA, \T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
+					$value      = '';
 					for ( $j = $valueStart; $j < $valueEnd; $j++ ) {
 						if ( isset( Tokens::$emptyTokens[ $this->tokens[ $j ]['code'] ] ) ) {
 							continue;

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -59,20 +59,19 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	 * @var array
 	 */
 	private $preceding_tokens_to_ignore = array(
-		T_NAMESPACE       => true,
-		T_USE             => true,
-		T_CLASS           => true,
-		T_TRAIT           => true,
-		T_INTERFACE       => true,
-		T_EXTENDS         => true,
-		T_IMPLEMENTS      => true,
-		T_NEW             => true,
-		T_FUNCTION        => true,
-		T_DOUBLE_COLON    => true,
-		T_OBJECT_OPERATOR => true,
-		T_INSTANCEOF      => true,
-		T_GOTO            => true,
-
+		\T_NAMESPACE       => true,
+		\T_USE             => true,
+		\T_CLASS           => true,
+		\T_TRAIT           => true,
+		\T_INTERFACE       => true,
+		\T_EXTENDS         => true,
+		\T_IMPLEMENTS      => true,
+		\T_NEW             => true,
+		\T_FUNCTION        => true,
+		\T_DOUBLE_COLON    => true,
+		\T_OBJECT_OPERATOR => true,
+		\T_INSTANCEOF      => true,
+		\T_GOTO            => true,
 	);
 
 	/**
@@ -114,7 +113,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
-		if ( false !== $next && T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
+		if ( false !== $next && \T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
 			// Function call or declaration.
 			return;
 		}
@@ -126,15 +125,15 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( false !== $prev
-			&& T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
-			&& T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
+			&& \T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
+			&& \T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
 		) {
 			// Namespaced constant of the same name.
 			return;
 		}
 
 		if ( false !== $prev
-			&& T_CONST === $this->tokens[ $prev ]['code']
+			&& \T_CONST === $this->tokens[ $prev ]['code']
 			&& true === $this->is_class_constant( $prev )
 		) {
 			// Class constant of the same name.
@@ -151,14 +150,14 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$first_on_line = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
-		if ( false !== $first_on_line && T_USE === $this->tokens[ $first_on_line ]['code'] ) {
+		if ( false !== $first_on_line && \T_USE === $this->tokens[ $first_on_line ]['code'] ) {
 			$next_on_line = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $first_on_line + 1 ), null, true );
 			if ( false !== $next_on_line ) {
-				if ( ( T_STRING === $this->tokens[ $next_on_line ]['code']
+				if ( ( \T_STRING === $this->tokens[ $next_on_line ]['code']
 						&& 'const' === $this->tokens[ $next_on_line ]['content'] )
-					|| T_CONST === $this->tokens[ $next_on_line ]['code'] // Happens in some PHPCS versions.
+					|| \T_CONST === $this->tokens[ $next_on_line ]['code'] // Happens in some PHPCS versions.
 				) {
-					$has_ns_sep = $this->phpcsFile->findNext( T_NS_SEPARATOR, ( $next_on_line + 1 ), $stackPtr );
+					$has_ns_sep = $this->phpcsFile->findNext( \T_NS_SEPARATOR, ( $next_on_line + 1 ), $stackPtr );
 					if ( false !== $has_ns_sep ) {
 						// Namespaced const (group) use statement.
 						return;

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -228,7 +228,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
 		if ( false === $func_open_paren_token
-			|| T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
+			|| \T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
 			|| ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] )
 		) {
 			// Live coding, parse error or not a function call.
@@ -255,7 +255,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			if ( isset( Tokens::$emptyTokens[ $this_token['code'] ] ) ) {
 				continue;
 			}
-			if ( T_COMMA === $this_token['code'] ) {
+			if ( \T_COMMA === $this_token['code'] ) {
 				$arguments_tokens[] = $argument_tokens;
 				$argument_tokens    = array();
 				continue;
@@ -455,7 +455,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			$this->check_text( $context );
 		}
 
-		if ( T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] || T_HEREDOC === $tokens[0]['code'] ) {
+		if ( \T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] || \T_HEREDOC === $tokens[0]['code'] ) {
 			$interpolated_variables = $this->get_interpolated_variables( $content );
 			foreach ( $interpolated_variables as $interpolated_variable ) {
 				$code = $this->string_to_errorcode( 'InterpolatedVariable' . ucfirst( $arg_name ) );
@@ -487,8 +487,8 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 					$error_code = 'SuperfluousDefaultTextDomain';
 
 					if ( $tokens[0]['token_index'] === $stack_ptr ) {
-						$prev = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $stack_ptr - 1 ), null, true );
-						if ( false !== $prev && T_COMMA === $this->tokens[ $prev ]['code'] ) {
+						$prev = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $stack_ptr - 1 ), null, true );
+						if ( false !== $prev && \T_COMMA === $this->tokens[ $prev ]['code'] ) {
 							$fixable = true;
 						}
 					}
@@ -668,7 +668,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 					if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) === $this->tokens[ $stack_ptr ]['line'] ) {
 						$correctly_placed = true;
 					} else {
-						$next_non_whitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
+						$next_non_whitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
 						if ( false === $next_non_whitespace || $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $stack_ptr ]['line'] ) {
 							// No non-whitespace found or next non-whitespace is on same line as gettext call.
 							$correctly_placed = true;
@@ -681,13 +681,13 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 					 */
 					if ( true === $correctly_placed ) {
 
-						if ( T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
+						if ( \T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
 							$comment_text = trim( $this->tokens[ $previous_comment ]['content'] );
 
 							// If it's multi-line /* */ comment, collect all the parts.
 							if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
 								for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
-									if ( T_COMMENT !== $this->tokens[ $i ]['code'] ) {
+									if ( \T_COMMENT !== $this->tokens[ $i ]['code'] ) {
 										break;
 									}
 
@@ -699,10 +699,10 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 								// Comment is ok.
 								return;
 							}
-						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
+						} elseif ( \T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
 							// If it's docblock comment (wrong style) make sure that it's a translators comment.
-							$db_start      = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
-							$db_first_text = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
+							$db_start      = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
+							$db_first_text = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
 
 							if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
 								$this->phpcsFile->addWarning(

--- a/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -66,31 +66,31 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 	 */
 	public function register() {
 
-		$this->ignoreTokens                           = Tokens::$functionNameTokens;
-		$this->ignoreTokens[ T_VARIABLE ]             = T_VARIABLE;
-		$this->ignoreTokens[ T_CLOSE_PARENTHESIS ]    = T_CLOSE_PARENTHESIS;
-		$this->ignoreTokens[ T_CLOSE_CURLY_BRACKET ]  = T_CLOSE_CURLY_BRACKET;
-		$this->ignoreTokens[ T_CLOSE_SQUARE_BRACKET ] = T_CLOSE_SQUARE_BRACKET;
-		$this->ignoreTokens[ T_CLOSE_SHORT_ARRAY ]    = T_CLOSE_SHORT_ARRAY;
-		$this->ignoreTokens[ T_ANON_CLASS ]           = T_ANON_CLASS;
-		$this->ignoreTokens[ T_USE ]                  = T_USE;
-		$this->ignoreTokens[ T_LIST ]                 = T_LIST;
-		$this->ignoreTokens[ T_DECLARE ]              = T_DECLARE;
+		$this->ignoreTokens                            = Tokens::$functionNameTokens;
+		$this->ignoreTokens[ \T_VARIABLE ]             = \T_VARIABLE;
+		$this->ignoreTokens[ \T_CLOSE_PARENTHESIS ]    = \T_CLOSE_PARENTHESIS;
+		$this->ignoreTokens[ \T_CLOSE_CURLY_BRACKET ]  = \T_CLOSE_CURLY_BRACKET;
+		$this->ignoreTokens[ \T_CLOSE_SQUARE_BRACKET ] = \T_CLOSE_SQUARE_BRACKET;
+		$this->ignoreTokens[ \T_CLOSE_SHORT_ARRAY ]    = \T_CLOSE_SHORT_ARRAY;
+		$this->ignoreTokens[ \T_ANON_CLASS ]           = \T_ANON_CLASS;
+		$this->ignoreTokens[ \T_USE ]                  = \T_USE;
+		$this->ignoreTokens[ \T_LIST ]                 = \T_LIST;
+		$this->ignoreTokens[ \T_DECLARE ]              = \T_DECLARE;
 
 		// The below two tokens have been added to the Tokens::$functionNameTokens array in PHPCS 3.1.0,
 		// so they can be removed once the minimum PHPCS requirement of WPCS has gone up.
-		$this->ignoreTokens[ T_SELF ]   = T_SELF;
-		$this->ignoreTokens[ T_STATIC ] = T_STATIC;
+		$this->ignoreTokens[ \T_SELF ]   = \T_SELF;
+		$this->ignoreTokens[ \T_STATIC ] = \T_STATIC;
 
 		// Language constructs where the use of parentheses should be discouraged instead.
-		$this->ignoreTokens[ T_THROW ]      = T_THROW;
-		$this->ignoreTokens[ T_YIELD ]      = T_YIELD;
-		$this->ignoreTokens[ T_YIELD_FROM ] = T_YIELD_FROM;
-		$this->ignoreTokens[ T_CLONE ]      = T_CLONE;
+		$this->ignoreTokens[ \T_THROW ]      = \T_THROW;
+		$this->ignoreTokens[ \T_YIELD ]      = \T_YIELD;
+		$this->ignoreTokens[ \T_YIELD_FROM ] = \T_YIELD_FROM;
+		$this->ignoreTokens[ \T_CLONE ]      = \T_CLONE;
 
 		return array(
-			T_OPEN_PARENTHESIS,
-			T_CLOSE_PARENTHESIS,
+			\T_OPEN_PARENTHESIS,
+			\T_CLOSE_PARENTHESIS,
 		);
 	}
 
@@ -113,7 +113,7 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 
 		// More checking for the type of parenthesis we *don't* want to handle.
 		$opener = $stackPtr;
-		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code'] ) {
 			if ( ! isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
 				// Parse error.
 				return;
@@ -131,10 +131,10 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 		/*
 		 * Check for empty parentheses.
 		 */
-		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+		if ( \T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
 			&& isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] )
 		) {
-			$nextNonEmpty = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$nextNonEmpty = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 			if ( $nextNonEmpty === $this->tokens[ $stackPtr ]['parenthesis_closer'] ) {
 				$this->phpcsFile->addWarning( 'Empty set of arbitrary parentheses found.', $stackPtr, 'FoundEmpty' );
 
@@ -147,12 +147,12 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 		 */
 		$this->spacingInside = (int) $this->spacingInside;
 
-		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+		if ( \T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
 			&& isset( $this->tokens[ ( $stackPtr + 1 ) ], $this->tokens[ ( $stackPtr + 2 ) ] )
 		) {
 			$nextToken = $this->tokens[ ( $stackPtr + 1 ) ];
 
-			if ( T_WHITESPACE !== $nextToken['code'] ) {
+			if ( \T_WHITESPACE !== $nextToken['code'] ) {
 				$inside = 0;
 			} else {
 				if ( $this->tokens[ ( $stackPtr + 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
@@ -185,7 +185,7 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 					} elseif ( 'newline' === $inside ) {
 						$this->phpcsFile->fixer->beginChangeset();
 						for ( $i = ( $stackPtr + 2 ); $i < $this->phpcsFile->numTokens; $i++ ) {
-							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+							if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
 								break;
 							}
 							$this->phpcsFile->fixer->replaceToken( $i, '' );
@@ -199,12 +199,12 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 			}
 		}
 
-		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+		if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
 			&& isset( $this->tokens[ ( $stackPtr - 1 ) ], $this->tokens[ ( $stackPtr - 2 ) ] )
 		) {
 			$prevToken = $this->tokens[ ( $stackPtr - 1 ) ];
 
-			if ( T_WHITESPACE !== $prevToken['code'] ) {
+			if ( \T_WHITESPACE !== $prevToken['code'] ) {
 				$inside = 0;
 			} else {
 				if ( $this->tokens[ ( $stackPtr - 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
@@ -237,7 +237,7 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 					} elseif ( 'newline' === $inside ) {
 						$this->phpcsFile->fixer->beginChangeset();
 						for ( $i = ( $stackPtr - 2 ); $i > 0; $i-- ) {
-							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+							if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
 								break;
 							}
 							$this->phpcsFile->fixer->replaceToken( $i, '' );

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -45,7 +45,7 @@ class CastStructureSpacingSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+		if ( \T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
 			$error = 'No space before opening casting parenthesis is prohibited';
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 			if ( true === $fix ) {
@@ -53,7 +53,7 @@ class CastStructureSpacingSniff extends Sniff {
 			}
 		}
 
-		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+		if ( \T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
 			$error = 'No space after closing casting parenthesis is prohibited';
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
 			if ( true === $fix ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -73,11 +73,11 @@ class ControlStructureSpacingSniff extends Sniff {
 	 * @var array
 	 */
 	private $ignore_extra_space_after_open_paren = array(
-		T_FUNCTION => true,
-		T_CLOSURE  => true,
-		T_DO       => true,
-		T_ELSE     => true,
-		T_TRY      => true,
+		\T_FUNCTION => true,
+		\T_CLOSURE  => true,
+		\T_DO       => true,
+		\T_ELSE     => true,
+		\T_TRY      => true,
 	);
 
 	/**
@@ -87,19 +87,19 @@ class ControlStructureSpacingSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_IF,
-			T_WHILE,
-			T_FOREACH,
-			T_FOR,
-			T_SWITCH,
-			T_DO,
-			T_ELSE,
-			T_ELSEIF,
-			T_FUNCTION,
-			T_CLOSURE,
-			T_USE,
-			T_TRY,
-			T_CATCH,
+			\T_IF,
+			\T_WHILE,
+			\T_FOREACH,
+			\T_FOR,
+			\T_SWITCH,
+			\T_DO,
+			\T_ELSE,
+			\T_ELSEIF,
+			\T_FUNCTION,
+			\T_CLOSURE,
+			\T_USE,
+			\T_TRY,
+			\T_CATCH,
 		);
 	}
 
@@ -113,9 +113,9 @@ class ControlStructureSpacingSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 		$this->spaces_before_closure_open_paren = (int) $this->spaces_before_closure_open_paren;
 
-		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
-			&& ! ( T_ELSE === $this->tokens[ $stackPtr ]['code'] && T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
-			&& ! ( T_CLOSURE === $this->tokens[ $stackPtr ]['code']
+		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && \T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ! ( \T_ELSE === $this->tokens[ $stackPtr ]['code'] && \T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
+			&& ! ( \T_CLOSURE === $this->tokens[ $stackPtr ]['code']
 				&& 0 >= $this->spaces_before_closure_open_paren )
 		) {
 			$error = 'Space after opening control structure is required';
@@ -128,10 +128,10 @@ class ControlStructureSpacingSniff extends Sniff {
 
 		if ( ! isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 
-			if ( T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
-				$scopeOpener = $this->phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
+			if ( \T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
+				$scopeOpener = $this->phpcsFile->findNext( \T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
 				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
-			} elseif ( T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {
+			} elseif ( \T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {
 				return;
 			}
 		} else {
@@ -140,11 +140,11 @@ class ControlStructureSpacingSniff extends Sniff {
 		}
 
 		// Alternative syntax.
-		if ( isset( $scopeOpener ) && T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
+		if ( isset( $scopeOpener ) && \T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
 
 			if ( 'required' === $this->space_before_colon ) {
 
-				if ( T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+				if ( \T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Space between opening control structure and T_COLON is required';
 					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
 
@@ -154,7 +154,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				}
 			} elseif ( 'forbidden' === $this->space_before_colon ) {
 
-				if ( T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+				if ( \T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
 					$error = 'Extra space between opening control structure and T_COLON found';
 					$fix   = $this->phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
 
@@ -168,13 +168,13 @@ class ControlStructureSpacingSniff extends Sniff {
 		$parenthesisOpener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
 		// If this is a function declaration.
-		if ( T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
 
-			if ( T_STRING === $this->tokens[ $parenthesisOpener ]['code'] ) {
+			if ( \T_STRING === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
 				$function_name_ptr = $parenthesisOpener;
 
-			} elseif ( T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
+			} elseif ( \T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
 				// This function returns by reference (function &function_name() {}).
 				$parenthesisOpener = $this->phpcsFile->findNext(
@@ -210,7 +210,7 @@ class ControlStructureSpacingSniff extends Sniff {
 					}
 				}
 			}
-		} elseif ( T_CLOSURE === $this->tokens[ $stackPtr ]['code'] ) {
+		} elseif ( \T_CLOSURE === $this->tokens[ $stackPtr ]['code'] ) {
 
 			// Check if there is a use () statement.
 			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
@@ -225,19 +225,17 @@ class ControlStructureSpacingSniff extends Sniff {
 				);
 
 				// If it is, we set that as the "scope opener".
-				if ( T_USE === $this->tokens[ $usePtr ]['code'] ) {
+				if ( \T_USE === $this->tokens[ $usePtr ]['code'] ) {
 					$scopeOpener = $usePtr;
 				}
 			}
 		}
 
-		if (
-			T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
-			&& T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
+		if ( \T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
+			&& \T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
 		) {
 
-			if (
-				T_CLOSURE === $this->tokens[ $stackPtr ]['code']
+			if ( \T_CLOSURE === $this->tokens[ $stackPtr ]['code']
 				&& 0 === $this->spaces_before_closure_open_paren
 			) {
 
@@ -252,7 +250,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				}
 			} elseif (
 				(
-					T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
+					\T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
 					|| 1 === $this->spaces_before_closure_open_paren
 				)
 				&& ( $stackPtr + 1 ) === $parenthesisOpener
@@ -268,8 +266,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			}
 		}
 
-		if (
-			T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
+		if ( \T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
 			&& ' ' !== $this->tokens[ ( $stackPtr + 1 ) ]['content']
 		) {
 			// Checking this: if [*](...) {}.
@@ -286,8 +283,8 @@ class ControlStructureSpacingSniff extends Sniff {
 			}
 		}
 
-		if ( T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
-			if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+		if ( \T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+			if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 				// Checking this: $value = my_function([*]...).
 				$error = 'No space after opening parenthesis is prohibited';
 				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
@@ -319,10 +316,10 @@ class ControlStructureSpacingSniff extends Sniff {
 
 			$parenthesisCloser = $this->tokens[ $parenthesisOpener ]['parenthesis_closer'];
 
-			if ( T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+			if ( \T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 
 				// Checking this: if (...[*]) {}.
-				if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
+				if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
 					$error = 'No space before closing parenthesis is prohibited';
 					$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
 
@@ -346,9 +343,8 @@ class ControlStructureSpacingSniff extends Sniff {
 					}
 				}
 
-				if (
-					T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
-					&& ( isset( $scopeOpener ) && T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
+				if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+					&& ( isset( $scopeOpener ) && \T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
 				) {
 					$error = 'Space between opening control structure and closing parenthesis is required';
 					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
@@ -360,8 +356,8 @@ class ControlStructureSpacingSniff extends Sniff {
 			}
 
 			// Ignore this for function declarations. Handled by the OpeningFunctionBraceKrnighanRitchie sniff.
-			if ( T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
-				&& T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
+			if ( \T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
+				&& \T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
 				&& isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
 				&& ( isset( $scopeOpener )
 				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
@@ -381,8 +377,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				}
 				return;
 
-			} elseif (
-				T_WHITESPACE === $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+			} elseif ( \T_WHITESPACE === $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
 				&& ' ' !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
 			) {
 
@@ -402,19 +397,19 @@ class ControlStructureSpacingSniff extends Sniff {
 		}
 
 		if ( false !== $this->blank_line_check && isset( $scopeOpener ) ) {
-			$firstContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
+			$firstContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
 
 			// We ignore spacing for some structures that tend to have their own rules.
 			$ignore = array(
-				T_FUNCTION             => true,
-				T_CLOSURE              => true,
-				T_CLASS                => true,
-				T_ANON_CLASS           => true,
-				T_INTERFACE            => true,
-				T_TRAIT                => true,
-				T_DOC_COMMENT_OPEN_TAG => true,
-				T_CLOSE_TAG            => true,
-				T_COMMENT              => true,
+				\T_FUNCTION             => true,
+				\T_CLOSURE              => true,
+				\T_CLASS                => true,
+				\T_ANON_CLASS           => true,
+				\T_INTERFACE            => true,
+				\T_TRAIT                => true,
+				\T_DOC_COMMENT_OPEN_TAG => true,
+				\T_CLOSE_TAG            => true,
+				\T_COMMENT              => true,
 			);
 
 			if ( ! isset( $ignore[ $this->tokens[ $firstContent ]['code'] ] )
@@ -439,7 +434,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			}
 
 			if ( $firstContent !== $scopeCloser ) {
-				$lastContent = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
+				$lastContent = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
 
 				$lastNonEmptyContent = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
 
@@ -453,7 +448,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				) {
 					for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
 						if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
-							&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
+							&& \T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
 						) {
 							// TODO: Reporting error at empty line won't highlight it in IDE.
 							$error = 'Blank line found at end of control structure';
@@ -474,7 +469,7 @@ class ControlStructureSpacingSniff extends Sniff {
 								 * the new line at the end, so don't add any extra as it would cause a fixer
 								 * conflict.
 								 */
-								if ( T_COMMENT !== $this->tokens[ $lastContent ]['code']
+								if ( \T_COMMENT !== $this->tokens[ $lastContent ]['code']
 									&& ! isset( $this->phpcsCommentTokens[ $this->tokens[ $lastContent ]['type'] ] ) ) {
 									$this->phpcsFile->fixer->addNewlineBefore( $j );
 								}
@@ -495,19 +490,19 @@ class ControlStructureSpacingSniff extends Sniff {
 
 		// {@internal This is just for the blank line check. Only whitespace should be considered,
 		// not "other" empty tokens.}}
-		$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
+		$trailingContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
 		if ( false === $trailingContent ) {
 			return;
 		}
 
-		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code']
+		if ( \T_COMMENT === $this->tokens[ $trailingContent ]['code']
 			|| isset( $this->phpcsCommentTokens[ $this->tokens[ $trailingContent ]['type'] ] )
 		) {
 			// Special exception for code where the comment about
 			// an ELSE or ELSEIF is written between the control structures.
 			$nextCode = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
 
-			if ( T_ELSE === $this->tokens[ $nextCode ]['code'] || T_ELSEIF === $this->tokens[ $nextCode ]['code'] ) {
+			if ( \T_ELSE === $this->tokens[ $nextCode ]['code'] || \T_ELSEIF === $this->tokens[ $nextCode ]['code'] ) {
 				$trailingContent = $nextCode;
 			}
 
@@ -515,32 +510,32 @@ class ControlStructureSpacingSniff extends Sniff {
 			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
 				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'], $matches ) > 0 ) {
 					$scopeCloser     = $trailingContent;
-					$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1 ), null, true );
+					$trailingContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $trailingContent + 1 ), null, true );
 				}
 			}
 		}
 
-		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] && T_IF === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_ELSE === $this->tokens[ $trailingContent ]['code'] && \T_IF === $this->tokens[ $stackPtr ]['code'] ) {
 			// IF with ELSE.
 			return;
 		}
 
-		if ( T_WHILE === $this->tokens[ $trailingContent ]['code'] && T_DO === $this->tokens[ $stackPtr ]['code'] ) {
+		if ( \T_WHILE === $this->tokens[ $trailingContent ]['code'] && \T_DO === $this->tokens[ $stackPtr ]['code'] ) {
 			// DO with WHILE.
 			return;
 		}
 
-		if ( T_CLOSE_TAG === $this->tokens[ $trailingContent ]['code'] ) {
+		if ( \T_CLOSE_TAG === $this->tokens[ $trailingContent ]['code'] ) {
 			// At the end of the script or embedded code.
 			return;
 		}
 
 		if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] )
-			&& T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code']
+			&& \T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code']
 		) {
 			// Another control structure's closing brace.
 			$owner = $this->tokens[ $trailingContent ]['scope_condition'];
-			if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+			if ( in_array( $this->tokens[ $owner ]['code'], array( \T_FUNCTION, \T_CLOSURE, \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ), true ) ) {
 				// The next content is the closing brace of a function, class, interface or trait
 				// so normal function/class rules apply and we can ignore it.
 				return;
@@ -561,7 +556,7 @@ class ControlStructureSpacingSniff extends Sniff {
 					}
 
 					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
-					if ( T_COMMENT !== $this->tokens[ $scopeCloser ]['code']
+					if ( \T_COMMENT !== $this->tokens[ $scopeCloser ]['code']
 						&& isset( $this->phpcsCommentTokens[ $this->tokens[ $scopeCloser ]['type'] ] ) === false
 					) {
 						$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );

--- a/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -38,7 +38,7 @@ class DisallowInlineTabsSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_OPEN_TAG,
+			\T_OPEN_TAG,
 		);
 	}
 
@@ -55,9 +55,9 @@ class DisallowInlineTabsSniff extends Sniff {
 		}
 
 		$check_tokens = array(
-			T_WHITESPACE             => true,
-			T_DOC_COMMENT_WHITESPACE => true,
-			T_DOC_COMMENT_STRING     => true,
+			\T_WHITESPACE             => true,
+			\T_DOC_COMMENT_WHITESPACE => true,
+			\T_DOC_COMMENT_STRING     => true,
 		);
 
 		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -52,9 +52,9 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 	 * @return array
 	 */
 	public function register() {
-		$tokens                  = parent::register();
-		$tokens[ T_BOOLEAN_NOT ] = T_BOOLEAN_NOT;
-		$logical_operators       = Tokens::$booleanOperators;
+		$tokens                   = parent::register();
+		$tokens[ \T_BOOLEAN_NOT ] = \T_BOOLEAN_NOT;
+		$logical_operators        = Tokens::$booleanOperators;
 
 		// Using array union to auto-dedup.
 		return $tokens + $logical_operators;

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -73,8 +73,8 @@ class PrecisionAlignmentSniff extends Sniff {
 	 */
 	public function register() {
 		return array(
-			T_OPEN_TAG,
-			T_OPEN_TAG_WITH_ECHO,
+			\T_OPEN_TAG,
+			\T_OPEN_TAG_WITH_ECHO,
 		);
 	}
 
@@ -107,7 +107,7 @@ class PrecisionAlignmentSniff extends Sniff {
 				continue;
 			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['type'] ] ) === false
 				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
-					&& T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] )
+					&& \T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] )
 				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar
 				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
 				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
@@ -127,8 +127,8 @@ class PrecisionAlignmentSniff extends Sniff {
 					$spaces = ( $length % $this->tab_width );
 
 					if ( isset( $this->tokens[ ( $i + 1 ) ] )
-						&& ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
-							|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
+						&& ( \T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
+							|| \T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
 						&& 0 !== $spaces
 					) {
 						// One alignment space expected before the *.

--- a/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -42,7 +42,7 @@ class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
 			if ( isset( $tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
 				$owner = $tokens[ $close_parenthesis ]['parenthesis_owner'];
 
-				if ( T_FOR === $tokens[ $owner ]['code'] ) {
+				if ( \T_FOR === $tokens[ $owner ]['code'] ) {
 					$previous = $phpcsFile->findPrevious(
 						Tokens::$emptyTokens,
 						( $stackPtr - 1 ),
@@ -52,7 +52,7 @@ class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
 
 					if ( false !== $previous
 						&& ( $previous === $tokens[ $owner ]['parenthesis_opener']
-							|| T_SEMICOLON === $tokens[ $previous ]['code'] )
+							|| \T_SEMICOLON === $tokens[ $previous ]['code'] )
 					) {
 						return;
 					}

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -56,7 +56,7 @@ class EmptyStatementUnitTest extends AbstractSniffUnitTest {
 			case 'EmptyStatementUnitTest.2.inc':
 				return array(
 					1 => 1, // Internal.NoCode warning when short open tags is off, otherwise EmptyStatement warning.
-					2 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					2 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
 				);
 
 			default:

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -120,19 +120,19 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	protected function getTestFiles( $testFileBase ) {
 
 		// Work around for PHP 5.3/PHPCS 2.x.
-		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
+		if ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 			unset( $this->expected_results['SomeView.inc'] );
 		}
 
 		// Work around for PHPCS < 3.2.0. The disables will be diregarded.
-		if ( ! defined( 'T_PHPCS_DISABLE' ) && ! defined( 'T_PHPCS_ENABLE' ) ) {
+		if ( ! defined( '\T_PHPCS_DISABLE' ) && ! defined( '\T_PHPCS_ENABLE' ) ) {
 			$this->expected_results['blanket-disable.inc']   = 1;
 			$this->expected_results['rule-disable.inc']      = 1;
 			$this->expected_results['wordpress-disable.inc'] = 1;
 		}
 
-		$sep        = DIRECTORY_SEPARATOR;
-		$test_files = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', GLOB_BRACE );
+		$sep        = \DIRECTORY_SEPARATOR;
+		$test_files = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
 		if ( ! empty( $test_files ) ) {
 			return $test_files;
@@ -170,7 +170,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 			case 'SomeView.inc':
 			case 'some-view.inc':
 				$expected = array();
-				if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
+				if ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
 					$expected[1] = 1; // Internal.NoCode warning on PHP 5.3 icw short open tags off.
 				}
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -116,10 +116,10 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 			case 'PrecisionAlignmentUnitTest.4.inc':
 				return array(
 					1 => 1, // Will show a `Internal.NoCodeFound` warning in PHP 5.3 with short open tags off.
-					2 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					3 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					4 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					5 => ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					2 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					3 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					4 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					5 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
 				);
 
 			case 'PrecisionAlignmentUnitTest.5.inc':


### PR DESCRIPTION
Constants in PHP are namespaced as well, however, when PHP cannot find the constant in the namespace, it will fall through to the global namespace.

The step to first check within the namespace can be skipped by either using `use const ...` (PHP 5.6+) or by prefixing the constant with a `\`.

As WPCS uses a lot of global constants, some performance gain can be archived by using the FQN for constants.

This PR implements this throughout the codebase.

@JDGrimes It would be great if you'd have the chance to run a performance test to see what the effect is of this PR ;-)