### PR TITLE
Changelog: bring back `unreleased` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [Unreleased]
+
+_No documentation available about unreleased changes as of yet._
+
 ## [1.0.0] - 2018-07-25
 
 ### Important information about this release:


### PR DESCRIPTION
As discussed: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1423#discussion_r202716538

[ci skip]