### PR TITLE
WordPress ruleset: fix deprecation notices coming through

### DIFF
--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -6,7 +6,10 @@
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-Extra">
+		<!-- Even though the VIP sniffs are not included in Extra, this will remove them from the scan. -->
+		<exclude name="WordPress.VIP"/>
+	</rule>
 
 	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
 		<!-- From "VIP": The obfuscation group is excluded as there are plenty of legitimate uses for the base64 functions. -->
@@ -15,8 +18,6 @@
 		</properties>
 	</rule>
 
-	<exclude name="WordPress.VIP"/>
-
 	<!--
 	#############################################################################
 	Account for deprecated sniffs.
@@ -24,7 +25,7 @@
 	#############################################################################
 	-->
 
-	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPress.WP.PreparedSQL.DeprecatedSniff">
 		<severity>0</severity>
 	</rule>
@@ -34,7 +35,7 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPress.Functions.DontExtract.DeprecatedSniff">
 		<severity>0</severity>
 	</rule>
@@ -44,7 +45,7 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPress.CSRF.NonceVerification.DeprecatedSniff">
 		<severity>0</severity>
 	</rule>
@@ -54,7 +55,7 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPress.XSS.EscapeOutput.DeprecatedSniff">
 		<severity>0</severity>
 	</rule>
@@ -73,7 +74,7 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Prevent deprecation notice when the sniff is not explicitely included. -->
+	<!-- Prevent deprecation notice when the sniff is not explicitly included. -->
 	<rule ref="WordPress.Variables.GlobalVariables.DeprecatedSniff">
 		<severity>0</severity>
 	</rule>


### PR DESCRIPTION
This "hack" works and seems to be the simplest solution to the issue at hand.

**Beware**: just like in the original VIP deprecation, the VIP sniffs are being `exclude`d. This means that if people use the `WordPress` ruleset and in their custom ruleset reference any of the VIP sniffs, they will **not** see the deprecation warning.

Note: This uses `<exclude>` rather than `severity` as in PHPCS 2.9 severity could only be changed on error code level.
Custom rulesets can overrule this  by changing the `severity` of either the category if using PHPCS 3.x or of the error codes when using PHPCS 2.9.

Fixes #1425

Includes a few more spelling fixes in the same ruleset.