### PR TITLE
Composer & Readme: update organisation name PHPCompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,15 +150,18 @@ You can find a complete list of all the properties you can change in the [wiki](
 
 ### Recommended additional rulesets
 
-The [PHPCompatibility](https://github.com/wimg/PHPCompatibility) ruleset comes highly recommended.
-The [PHPCompatibility](https://github.com/wimg/PHPCompatibility) sniffs are designed to analyse your code for cross-PHP version compatibility.
-Install it as a separate ruleset and either run it separately against your code or add it to your custom ruleset.
+The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset and its subset [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) come highly recommended.
+The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyse your code for cross-PHP version compatibility.
+
+The [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset is based on PHPCompatibility, but specifically crafted to prevent false positives for projects which expect to run within the context of WordPress, i.e. core, plugins and themes.
+
+Install either as a separate ruleset and either run it separately against your code or add it to your custom ruleset.
 
 Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `5.2-` to support the same PHP versions as WordPress Core supports.
 
 For more information about setting the `testVersion`, see:
-* [PHPCompatibility: Sniffing your code for compatibility with specific PHP version(s)](https://github.com/wimg/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions)
-* [PHPCompatibility: Using a custom ruleset](https://github.com/wimg/PHPCompatibility#using-a-custom-ruleset)
+* [PHPCompatibility: Sniffing your code for compatibility with specific PHP version(s)](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions)
+* [PHPCompatibility: Using a custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset)
 
 ## How to use
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"require-dev" : {
-		"wimg/php-compatibility": "*"
+		"phpcompatibility/php-compatibility": "*"
 	},
 	"suggest" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -28,7 +28,7 @@
 	},
 	"type"       : "phpcodesniffer-standard",
 	"scripts"    : {
-		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wimg/php-compatibility",
-		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../wimg/php-compatibility"
+		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
+		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility"
 	}
 }


### PR DESCRIPTION
Since this week, the PHPCompatibility has been moved to a dedicated GitHub organisation account.

A `PHPCompatibilityWP` ruleset is now also available in a separate repo which already excludes all back-fills/poly-fills which WP provides.

For more details, see the [release notes of the PHPCompatibility 8.2.0 release](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0).


:point_right: I was also wondering whether we should start to `suggest` the `PHPCompatibilityWP` ruleset from Composer, usage of which has become easy now it is in its own repo.