### PR TITLE
Travis: add a new check for early detection of ruleset problems

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<!-- Exclude the code in the PHPCS 2.x test files copied in from PHPCS. -->
 	<exclude-pattern>/Test/AllTests.php</exclude-pattern>
 	<exclude-pattern>/Test/Standards/*.php</exclude-pattern>
+	<exclude-pattern>/bin/class-ruleset-test.php</exclude-pattern>
 
 	<!-- Exclude Composer vendor directory. -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_install:
 
 script:
     # Lint the PHP files against parse errors.
-    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} == "2." ]]; then phpunit --filter WordPress $(pwd)/Test/AllTests.php; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:2} != "2." ]]; then phpunit --filter WordPress $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php; fi
@@ -92,6 +92,14 @@ script:
     # `travis_retry` should then kick in to run the fixer again which should now return 0 (= no fixable errors found).
     # All error codes for the PHPCBF: https://github.com/squizlabs/PHP_CodeSniffer/issues/1270#issuecomment-272768413
     - if [[ "$SNIFF" == "1" ]]; then travis_retry $(pwd)/vendor/bin/phpcbf -p ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary; fi
+    # Make sure the rulesets don't thrown unexpected errors or warnings.
+    # This check needs to be run against a high PHP version to prevent triggering the syntax error check.
+    # It also needs to be run against all PHPCS versions WPCS is tested against.
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Core; fi
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Docs; fi
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Extra; fi
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-VIP; fi
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress; fi
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/bin/class-ruleset-test.php
+++ b/bin/class-ruleset-test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Simple file which should not have any issues when testing against the WPCS rulesets.
+ *
+ * Most - if not all - sniffs should be triggered by this file.
+ *
+ * Used to do a simple CI test on the rulesets.
+ *
+ * Currently covered - based on the rulesets as of July 24 2018:
+ * - Every WPCS native sniff is triggered.
+ * - Every WPCS + PHPCS sniff within the Core ruleset is triggered.
+ * - Every WPCS + PHPCS sniff within the VIP ruleset is triggered.
+ *
+ * @package WPCS\WordPressCodingStandards
+ */
+
+echo 'Hello world';
+
+$a = function_call();
+
+/**
+ * Class docblock.
+ */
+class Ruleset_Test {
+	/**
+	 * Constant docblock.
+	 *
+	 * @var bool
+	 */
+	const A = false;
+
+	/**
+	 * Property docblock.
+	 *
+	 * @var int
+	 */
+	public $a = 123;
+
+	/**
+	 * Property docblock.
+	 *
+	 * @var array
+	 */
+	protected $array_prop = array(
+		'a' => 1,
+		'b' => 2,
+	);
+
+	/**
+	 * Function docblock.
+	 *
+	 * @param int       $param_a Testing.
+	 * @param bool|null $param_b Testing.
+	 *
+	 * @return void
+	 */
+	public function testing( $param_a, ?bool $param_b = false ): void {
+		?>
+		<a href="<?php echo esc_html( $param_a ); ?>"><?php echo (int) $param_b; ?></a>
+		<?php
+
+		$a = ( $cond ) ? true : false;
+
+		$b = function ( $a ) use ( $param_a ) {
+			if ( preg_match( '`' . preg_quote( $param_a, '`' ) . '`i', $param_b ) === 1 ) {
+				echo esc_html( "doublequoted $string" );
+			} elseif ( $this->a ) {
+				$ab = $a % $b + $c / $d && $param_a || $param_b >> $bitshift;
+			}
+		};
+
+		$c = $this->array_prop['a'];
+		$d = new self();
+		$e = apply_filter( 'filter_name', $d, $c );
+
+		if ( $a == $b ) { // WPCS: loose comparison OK.
+			$f = isset( $_GET['nonce'] ) ? 1 : 2; // WPCS: CSRF ok, input var ok.
+		}
+
+		// @codingStandardsIgnoreLine
+		$g = @eval( 'return true;' );
+
+		switch ( $param_a ) {
+			case 1:
+				echo esc_html( self::A );
+				break;
+			case 2:
+				include_once 'some-file.php';
+				continue;
+		}
+	}
+
+	/**
+	 * Function docblock.
+	 *
+	 * @return void
+	 */
+	public function test_goto() {
+		$i = 0;
+		$j = 50;
+		for ( ; $i < 100; $i++ ) {
+			while ( $j-- ) {
+				if ( 17 === $j ) {
+					// @codingStandardsIgnoreLine
+					goto end;
+				}
+			}
+		}
+
+		// @codingStandardsIgnoreLine
+		end:
+		echo 'This is a goto - it needs to be here to prevent parse errors';
+	}
+
+}


### PR DESCRIPTION
WPCS itself uses `WordPress-Extra` + `WordPress-Docs` for its CS, which includes `WordPress-Core`.

Those rulesets were therefore "tested" on each build, just by running them against the WPCS code.
However, the WPCS native CS ruleset also excludes some things and the CS check ignores warnings for the Travis run and it also left the `WordPress-VIP` and `WordPress` rulesets _untested_.

This PR intends to fix this by adding a minimal test file which should trigger most sniffs and testing each ruleset against it.

This should, from now on, prevent the ruleset issues we've seen related to the moving and deprecating of sniffs, i.e. #1325  and #1425.
This will also serve as an early warning system in case any of the upstream sniffs which are included in the rulesets would be removed/renamed or otherwise have a change in behaviour which WPCS will need to take into account.

Notes:
* This is complimentary to the unit tests as those are run in a ruleset-agnostic manner, i.e. the ruleset isn't loaded and any settings in the ruleset are ignored.
* At this moment, the test file is incomplete, but complete enough for our purposes. Further improvement of the test file in the future to make sure that all sniffs are triggered is recommended.
* The check only needs to be run once against every PHPCS version supported/tested.
    With that in mind, "old-style" ignore annotations have been used.
    Once the minimum PHPCS version WPCS supports goes beyond PHPCS 3.2.0, those should be swopped out for selective ignores instead.
* The check should be run on a high PHP version to prevent triggering the `Generic.PHP.Syntax` sniff when modern PHP code is included in the test file to ensure that this triggers the appropriate sniffs.
    At this moment, the most modern syntax included in nullable types which was introduced in PHP 7.1 which is why that is the PHP version against which these tests are currently run.

**_N.B.: The builds for this PR won't pass until the current issue with the VIP deprecation warnings (#1425) is fixed_**, which is, of course, exactly the point of this PR ;-)