### PR TITLE
Fix NoSpacesAroundArrayKeys doesn't like dynamic strings

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -52,7 +52,7 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 		}
 
 		$need_spaces = $this->phpcsFile->findNext(
-			array( \T_CONSTANT_ENCAPSED_STRING, \T_LNUMBER, \T_WHITESPACE, \T_MINUS ),
+			array( T_DOUBLE_QUOTED_STRING, \T_CONSTANT_ENCAPSED_STRING, \T_LNUMBER, \T_WHITESPACE, \T_MINUS ),
 			( $stackPtr + 1 ),
 			$token['bracket_closer'],
 			true

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
@@ -33,3 +33,9 @@ $arr[0]; // Good.
 $arr[ 0 ]; // Bad.
 $arr[-1]; // Good.
 $arr[ -1 ]; // Bad.
+
+// Dynamic keys
+$events["{$prefix}_before_header"]; // Good.
+$events[ "{$prefix}_before_header"]; // Bad.
+$events["{$prefix}_before_header" ]; // Bad.
+$events[ "{$prefix}_before_header" ]; // Bad.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
@@ -11,11 +11,15 @@ foo( $arr['test'] ); // Good.
 bar( $arr[ 'test'] ); // Bad.
 foo( $arr['test' ] ); // Bad.
 bar( $arr[ 'test' ] ); // Bad.
+foo( $arr["test"] ); // Good.
+bar( $arr[ "test"] ); // Bad.
+foo( $arr["test" ] ); // Bad.
+bar( $arr[ "test" ] ); // Bad.
 
 // Nested ones.
 foo( $arr[ $test[$taz] ] ); // Bad.
 bar( $arr[ $test[ 'taz' ] ] ); // Bad.
-foo( $arr[$test[ 'taz' ]] ); // Bad.
+foo( $arr[$test[ 'taz' ]] ); // Bad x2.
 bar( $arr[ $test['taz'] ] ); // Good.
 
 // Mixed key.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
@@ -11,11 +11,15 @@ foo( $arr['test'] ); // Good.
 bar( $arr['test'] ); // Bad.
 foo( $arr['test'] ); // Bad.
 bar( $arr['test'] ); // Bad.
+foo( $arr["test"] ); // Good.
+bar( $arr["test"] ); // Bad.
+foo( $arr["test"] ); // Bad.
+bar( $arr["test"] ); // Bad.
 
 // Nested ones.
 foo( $arr[ $test[ $taz ] ] ); // Bad.
 bar( $arr[ $test['taz'] ] ); // Bad.
-foo( $arr[ $test['taz'] ] ); // Bad.
+foo( $arr[ $test['taz'] ] ); // Bad x2.
 bar( $arr[ $test['taz'] ] ); // Good.
 
 // Mixed key.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
@@ -33,3 +33,9 @@ $arr[0]; // Good.
 $arr[0]; // Bad.
 $arr[-1]; // Good.
 $arr[-1]; // Bad.
+
+// Dynamic keys
+$events["{$prefix}_before_header"]; // Good.
+$events["{$prefix}_before_header"]; // Bad.
+$events["{$prefix}_before_header"]; // Bad.
+$events["{$prefix}_before_header"]; // Bad.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -34,13 +34,16 @@ class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 			11 => 1,
 			12 => 1,
 			13 => 1,
+			15 => 1,
 			16 => 1,
 			17 => 1,
-			18 => 2,
-			23 => 1,
-			26 => 1,
-			29 => 1,
-			31 => 1,
+			20 => 1,
+			21 => 1,
+			22 => 2,
+			27 => 1,
+			30 => 1,
+			33 => 1,
+			35 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -44,6 +44,9 @@ class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 			30 => 1,
 			33 => 1,
 			35 => 1,
+			39 => 1,
+			40 => 1,
+			41 => 1,
 		);
 	}
 


### PR DESCRIPTION
Fixes #404.

When a simple string is in double quotes, it has a token of `T_CONSTANT_ENCAPSED_STRING`.

When a double-quoted string contains a variable though, the token changes to `T_DOUBLE_QUOTED_STRING`, and we weren't checking for that token when working out if spaces were needed or not.