### PR TITLE
Travis/PHPCS: check WPCS own code for PHP cross-version compatibility

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,4 +33,22 @@
 
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
+	<!-- Check code for cross-version PHP compatibility. -->
+	<config name="testVersion" value="5.3-"/>
+	<rule ref="PHPCompatibility">
+		<!-- Exclude PHP constants back-filled by PHPCS. -->
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_yieldFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_ellipsisFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_powFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_pow_equalFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_spaceshipFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesceFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_yield_fromFound"/>
+
+		<!-- Unclear how, but appears to be back-filled anyhow, could be that PHP did so before the token was in use. -->
+		<exclude name="PHPCompatibility.PHP.NewConstants.t_traitFound"/>
+	</rule>
+
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,18 @@ php:
 
 env:
   # `master` is now 3.x.
-  - PHPCS_BRANCH=master LINT=1
+  - PHPCS_BRANCH="dev-master" LINT=1
   # Lowest supported release in the 3.x series with which WPCS is compatible (and which can run the unit tests).
-  - PHPCS_BRANCH=3.1.0
+  - PHPCS_BRANCH="3.1.0"
   # Lowest tagged release in the 2.x series with which WPCS is compatible.
-  - PHPCS_BRANCH=2.9.0
+  - PHPCS_BRANCH="2.9.0"
 
 matrix:
   fast_finish: true
   include:
     # Run PHPCS against WPCS. I just picked to run it against 7.2.
     - php: 7.2
-      env: PHPCS_BRANCH=master SNIFF=1
+      env: PHPCS_BRANCH="dev-master" SNIFF=1
       addons:
         apt:
           packages:
@@ -38,11 +38,11 @@ matrix:
 
     # Test PHP 5.3 only against PHPCS 2.x as PHPCS 3.x has a minimum requirement of PHP 5.4.
     - php: 5.3
-      env: PHPCS_BRANCH=2.9 LINT=1
+      env: PHPCS_BRANCH="2.9.*" LINT=1
       dist: precise
     # Test PHP 5.3 with short_open_tags set to On (is Off by default)
     - php: 5.3
-      env: PHPCS_BRANCH=2.9.0 SHORT_OPEN_TAGS=true
+      env: PHPCS_BRANCH="2.9.0" SHORT_OPEN_TAGS=true
       dist: precise
 
   allow_failures:
@@ -55,11 +55,22 @@ before_install:
     # https://twitter.com/kelunik/status/954242454676475904
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     - export XMLLINT_INDENT="	"
-    - export PHPCS_DIR=/tmp/phpcs
     - export PHPUNIT_DIR=/tmp/phpunit
-    - export PHPCS_BIN=$(if [[ ${PHPCS_BRANCH:0:2} != "2." ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi)
-    - mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_BRANCH $PHPCS_DIR
-    - $PHPCS_BIN --config-set installed_paths $(pwd)
+    - |
+      if [[ ${PHPCS_BRANCH:0:2} == "2." ]]; then
+          # --prefer-source is needed to ensure that the PHPCS unit test suite is available in PHPCS 2.9.
+          composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --prefer-source --update-no-dev --no-suggest --no-scripts
+      else
+          composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --update-no-dev --no-suggest --no-scripts
+      fi
+    - |
+      if [[ "$SNIFF" == "1" ]]; then
+          composer install --dev --no-suggest
+          # The post-install-cmd script takes care of the installed_paths.
+      else
+          # The above require already does the install.
+          $(pwd)/vendor/bin/phpcs --config-set installed_paths $(pwd)
+      fi
     # Download PHPUnit 5.x for builds on PHP 7 and nightly as the PHPCS
     # test suite is currently not compatible with PHPUnit 6.x.
     # Fixed at a very specific PHPUnit version.
@@ -69,22 +80,22 @@ before_install:
 
 script:
     # Lint the PHP files against parse errors.
-    - if [[ "$LINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then phpunit --filter WordPress $(pwd)/Test/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --filter WordPress $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar --filter WordPress $(pwd)/Test/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar  --filter WordPress $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then php $PHPUNIT_DIR/phpunit-5.7.17.phar  --filter WordPress $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php; fi
     # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
     # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
     # For the first run, the exit code will be 1 (= all fixable errors fixed).
     # `travis_retry` should then kick in to run the fixer again which should now return 0 (= no fixable errors found).
     # All error codes for the PHPCBF: https://github.com/squizlabs/PHP_CodeSniffer/issues/1270#issuecomment-272768413
-    - if [[ "$SNIFF" == "1" ]]; then travis_retry $PHPCS_DIR/bin/phpcbf -p ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary; fi
+    - if [[ "$SNIFF" == "1" ]]; then travis_retry $(pwd)/vendor/bin/phpcbf -p ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN --runtime-set ignore_warnings_on_exit 1; fi
+    - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
     - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./*/ruleset.xml; fi

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -318,6 +318,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							break;
 
 						case 'T_TRAIT':
+							// phpcs:ignore PHPCompatibility.PHP.NewFunctions.trait_existsFound
 							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native trait.
 								return;

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
 		"php" : ">=5.3",
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
+	"require-dev" : {
+		"wimg/php-compatibility": "*"
+	},
 	"suggest" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
@@ -25,7 +28,7 @@
 	},
 	"type"       : "phpcodesniffer-standard",
 	"scripts"    : {
-		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..",
-		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wimg/php-compatibility",
+		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wimg/php-compatibility"
 	}
 }


### PR DESCRIPTION
As the code in WPCS itself should be compatible with PHP 5.3 - nightly, why not let the PHPCompatibility standard check this for us ?

Composer:
* Adds `require-dev` section to `composer.json`.
* Adds install path for PHPCompatibility to the default script.
    This is only run when WPCS is installed from the root, so only relevant for devs, so adding PHPCompatibility there can be considered "safe".
    Note: PHPCS will complain if it is run with this installed path if PHPCompatibility is not installed, i.e. if Composer was run from root with `--no-dev`.

Travis:
* Switches over the Travis script to use Composer to install the dependencies.
    - As the bootstraps are already coded to pick up PHPCS when installed in the `vendor` directory, no need for the `PHPCS_DIR` variable anymore.
    - As the `phpcs` executable will always be in the `vendor/bin/` directory, no need for the `PHPCS_BIN` variable anymore.
    - `--(update-)no-dev` is used as for the unit test runs, we don't need PHPCompatibility for those.
    - For PHPCS 2.x installing with `--prefer-source` is needed as otherwise the unit tests base files we need are not included in the install.
    - `--no-scripts` is used as the script in the `composer.json` file presumes PHPCompatibility, while for most builds it will not be available.
    - For the non-sniff runs, the `installed_paths` command is run. For the sniff-run, a` composer install` (with `dev`) is run which will let the `post-install-cmd` run this for us.
* Adjusted the `PHP_BRANCH` environment variable values to be usable by Composer.
* Excludes the `vendor` directory from the PHP lint check in the Travis script.

WPCS own ruleset:
* Adds the PHPCompatibility standard, set the `testVersion` and exclude errors for PHP native constants which are back-filled by PHPCS.

Includes one `phpcs:ignore` for a correctly used function which is not always available.