### PR TITLE
Performance: use FQN for functions which can use PHP7 compile time opcodes

### DIFF
--- a/Test/Standards/AbstractSniffUnitTest.php
+++ b/Test/Standards/AbstractSniffUnitTest.php
@@ -80,7 +80,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
             self::$phpcs = new PHP_CodeSniffer();
         }
 
-        $class = get_class($this);
+        $class = \get_class($this);
         $this->standardsDir = $GLOBALS['PHP_CODESNIFFER_STANDARD_DIRS'][$class];
 
     }//end setUp()
@@ -105,7 +105,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
 
         foreach ($di as $file) {
             $path = $file->getPathname();
-            if (substr($path, 0, strlen($testFileBase)) === $testFileBase) {
+            if (substr($path, 0, \strlen($testFileBase)) === $testFileBase) {
 
                 /* Start of WPCS adjustment */
                 // If we're changing things anyway, we may as well exclude backup files
@@ -153,7 +153,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
         }
 
         // The basis for determining file locations.
-        $basename = substr(get_class($this), 0, -8);
+        $basename = substr(\get_class($this), 0, -8);
 
         /* Start of WPCS adjustment */
         // Support the use of PHP namespaces.
@@ -237,11 +237,11 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
         $expectedErrors   = $this->getErrorList(basename($testFile));
         $expectedWarnings = $this->getWarningList(basename($testFile));
 
-        if (is_array($expectedErrors) === false) {
+        if (\is_array($expectedErrors) === false) {
             throw new PHP_CodeSniffer_Exception('getErrorList() must return an array');
         }
 
-        if (is_array($expectedWarnings) === false) {
+        if (\is_array($expectedWarnings) === false) {
             throw new PHP_CodeSniffer_Exception('getWarningList() must return an array');
         }
 
@@ -276,12 +276,12 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
                     $errorsTemp[] = $foundError['message'].' ('.$foundError['source'].')';
 
                     $source = $foundError['source'];
-                    if (in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']) === false) {
+                    if (\in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']) === false) {
                         $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'][] = $source;
                     }
 
                     if ($foundError['fixable'] === true
-                        && in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']) === false
+                        && \in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']) === false
                     ) {
                         $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'][] = $source;
                     }
@@ -362,8 +362,8 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase {
         ksort($allProblems);
 
         foreach ($allProblems as $line => $problems) {
-            $numErrors        = count($problems['found_errors']);
-            $numWarnings      = count($problems['found_warnings']);
+            $numErrors        = \count($problems['found_errors']);
+            $numWarnings      = \count($problems['found_warnings']);
             $expectedErrors   = $problems['expected_errors'];
             $expectedWarnings = $problems['expected_warnings'];
 

--- a/Test/Standards/AllSniffs.php
+++ b/Test/Standards/AllSniffs.php
@@ -86,7 +86,7 @@ class AllSniffs extends PHP_CodeSniffer_Standards_AllSniffs
             }
 
             foreach ($standards as $standard) {
-                if (in_array($standard, $ignoreTestsForStandards, true)) {
+                if (\in_array($standard, $ignoreTestsForStandards, true)) {
                     continue;
                 }
 

--- a/Test/phpcs3-bootstrap.php
+++ b/Test/phpcs3-bootstrap.php
@@ -15,7 +15,7 @@
  * @since   0.13.0
  */
 
-if ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+if ( ! \defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
 	define( 'PHP_CODESNIFFER_IN_TESTS', true );
 }
 

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -156,7 +156,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		 * $foo = array( 'bar' => 'taz' );
 		 * $foo['bar'] = $taz;
 		 */
-		if ( in_array( $token['code'], array( \T_CLOSE_SQUARE_BRACKET, \T_DOUBLE_ARROW ), true ) ) {
+		if ( \in_array( $token['code'], array( \T_CLOSE_SQUARE_BRACKET, \T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
 			if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
 				$operator = $this->phpcsFile->findNext( \T_EQUAL, ( $stackPtr + 1 ) );
@@ -171,7 +171,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$val            = $this->strip_quotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
-		} elseif ( in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
+		} elseif ( \in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 			// $foo = 'bar=taz&other=thing';
 			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', $this->strip_quotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.
@@ -197,11 +197,11 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				foreach ( $assignments as $occurance ) {
 					list( $val, $line ) = $occurance;
 
-					if ( ! in_array( $key, $group['keys'], true ) ) {
+					if ( ! \in_array( $key, $group['keys'], true ) ) {
 						continue;
 					}
 
-					$output = call_user_func( $callback, $key, $val, $line, $group );
+					$output = \call_user_func( $callback, $key, $val, $line, $group );
 
 					if ( ! isset( $output ) || false === $output ) {
 						continue;

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -118,7 +118,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		$token     = $this->tokens[ $stackPtr ];
 		$classname = '';
 
-		if ( in_array( $token['code'], array( \T_NEW, \T_EXTENDS, \T_IMPLEMENTS ), true ) ) {
+		if ( \in_array( $token['code'], array( \T_NEW, \T_EXTENDS, \T_IMPLEMENTS ), true ) ) {
 			if ( \T_NEW === $token['code'] ) {
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_PARENTHESIS, \T_WHITESPACE, \T_SEMICOLON, \T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
@@ -150,7 +150,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 		}
 
 		// Nothing to do if 'parent', 'self' or 'static'.
-		if ( in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
+		if ( \in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
 			return false;
 		}
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -165,7 +165,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		// Create one "super-regex" to allow for initial filtering.
-		$all_items                = call_user_func_array( 'array_merge', $all_items );
+		$all_items                = \call_user_func_array( 'array_merge', $all_items );
 		$all_items                = implode( '|', array_unique( $all_items ) );
 		$this->prelim_check_regex = sprintf( $this->regex_pattern, $all_items );
 

--- a/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/WordPress/AbstractVariableRestrictionsSniff.php
@@ -147,7 +147,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 		}
 
 		// Check if it is a function not a variable.
-		if ( in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
+		if ( \in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
 			$method               = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
 			$possible_parenthesis = $this->phpcsFile->findNext( \T_WHITESPACE, ( $method + 1 ), null, true );
 			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
@@ -164,13 +164,13 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 			$patterns = array();
 
 			// Simple variable.
-			if ( in_array( $token['code'], array( \T_VARIABLE, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
+			if ( \in_array( $token['code'], array( \T_VARIABLE, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
 				$patterns = array_merge( $patterns, $group['variables'] );
 				$var      = $token['content'];
 
 			}
 
-			if ( in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
+			if ( \in_array( $token['code'], array( \T_OBJECT_OPERATOR, \T_DOUBLE_COLON, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
 				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
 				$patterns = array_merge( $patterns, $group['object_vars'] );
 
@@ -180,7 +180,7 @@ abstract class AbstractVariableRestrictionsSniff extends Sniff {
 
 			}
 
-			if ( in_array( $token['code'], array( \T_OPEN_SQUARE_BRACKET, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
+			if ( \in_array( $token['code'], array( \T_OPEN_SQUARE_BRACKET, \T_DOUBLE_QUOTED_STRING, \T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
 				// Array members.
 				$patterns = array_merge( $patterns, $group['array_members'] );
 

--- a/WordPress/PHPCSAliases.php
+++ b/WordPress/PHPCSAliases.php
@@ -23,7 +23,7 @@
  * external PHPCS standards creating cross-version compatibility in the same
  * manner.}}
  */
-if ( ! defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
+if ( ! \defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
 	// PHPCS base classes/interface.
 	if ( ! interface_exists( '\PHP_CodeSniffer_Sniff' ) ) {
 		class_alias( 'PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff' );

--- a/WordPress/PHPCSHelper.php
+++ b/WordPress/PHPCSHelper.php
@@ -33,7 +33,7 @@ class PHPCSHelper {
 	 * @return string
 	 */
 	public static function get_version() {
-		if ( defined( '\PHP_CodeSniffer\Config::VERSION' ) ) {
+		if ( \defined( '\PHP_CodeSniffer\Config::VERSION' ) ) {
 			// PHPCS 3.x.
 			return \PHP_CodeSniffer\Config::VERSION;
 		} else {

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1015,7 +1015,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			$method .= 'Warning';
 		}
 
-		return call_user_func( array( $this->phpcsFile, $method ), $message, $stackPtr, $code, $data, $severity );
+		return \call_user_func( array( $this->phpcsFile, $method ), $message, $stackPtr, $code, $data, $severity );
 	}
 
 	/**
@@ -1069,12 +1069,12 @@ abstract class Sniff implements PHPCS_Sniff {
 			$base = array_filter( $base );
 		}
 
-		if ( empty( $custom ) || ( ! is_array( $custom ) && ! is_string( $custom ) ) ) {
+		if ( empty( $custom ) || ( ! \is_array( $custom ) && ! \is_string( $custom ) ) ) {
 			return $base;
 		}
 
 		// Allow for a comma delimited list.
-		if ( is_string( $custom ) ) {
+		if ( \is_string( $custom ) ) {
 			$custom = explode( ',', $custom );
 		}
 
@@ -1263,7 +1263,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function is_test_class( $stackPtr ) {
 
 		if ( ! isset( $this->tokens[ $stackPtr ] )
-			|| in_array( $this->tokens[ $stackPtr ]['type'], array( 'T_CLASS', 'T_ANON_CLASS', 'T_TRAIT' ), true ) === false
+			|| \in_array( $this->tokens[ $stackPtr ]['type'], array( 'T_CLASS', 'T_ANON_CLASS', 'T_TRAIT' ), true ) === false
 		) {
 			return false;
 		}
@@ -1492,7 +1492,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		end( $nested_parenthesis );
 		$open_parenthesis = key( $nested_parenthesis );
 
-		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( \T_ISSET, \T_EMPTY ), true );
+		return \in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( \T_ISSET, \T_EMPTY ), true );
 	}
 
 	/**
@@ -1525,7 +1525,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// The only parentheses should belong to the sanitizing function. If there's
 		// more than one set, this isn't *only* sanitization.
-		return ( count( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === 1 );
+		return ( \count( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === 1 );
 	}
 
 	/**
@@ -1548,7 +1548,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		);
 
 		// Check if it is a safe cast.
-		return in_array( $this->tokens[ $prev ]['code'], array( \T_INT_CAST, \T_DOUBLE_CAST, \T_BOOL_CAST ), true );
+		return \in_array( $this->tokens[ $prev ]['code'], array( \T_INT_CAST, \T_DOUBLE_CAST, \T_BOOL_CAST ), true );
 	}
 
 	/**
@@ -1795,7 +1795,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
-			if ( ! in_array( $this->tokens[ $i ]['code'], array( \T_ISSET, \T_EMPTY, \T_UNSET ), true ) ) {
+			if ( ! \in_array( $this->tokens[ $i ]['code'], array( \T_ISSET, \T_EMPTY, \T_UNSET ), true ) ) {
 				continue;
 			}
 
@@ -1945,7 +1945,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$variables = array();
 		if ( preg_match_all( '/(?P<backslashes>\\\\*)\$(?P<symbol>\w+)/', $string, $match_sets, \PREG_SET_ORDER ) ) {
 			foreach ( $match_sets as $matches ) {
-				if ( ! isset( $matches['backslashes'] ) || ( strlen( $matches['backslashes'] ) % 2 ) === 0 ) {
+				if ( ! isset( $matches['backslashes'] ) || ( \strlen( $matches['backslashes'] ) % 2 ) === 0 ) {
 					$variables[] = $matches['symbol'];
 				}
 			}
@@ -1998,7 +1998,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Is this one of the tokens this function handles ?
-		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], array( \T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY ), true ) ) {
+		if ( false === \in_array( $this->tokens[ $stackPtr ]['code'], array( \T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY ), true ) ) {
 			return false;
 		}
 
@@ -2063,7 +2063,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			return 0;
 		}
 
-		return count( $this->get_function_call_parameters( $stackPtr ) );
+		return \count( $this->get_function_call_parameters( $stackPtr ) );
 	}
 
 	/**
@@ -2113,7 +2113,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Which nesting level is the one we are interested in ?
 		if ( isset( $this->tokens[ $opener ]['nested_parenthesis'] ) ) {
-			$nestedParenthesisCount += count( $this->tokens[ $opener ]['nested_parenthesis'] );
+			$nestedParenthesisCount += \count( $this->tokens[ $opener ]['nested_parenthesis'] );
 		}
 
 		$parameters  = array();
@@ -2146,7 +2146,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			// Ignore comma's at a lower nesting level.
 			if ( \T_COMMA === $this->tokens[ $next_comma ]['code']
 				&& isset( $this->tokens[ $next_comma ]['nested_parenthesis'] )
-				&& count( $this->tokens[ $next_comma ]['nested_parenthesis'] ) !== $nestedParenthesisCount
+				&& \count( $this->tokens[ $next_comma ]['nested_parenthesis'] ) !== $nestedParenthesisCount
 			) {
 				continue;
 			}

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -191,7 +191,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 			if ( ( false === $this->allow_single_item_single_line_associative_arrays
 					&& ! empty( $array_items ) )
 				|| ( true === $this->allow_single_item_single_line_associative_arrays
-					&& count( $array_items ) > 1 )
+					&& \count( $array_items ) > 1 )
 			) {
 				/*
 				 * Make sure the double arrow is for *this* array, not for a nested one.
@@ -290,7 +290,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 				'Expected 1 space after array opener, found %s.',
 				$opener,
 				'SpaceAfterArrayOpener',
-				array( strlen( $this->tokens[ ( $opener + 1 ) ]['content'] ) )
+				array( \strlen( $this->tokens[ ( $opener + 1 ) ]['content'] ) )
 			);
 
 			if ( true === $fix ) {
@@ -315,7 +315,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 				'Expected 1 space before array closer, found %s.',
 				$closer,
 				'SpaceBeforeArrayCloser',
-				array( strlen( $this->tokens[ ( $closer - 1 ) ]['content'] ) )
+				array( \strlen( $this->tokens[ ( $closer - 1 ) ]['content'] ) )
 			);
 
 			if ( true === $fix ) {

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -470,7 +470,7 @@ class ArrayIndentationSniff extends Sniff {
 			$whitespace     = str_replace( $actual_comment, '', $content );
 		}
 
-		return strlen( $whitespace );
+		return \strlen( $whitespace );
 	}
 
 	/**

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -80,7 +80,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 			return;
 		}
 
-		$array_item_count = count( $array_items );
+		$array_item_count = \count( $array_items );
 
 		// Note: $item_index is 1-based and the array items are split on the commas!
 		foreach ( $array_items as $item_index => $item ) {

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -282,7 +282,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		$index_end_cols    = array(); // Keep track of the end column position of index keys.
 		$double_arrow_cols = array(); // Keep track of arrow column position and count.
 		$multi_line_count  = 0;
-		$total_items       = count( $items );
+		$total_items       = \count( $items );
 
 		foreach ( $items as $key => $item ) {
 			if ( strpos( $item['raw'], '=>' ) === false ) {
@@ -428,7 +428,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 			reset( $double_arrow_cols );
 			$count = current( $double_arrow_cols );
 
-			if ( $count > 1 || ( 1 === $count && count( $items ) === 1 ) ) {
+			if ( $count > 1 || ( 1 === $count && \count( $items ) === 1 ) ) {
 				// Allow for several groups of arrows having the same $count.
 				$filtered_double_arrow_cols = array_keys( $double_arrow_cols, $count, true );
 
@@ -584,7 +584,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				$operator = $matches[1];
 				$number   = (int) $matches[2];
 
-				if ( in_array( $operator, array( '<', '<=', '>', '>=', '==', '=', '!=', '<>' ), true ) === true
+				if ( \in_array( $operator, array( '<', '<=', '>', '>=', '==', '=', '!=', '<>' ), true ) === true
 					&& ( $number >= 0 && $number <= 100 )
 				) {
 					$this->alignMultilineItems = $alignMultilineItems;

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -194,7 +194,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 
 						if ( isset( $this->cacheDeleteFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
 
-							if ( in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
+							if ( \in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
 								$cached = true;
 								break;
 							}

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -184,7 +184,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 		$variable_found           = false;
 		$sql_wildcard_found       = false;
 		$total_placeholders       = 0;
-		$total_parameters         = count( $parameters );
+		$total_parameters         = \count( $parameters );
 		$valid_in_clauses         = array(
 			'uses_in'          => 0,
 			'implode_fill'     => 0,
@@ -218,7 +218,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 							$skip_to    = ( $last_param['end'] + 1 );
 
 							$valid_in_clauses['implode_fill']     += $this->analyse_sprintf( $sprintf_parameters );
-							$valid_in_clauses['adjustment_count'] += ( count( $sprintf_parameters ) - 1 );
+							$valid_in_clauses['adjustment_count'] += ( \count( $sprintf_parameters ) - 1 );
 						}
 						unset( $sprintf_parameters, $last_param );
 
@@ -510,7 +510,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 		}
 
-		$total_replacements  = count( $replacements );
+		$total_replacements  = \count( $replacements );
 		$total_placeholders -= $valid_in_clauses['adjustment_count'];
 
 		// Bow out when `IN` clauses have been used which appear to be correct.
@@ -624,7 +624,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 	protected function analyse_implode( $implode_token ) {
 		$implode_params = $this->get_function_call_parameters( $implode_token );
 
-		if ( empty( $implode_params ) || count( $implode_params ) !== 2 ) {
+		if ( empty( $implode_params ) || \count( $implode_params ) !== 2 ) {
 			return false;
 		}
 
@@ -651,7 +651,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 
 		$array_fill_params = $this->get_function_call_parameters( $array_fill );
 
-		if ( empty( $array_fill_params ) || count( $array_fill_params ) !== 3 ) {
+		if ( empty( $array_fill_params ) || \count( $array_fill_params ) !== 3 ) {
 			return false;
 		}
 

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -68,7 +68,7 @@ class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			 * Only throw the warning about a deprecated comment when the sniff would otherwise
 			 * have been triggered on the array key.
 			 */
-			if ( in_array( $this->tokens[ $stackPtr ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( \in_array( $this->tokens[ $stackPtr ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				$this->phpcsFile->addWarning(
 					'The "tax_query" whitelist comment is deprecated in favor of the "slow query" whitelist comment.',
 					$stackPtr,

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -118,7 +118,7 @@ class FileNameSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		if ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
+		if ( \defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
 			$this->class_exceptions = array_merge( $this->class_exceptions, $this->unittest_class_exceptions );
 		}
 
@@ -145,7 +145,7 @@ class FileNameSniff extends Sniff {
 		}
 
 		// Respect phpcs:disable comments as long as they are not accompanied by an enable (PHPCS 3.2+).
-		if ( defined( '\T_PHPCS_DISABLE' ) && defined( '\T_PHPCS_ENABLE' ) ) {
+		if ( \defined( '\T_PHPCS_DISABLE' ) && \defined( '\T_PHPCS_ENABLE' ) ) {
 			$i = -1;
 			while ( $i = $this->phpcsFile->findNext( \T_PHPCS_DISABLE, ( $i + 1 ) ) ) {
 				if ( empty( $this->tokens[ $i ]['sniffCodes'] )
@@ -223,8 +223,8 @@ class FileNameSniff extends Sniff {
 
 					if ( ( 'Template' === trim( $this->tokens[ $subpackage ]['content'] )
 						&& $this->tokens[ $subpackage_tag ]['line'] === $this->tokens[ $subpackage ]['line'] )
-						&& ( ( ! defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
-						|| ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
+						&& ( ( ! \defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
+						|| ( \defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
 						&& false === $has_class
 					) {
 						$this->phpcsFile->addError(

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -347,7 +347,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					}
 
 					$item_name = $this->tokens[ $constant_name_ptr ]['content'];
-					if ( defined( '\\' . $item_name ) ) {
+					if ( \defined( '\\' . $item_name ) ) {
 						// Backfill for PHP native constant.
 						return;
 					}
@@ -702,7 +702,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( 'define' === $matched_content ) {
-			if ( defined( '\\' . $raw_content ) ) {
+			if ( \defined( '\\' . $raw_content ) ) {
 				// Backfill for PHP native constant.
 				return;
 			}

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -108,7 +108,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			$content[ $i ]  = $this->tokens[ $i ]['content'];
 			$expected[ $i ] = $this->tokens[ $i ]['content'];
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( \in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				$string = $this->strip_quotes( $this->tokens[ $i ]['content'] );
 
 				/*
@@ -170,7 +170,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 */
 	protected function prepare_regex() {
 		$extra = '';
-		if ( '' !== $this->additionalWordDelimiters && is_string( $this->additionalWordDelimiters ) ) {
+		if ( '' !== $this->additionalWordDelimiters && \is_string( $this->additionalWordDelimiters ) ) {
 			$extra = preg_quote( $this->additionalWordDelimiters, '`' );
 		}
 
@@ -218,7 +218,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 		$braces      = 0;
 
 		foreach ( $output as $i => $part ) {
-			if ( in_array( $part, array( '$', '{' ), true ) ) {
+			if ( \in_array( $part, array( '$', '{' ), true ) ) {
 				$is_variable = true;
 				if ( '{' === $part ) {
 					$has_braces = true;
@@ -232,7 +232,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 					$has_braces = true;
 					$braces++;
 				}
-				if ( in_array( $part, array( '}', ']' ), true ) ) {
+				if ( \in_array( $part, array( '}', ']' ), true ) ) {
 					$braces--;
 				}
 				if ( false === $has_braces && ' ' === $part ) {
@@ -240,7 +240,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 					$output[ $i ] = $this->transform( $part, $regex, $transform_type );
 				}
 
-				if ( ( true === $has_braces && 0 === $braces ) && false === in_array( $output[ ( $i + 1 ) ], array( '{', '[' ), true ) ) {
+				if ( ( true === $has_braces && 0 === $braces ) && false === \in_array( $output[ ( $i + 1 ) ], array( '{', '[' ), true ) ) {
 					$has_braces  = false;
 					$is_variable = false;
 				}

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -55,7 +55,7 @@ class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		if ( count( $parameters ) > 1 ) {
+		if ( \count( $parameters ) > 1 ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -74,7 +74,7 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		// Check if the strict check is actually needed.
 		if ( false === $this->target_functions[ $matched_content ] ) {
-			if ( count( $parameters ) === 1 ) {
+			if ( \count( $parameters ) === 1 ) {
 				return;
 			}
 		}

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -106,7 +106,7 @@ class YodaConditionsSniff extends Sniff {
 			$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
 		}
 
-		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( \T_SELF, \T_PARENT, \T_STATIC ), true ) ) {
+		if ( \in_array( $this->tokens[ $next_non_empty ]['code'], array( \T_SELF, \T_PARENT, \T_STATIC ), true ) ) {
 			$next_non_empty = $this->phpcsFile->findNext(
 				array_merge( Tokens::$emptyTokens, array( \T_DOUBLE_COLON ) ),
 				( $next_non_empty + 1 ),

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -232,7 +232,7 @@ class EscapeOutputSniff extends Sniff {
 			}
 
 			// These functions only need to have the first argument escaped.
-			if ( in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
+			if ( \in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
 				$first_param      = $this->get_function_call_parameter( $stackPtr, 1 );
 				$end_of_statement = ( $first_param['end'] + 1 );
 				unset( $first_param );
@@ -361,7 +361,7 @@ class EscapeOutputSniff extends Sniff {
 				continue;
 			}
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( \T_DOUBLE_ARROW, \T_CLOSE_PARENTHESIS ), true ) ) {
+			if ( \in_array( $this->tokens[ $i ]['code'], array( \T_DOUBLE_ARROW, \T_CLOSE_PARENTHESIS ), true ) ) {
 				continue;
 			}
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -109,7 +109,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// Check if this is a superglobal.
-		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
+		if ( ! \in_array( $this->tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -152,7 +152,7 @@ class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
 		$selectors = array_map(
 			'preg_quote',
 			$this->target_css_selectors,
-			array_fill( 0, count( $this->target_css_selectors ), '`' )
+			array_fill( 0, \count( $this->target_css_selectors ), '`' )
 		);
 		// Parse the selectors array into the regex string.
 		$this->target_css_selectors_regex = sprintf( $this->target_css_selectors_regex, implode( '|', $selectors ) );

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -94,7 +94,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 		$key = strtolower( $key );
 
 		if ( ( 'nopaging' === $key && ( 'true' === $val || 1 === $val ) )
-			|| ( in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' === $val )
+			|| ( \in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' === $val )
 		) {
 			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
 		}

--- a/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -44,7 +44,7 @@ class SuperGlobalInputUsageSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		// Check for global input variable.
-		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], $this->input_superglobals, true ) ) {
+		if ( ! \in_array( $this->tokens[ $stackPtr ]['content'], $this->input_superglobals, true ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -210,7 +210,7 @@ class CapitalPDangitSniff extends Sniff {
 			if ( isset( $this->text_and_comment_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
 				$offset = 0;
 				foreach ( $matches[1] as $key => $match_data ) {
-					$next_offset = ( $match_data[1] + strlen( $match_data[0] ) );
+					$next_offset = ( $match_data[1] + \strlen( $match_data[0] ) );
 
 					// Prevent matches on part of a URL.
 					if ( preg_match( '`http[s]?://[^\s<>\'"()]*' . preg_quote( $match_data[0], '`' ) . '`', $content, $discard, 0, $offset ) === 1 ) {
@@ -245,7 +245,7 @@ class CapitalPDangitSniff extends Sniff {
 				$stackPtr,
 				'Misspelled',
 				array(
-					count( $mispelled ),
+					\count( $mispelled ),
 					implode( ', ', $mispelled ),
 				)
 			);
@@ -254,7 +254,7 @@ class CapitalPDangitSniff extends Sniff {
 				// Apply fixes based on offset to ensure we don't replace false positives.
 				$replacement = $content;
 				foreach ( $matches[1] as $match ) {
-					$replacement = substr_replace( $replacement, 'WordPress', $match[1], strlen( $match[0] ) );
+					$replacement = substr_replace( $replacement, 'WordPress', $match[1], \strlen( $match[0] ) );
 				}
 
 				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
@@ -272,7 +272,7 @@ class CapitalPDangitSniff extends Sniff {
 		$mispelled = array();
 		foreach ( $match_stack as $match ) {
 			// Deal with multi-dimensional arrays when capturing offset.
-			if ( is_array( $match ) ) {
+			if ( \is_array( $match ) ) {
 				$match = $match[0];
 			}
 

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -150,7 +150,7 @@ class CronIntervalSniff extends Sniff {
 		$closing = $this->tokens[ $functionPtr ]['scope_closer'];
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
-			if ( in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
+			if ( \in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 				if ( 'interval' === $this->strip_quotes( $this->tokens[ $i ]['content'] ) ) {
 					$operator = $this->phpcsFile->findNext( \T_DOUBLE_ARROW, $i, null, false, null, true );
 					if ( false === $operator ) {

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -281,7 +281,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 
 		$this->get_wp_version_from_cl();
 
-		$paramCount = count( $parameters );
+		$paramCount = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 
 			// Check that number of parameters defined is not less than the position to check.

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -134,7 +134,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			for ( $ptr = $start; $ptr < $end; $ptr++ ) {
 
 				// If the global statement was in the global scope, skip over functions, classes and the likes.
-				if ( true === $global_scope && in_array( $this->tokens[ $ptr ]['code'], array( \T_FUNCTION, \T_CLOSURE, \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ), true ) ) {
+				if ( true === $global_scope && \in_array( $this->tokens[ $ptr ]['code'], array( \T_FUNCTION, \T_CLOSURE, \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ), true ) ) {
 					if ( ! isset( $this->tokens[ $ptr ]['scope_closer'] ) ) {
 						// Live coding, skip the rest of the file.
 						return;
@@ -145,7 +145,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				}
 
 				if ( \T_VARIABLE === $this->tokens[ $ptr ]['code']
-					&& in_array( $this->tokens[ $ptr ]['content'], $search, true )
+					&& \in_array( $this->tokens[ $ptr ]['content'], $search, true )
 				) {
 					// Don't throw false positives for static class properties.
 					$previous = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -198,9 +198,9 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		$this->text_domain = $this->merge_custom_array( $this->text_domain, array(), false );
 
 		if ( ! empty( $this->text_domain ) ) {
-			if ( in_array( 'default', $this->text_domain, true ) ) {
+			if ( \in_array( 'default', $this->text_domain, true ) ) {
 				$this->text_domain_contains_default = true;
-				if ( count( $this->text_domain ) === 1 ) {
+				if ( \count( $this->text_domain ) === 1 ) {
 					$this->text_domain_is_default = true;
 				}
 			}
@@ -240,7 +240,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			return;
 		}
 
-		if ( in_array( $matched_content, array( 'translate', 'translate_with_gettext_context' ), true ) ) {
+		if ( \in_array( $matched_content, array( 'translate', 'translate_with_gettext_context' ), true ) ) {
 			$this->phpcsFile->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $matched_content ) );
 		}
 
@@ -415,7 +415,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		$is_error  = empty( $context['warning'] );
 		$content   = isset( $tokens[0] ) ? $tokens[0]['content'] : '';
 
-		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
+		if ( empty( $tokens ) || 0 === \count( $tokens ) ) {
 			$code = $this->string_to_errorcode( 'MissingArg' . ucfirst( $arg_name ) );
 			if ( 'domain' !== $arg_name ) {
 				$this->addMessage( 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
@@ -441,7 +441,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			return false;
 		}
 
-		if ( count( $tokens ) > 1 ) {
+		if ( \count( $tokens ) > 1 ) {
 			$contents = '';
 			foreach ( $tokens as $token ) {
 				$contents .= $token['content'];
@@ -451,7 +451,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			return false;
 		}
 
-		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
+		if ( \in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
 			$this->check_text( $context );
 		}
 
@@ -470,7 +470,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) ) {
 				$stripped_content = $this->strip_quotes( $content );
 
-				if ( ! in_array( $stripped_content, $this->text_domain, true ) ) {
+				if ( ! \in_array( $stripped_content, $this->text_domain, true ) ) {
 					$this->addMessage(
 						'Mismatched text domain. Expected \'%s\' but got %s.',
 						$stack_ptr,
@@ -540,7 +540,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 		// English conflates "singular" with "only one", described in the codex:
 		// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals .
-		if ( count( $single_placeholders ) < count( $plural_placeholders ) ) {
+		if ( \count( $single_placeholders ) < \count( $plural_placeholders ) ) {
 			$error_string = 'Missing singular placeholder, needed for some languages. See https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals';
 			$single_index = $single_context['tokens'][0]['token_index'];
 
@@ -638,7 +638,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	protected function check_for_translator_comment( $stack_ptr, $args ) {
 		foreach ( $args as $arg ) {
-			if ( false === in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
+			if ( false === \in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
 				continue;
 			}
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -535,7 +535,7 @@ class ControlStructureSpacingSniff extends Sniff {
 		) {
 			// Another control structure's closing brace.
 			$owner = $this->tokens[ $trailingContent ]['scope_condition'];
-			if ( in_array( $this->tokens[ $owner ]['code'], array( \T_FUNCTION, \T_CLOSURE, \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ), true ) ) {
+			if ( \in_array( $this->tokens[ $owner ]['code'], array( \T_FUNCTION, \T_CLOSURE, \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ), true ) ) {
 				// The next content is the closing brace of a function, class, interface or trait
 				// so normal function/class rules apply and we can ignore it.
 				return;

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -148,7 +148,7 @@ class PrecisionAlignmentSniff extends Sniff {
 					 */
 					$comment    = ltrim( $this->tokens[ $i ]['content'] );
 					$whitespace = str_replace( $comment, '', $this->tokens[ $i ]['content'] );
-					$length     = strlen( $whitespace );
+					$length     = \strlen( $whitespace );
 					$spaces     = ( $length % $this->tab_width );
 
 					if ( isset( $comment[0] ) && '*' === $comment[0] && 0 !== $spaces ) {
@@ -165,7 +165,7 @@ class PrecisionAlignmentSniff extends Sniff {
 						 */
 						$content    = ltrim( $this->tokens[ $i ]['content'] );
 						$whitespace = str_replace( $content, '', $this->tokens[ $i ]['content'] );
-						$spaces     = ( strlen( $whitespace ) % $this->tab_width );
+						$spaces     = ( \strlen( $whitespace ) % $this->tab_width );
 					}
 					break;
 			}

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -125,7 +125,7 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		}
 
 		// Work around for PHPCS < 3.2.0. The disables will be diregarded.
-		if ( ! defined( '\T_PHPCS_DISABLE' ) && ! defined( '\T_PHPCS_ENABLE' ) ) {
+		if ( ! \defined( '\T_PHPCS_DISABLE' ) && ! \defined( '\T_PHPCS_ENABLE' ) ) {
 			$this->expected_results['blanket-disable.inc']   = 1;
 			$this->expected_results['rule-disable.inc']      = 1;
 			$this->expected_results['wordpress-disable.inc'] = 1;

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -54,7 +54,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					// Backfills.
 					225 => ( function_exists( '\mb_strpos' ) ) ? 0 : 1,
 					230 => ( function_exists( '\array_column' ) ) ? 0 : 1,
-					234 => ( defined( '\E_DEPRECATED' ) ) ? 0 : 1,
+					234 => ( \defined( '\E_DEPRECATED' ) ) ? 0 : 1,
 					238 => ( class_exists( '\IntlTimeZone' ) ) ? 0 : 1,
 					318 => 1,
 					339 => 1,


### PR DESCRIPTION
Functions in PHP are namespaced as well, however, when PHP cannot find the function in the namespace, it will fall through to the global namespace.

The step to first check within the namespace can be skipped by either using `use func ...` (PHP 5.6+) or by prefixing the function with a `\`.

While this offers a small performance gain as a general practice, using this for the special compiled functions should offer a noticeable performance gain when running WPCS on PHP 7+.
The special compiled functions are replaced by opcodes at compile time, but only if it's clear at compile time that the global PHP native functions will be used.
For the list of functions, see: https://github.com/php/php-src/blob/f2db305fa4e9bd7d04d567822687ec714aedcdb5/Zend/zend_compile.c#L3872

This PR implements this throughout the codebase.

@GaryJones You meant this, didn't you ?