### PR TITLE
Travis: cache composer downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ dist: trusty
 
 cache:
   apt: true
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
 
 language:
     - php


### PR DESCRIPTION
PR #1415 switched Travis over to using Composer to install the dependencies.

This now adds caching for the packages composer downloads to speed up the build process.