### PR TITLE
Composer: Make script DRY

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 	},
 	"type"       : "phpcodesniffer-standard",
 	"scripts"    : {
-		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
-		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility"
+		"install-codestandards": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
+		"post-install-cmd": "@install-codestandards",
+		"post-update-cmd" : "@install-codestandards"
 	}
 }


### PR DESCRIPTION
Also allows the functionality to be run directly (`composer install-codestandards`) instead of having to do a full `composer install` or `composer update`.