### PR TITLE
New WPCS native `NoSilencedErrors` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -406,7 +406,7 @@
 	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#error-control-operator
 	#############################################################################
 	-->
-	<rule ref="Generic.PHP.NoSilencedErrors"/>
+	<rule ref="WordPress.PHP.NoSilencedErrors"/>
 
 
 	<!--

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -4,6 +4,8 @@
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>
 
+	<rule ref="WordPress-Core"/>
+
 	<!-- Generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
@@ -85,8 +87,6 @@
 		<type>warning</type>
 		<message>Best practice suggestion: Declare only one trait in a file.</message>
 	</rule>
-
-	<rule ref="WordPress-Core"/>
 
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1101 -->
@@ -177,6 +177,15 @@
 	<!-- Verify some regex best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1371 -->
 	<rule ref="WordPress.PHP.PregQuoteDelimiter"/>
+
+	<!-- The Core ruleset respects the whitelist. For `Extra` the sniff is stricter.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1450 -->
+	<rule ref="WordPress.PHP.NoSilencedErrors">
+		<properties>
+			<property name="use_default_whitelist" value="false"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -166,13 +166,13 @@ class NoSilencedErrorsSniff extends Sniff {
 		$this->custom_whitelist = array_map( 'strtolower', $this->custom_whitelist );
 
 		/*
-		 * Check if the error silencing if done for one of the whitelisted functions.
+		 * Check if the error silencing is done for one of the whitelisted functions.
 		 */
-		$nextNonEmpty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
-		if ( false !== $nextNonEmpty && \T_STRING === $this->tokens[ $nextNonEmpty ]['code'] ) {
-			$hasParenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $nextNonEmpty + 1 ), null, true, null, true );
-			if ( false !== $hasParenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $hasParenthesis ]['code'] ) {
-				$function_name = strtolower( $this->tokens[ $nextNonEmpty ]['content'] );
+		$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( false !== $next_non_empty && \T_STRING === $this->tokens[ $next_non_empty ]['code'] ) {
+			$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
+			if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
+				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
 				if ( isset( $this->function_whitelist[ $function_name ] ) === true
 					|| in_array( $function_name, $this->custom_whitelist, true ) === true
 				) {
@@ -183,10 +183,10 @@ class NoSilencedErrorsSniff extends Sniff {
 		}
 
 		// Prepare the "Found" string to display.
-		$context_length = (int) $this->context_length;
-		$endOfStatement = $this->phpcsFile->findEndOfStatement( $stackPtr, T_COMMA );
-		if ( ( $endOfStatement - $stackPtr ) < $context_length ) {
-			$context_length = ( $endOfStatement - $stackPtr );
+		$context_length   = (int) $this->context_length;
+		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr, \T_COMMA );
+		if ( ( $end_of_statement - $stackPtr ) < $context_length ) {
+			$context_length = ( $end_of_statement - $stackPtr );
 		}
 		$found = $this->phpcsFile->getTokensAsString( $stackPtr, $context_length );
 		$found = str_replace( array( "\t", "\n", "\r" ), ' ', $found ) . '...';

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Discourage the use of the PHP error silencing operator.
+ *
+ * This sniff allows the error operator to be used with a select list
+ * of whitelisted functions, as no amount of error checking can prevent
+ * PHP from throwing errors when those functions are used.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.1.0
+ */
+class NoSilencedErrorsSniff extends Sniff {
+
+	/**
+	 * Number of tokens to display in the error message to show
+	 * the error silencing context.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var int
+	 */
+	public $context_length = 6;
+
+	/**
+	 * User defined whitelist.
+	 *
+	 * Allows users to pass a list of additional functions to whitelist
+	 * from their custom ruleset.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var array
+	 */
+	public $custom_whitelist = array();
+
+	/**
+	 * PHP native function whitelist.
+	 *
+	 * Errors caused by calls to any of these native PHP functions
+	 * are allowed to be silenced as file system permissions and such
+	 * can cause E_WARNINGs to be thrown which cannot be prevented via
+	 * error checking.
+	 *
+	 * Note: only calls to global functions - in contrast to class methods -
+	 * are taken into account.
+	 *
+	 * Only functions for which the PHP manual annotates that an
+	 * error will be thrown on failure are accepted into this list.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var array <string function name> => <bool true>
+	 */
+	protected $function_whitelist = array(
+		// Directory extension.
+		'chdir'                 => true,
+		'opendir'               => true,
+		'scandir'               => true,
+
+		// File extension.
+		'file_exists'           => true,
+		'file_get_contents'     => true,
+		'file'                  => true,
+		'fileatime'             => true,
+		'filectime'             => true,
+		'filegroup'             => true,
+		'fileinode'             => true,
+		'filemtime'             => true,
+		'fileowner'             => true,
+		'fileperms'             => true,
+		'filesize'              => true,
+		'filetype'              => true,
+		'fopen'                 => true,
+		'is_dir'                => true,
+		'is_executable'         => true,
+		'is_file'               => true,
+		'is_link'               => true,
+		'is_readable'           => true,
+		'is_writable'           => true,
+		'is_writeable'          => true,
+		'lstat'                 => true,
+		'mkdir'                 => true,
+		'move_uploaded_file'    => true,
+		'readfile'              => true,
+		'readlink'              => true,
+		'rename'                => true,
+		'rmdir'                 => true,
+		'stat'                  => true,
+		'unlink'                => true,
+
+		// FTP extension.
+		'ftp_chdir'             => true,
+		'ftp_login'             => true,
+		'ftp_rename'            => true,
+
+		// Stream extension.
+		'stream_select'         => true,
+		'stream_set_chunk_size' => true,
+
+		// Zlib extension.
+		'deflate_add'           => true,
+		'deflate_init'          => true,
+		'inflate_add'           => true,
+		'inflate_init'          => true,
+		'readgzfile'            => true,
+
+		// Miscellaneous other functions.
+		'imagecreatefromstring' => true,
+		'parse_url'             => true, // Pre-PHP 5.3.3 an E_WARNING was thrown when URL parsing failed.
+		'unserialize'           => true,
+	);
+
+	/**
+	 * Tokens which are regarded as empty for the purpose of determining
+	 * the name of the called function.
+	 *
+	 * This property is set from within the register() method.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var array
+	 */
+	private $empty_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$this->empty_tokens                    = Tokens::$emptyTokens;
+		$this->empty_tokens[ \T_NS_SEPARATOR ] = \T_NS_SEPARATOR;
+		$this->empty_tokens[ \T_BITWISE_AND ]  = \T_BITWISE_AND;
+
+		return array(
+			\T_ASPERAND,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function process_token( $stackPtr ) {
+		// Handle the user-defined custom function whitelist.
+		$this->custom_whitelist = $this->merge_custom_array( $this->custom_whitelist, array(), false );
+		$this->custom_whitelist = array_map( 'strtolower', $this->custom_whitelist );
+
+		/*
+		 * Check if the error silencing if done for one of the whitelisted functions.
+		 */
+		$nextNonEmpty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( false !== $nextNonEmpty && \T_STRING === $this->tokens[ $nextNonEmpty ]['code'] ) {
+			$hasParenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $nextNonEmpty + 1 ), null, true, null, true );
+			if ( false !== $hasParenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $hasParenthesis ]['code'] ) {
+				$function_name = strtolower( $this->tokens[ $nextNonEmpty ]['content'] );
+				if ( isset( $this->function_whitelist[ $function_name ] ) === true
+					|| in_array( $function_name, $this->custom_whitelist, true ) === true
+				) {
+					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
+					return;
+				}
+			}
+		}
+
+		// Prepare the "Found" string to display.
+		$context_length = (int) $this->context_length;
+		$endOfStatement = $this->phpcsFile->findEndOfStatement( $stackPtr, T_COMMA );
+		if ( ( $endOfStatement - $stackPtr ) < $context_length ) {
+			$context_length = ( $endOfStatement - $stackPtr );
+		}
+		$found = $this->phpcsFile->getTokensAsString( $stackPtr, $context_length );
+		$found = str_replace( array( "\t", "\n", "\r" ), ' ', $found ) . '...';
+
+		$this->phpcsFile->addWarning(
+			'Silencing errors is strongly discouraged. Use proper error checking instead. Found: %s',
+			$stackPtr,
+			'Discouraged',
+			array( $found )
+		);
+
+		if ( isset( $function_name ) ) {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', $function_name );
+		} else {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', $found );
+		}
+	}
+
+}

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -36,6 +36,20 @@ class NoSilencedErrorsSniff extends Sniff {
 	public $context_length = 6;
 
 	/**
+	 * Whether or not the `$function_whitelist` should be used.
+	 *
+	 * Defaults to true.
+	 *
+	 * This property only affects whether the standard function whitelist is
+	 * used. The custom whitelist, if set, will always be respected.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var bool
+	 */
+	public $use_default_whitelist = true;
+
+	/**
 	 * User defined whitelist.
 	 *
 	 * Allows users to pass a list of additional functions to whitelist
@@ -165,19 +179,22 @@ class NoSilencedErrorsSniff extends Sniff {
 		$this->custom_whitelist = $this->merge_custom_array( $this->custom_whitelist, array(), false );
 		$this->custom_whitelist = array_map( 'strtolower', $this->custom_whitelist );
 
-		/*
-		 * Check if the error silencing is done for one of the whitelisted functions.
-		 */
-		$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
-		if ( false !== $next_non_empty && \T_STRING === $this->tokens[ $next_non_empty ]['code'] ) {
-			$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
-			if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
-				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
-				if ( isset( $this->function_whitelist[ $function_name ] ) === true
-					|| in_array( $function_name, $this->custom_whitelist, true ) === true
-				) {
-					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
-					return;
+		if ( true === $this->use_default_whitelist || ! empty( $this->custom_whitelist ) ) {
+			/*
+			 * Check if the error silencing is done for one of the whitelisted functions.
+			 */
+			$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
+			if ( false !== $next_non_empty && \T_STRING === $this->tokens[ $next_non_empty ]['code'] ) {
+				$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
+				if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
+					$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
+					if ( ( true === $this->use_default_whitelist
+						&& isset( $this->function_whitelist[ $function_name ] ) === true )
+						|| in_array( $function_name, $this->custom_whitelist, true ) === true
+					) {
+						$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
+						return;
+					}
 				}
 			}
 		}

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -199,8 +199,13 @@ class NoSilencedErrorsSniff extends Sniff {
 			}
 		}
 
+		$this->context_length = (int) $this->context_length;
+		$context_length       = $this->context_length;
+		if ( $this->context_length <= 0 ) {
+			$context_length = 2;
+		}
+
 		// Prepare the "Found" string to display.
-		$context_length   = (int) $this->context_length;
 		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr, \T_COMMA );
 		if ( ( $end_of_statement - $stackPtr ) < $context_length ) {
 			$context_length = ( $end_of_statement - $stackPtr );
@@ -208,11 +213,18 @@ class NoSilencedErrorsSniff extends Sniff {
 		$found = $this->phpcsFile->getTokensAsString( $stackPtr, $context_length );
 		$found = str_replace( array( "\t", "\n", "\r" ), ' ', $found ) . '...';
 
+		$error_msg = 'Silencing errors is strongly discouraged. Use proper error checking instead.';
+		$data      = array();
+		if ( $this->context_length > 0 ) {
+			$error_msg .= ' Found: %s';
+			$data[]     = $found;
+		}
+
 		$this->phpcsFile->addWarning(
-			'Silencing errors is strongly discouraged. Use proper error checking instead. Found: %s',
+			$error_msg,
 			$stackPtr,
 			'Discouraged',
-			array( $found )
+			$data
 		);
 
 		if ( isset( $function_name ) ) {

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -2,13 +2,13 @@
 /**
  * @see No confusion with @ used in comments.
  */
-if (@in_array($array, $needle)) {
+if (@in_array($array, $needle)) { // Bad.
     echo '@';
-    echo @some_userland_function( $param );
-    $file = @MyClass::file_get_contents( $file );
-    $file = @\MyNS\MyClass::file_get_contents( $file );
-    $file = @\MyNS\file_get_contents( $file );
-    $file = @$obj->file_get_contents( $file );
+    echo @some_userland_function( $param ); // Bad.
+    $file = @MyClass::file_get_contents( $file ); // Bad.
+    $file = @\MyNS\MyClass::file_get_contents( $file ); // Bad.
+    $file = @\MyNS\file_get_contents( $file ); // Bad.
+    $file = @$obj->file_get_contents( $file ); // Bad.
 }
 
 // File extension.
@@ -17,34 +17,66 @@ if ( @&file_exists( $filename ) && @ /*comment*/ is_readable( $filename ) ) {
 }
 
 $fp = @fopen('http://www.example.com', 'r', false);
-@fpassthru($fp);
-@fclose($fp);
+@fpassthru($fp); // Bad.
+@fclose($fp); // Bad.
 
 // Directory extension.
 if (@is_dir($dir)) {
     if ($dh = @\opendir($dir)) {
-        while (($file = @readdir($dh)) !== false) {
+        while (($file = @readdir($dh)) !== false) { // Bad.
             echo "filename: $file : filetype: " . @\filetype($dir . $file) . "\n";
         }
-        @closedir($dh);
+        @closedir($dh); // Bad.
     }
 }
 $files1 = @ & scandir($dir);
 
 // FTP extension.
-$conn_id = @ftp_connect($ftp_server);
+$conn_id = @ftp_connect($ftp_server); // Bad.
 $login_result = @ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
-if ( @ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0 ) ) {
+if ( @ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0 ) ) { // Bad.
 	@ftp_rename($conn_id, $remote_file, $new_name);
 }
-@ftp_close($conn_id);
+@ftp_close($conn_id); // Bad.
 
 // @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
-echo @some_userland_function( $param );
+echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
 // @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
 
-$decoded = @hex2bin( $data );
+$decoded = @hex2bin( $data ); // Bad.
 
 $unserialized = @unserialize( $str );
+
+/*
+ * ... and test the same principle again, but now without using the whitelist.
+ */
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors use_default_whitelist false
+
+// File extension.
+if ( @&file_exists( $filename ) && @ /*comment*/ is_readable( $filename ) ) { // Bad x2.
+	$file = @ \file( $filename ); // Bad.
+}
+
+// Directory extension.
+if (@is_dir($dir)) { // Bad.
+    if ($dh = @\opendir($dir)) { // Bad.
+        while (($file = @readdir($dh)) !== false) { // Bad.
+            echo "filename: $file : filetype: " . @\filetype($dir . $file) . "\n"; // Bad.
+        }
+        @closedir($dh); // Bad.
+    }
+}
+$files1 = @ & scandir($dir); // Bad.
+
+/*
+ * Custom whitelist will be respected even when `use_default_whitelist` is set to false.
+ */
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist fgetcsv,hex2bin
+while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
+echo @some_userland_function( $param ); // Bad.
+$decoded = @hex2bin( $data );
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
+
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors use_default_whitelist true

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @see No confusion with @ used in comments.
+ */
+if (@in_array($array, $needle)) {
+    echo '@';
+    echo @some_userland_function( $param );
+    $file = @MyClass::file_get_contents( $file );
+    $file = @\MyNS\MyClass::file_get_contents( $file );
+    $file = @\MyNS\file_get_contents( $file );
+    $file = @$obj->file_get_contents( $file );
+}
+
+// File extension.
+if ( @&file_exists( $filename ) && @ /*comment*/ is_readable( $filename ) ) {
+	$file = @ \file( $filename );
+}
+
+$fp = @fopen('http://www.example.com', 'r', false);
+@fpassthru($fp);
+@fclose($fp);
+
+// Directory extension.
+if (@is_dir($dir)) {
+    if ($dh = @\opendir($dir)) {
+        while (($file = @readdir($dh)) !== false) {
+            echo "filename: $file : filetype: " . @\filetype($dir . $file) . "\n";
+        }
+        @closedir($dh);
+    }
+}
+$files1 = @ & scandir($dir);
+
+// FTP extension.
+$conn_id = @ftp_connect($ftp_server);
+$login_result = @ftp_login($conn_id, $ftp_user_name, $ftp_user_pass);
+if ( @ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0 ) ) {
+	@ftp_rename($conn_id, $remote_file, $new_name);
+}
+@ftp_close($conn_id);
+
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist fgetcsv,hex2bin
+while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
+echo @some_userland_function( $param );
+$decoded = @hex2bin( $data );
+// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
+
+$decoded = @hex2bin( $data );
+
+$unserialized = @unserialize( $str );

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PHP.NoSilencedErrors sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.1.0
+ */
+class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			5  => 1,
+			7  => 1,
+			8  => 1,
+			9  => 1,
+			10 => 1,
+			11 => 1,
+			20 => 1,
+			21 => 1,
+			26 => 1,
+			29 => 1,
+			35 => 1,
+			37 => 1,
+			40 => 1,
+			44 => 1,
+			48 => 1,
+		);
+	}
+
+}

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -51,6 +51,15 @@ class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 			40 => 1,
 			44 => 1,
 			48 => 1,
+			58 => 2,
+			59 => 1,
+			63 => 1,
+			64 => 1,
+			65 => 1,
+			66 => 1,
+			68 => 1,
+			71 => 1,
+			78 => 1,
 		);
 	}
 


### PR DESCRIPTION
Until now, WPCS used the PHPCS native `Generic.PHP.NoSilencedErrors` sniff. This sniff would throw warnings for all uses of the `@` error silencing operator. However, there are a number of PHP functions for which the use of the error silencing operator is warranted as no amount of error checking can prevent warnings from being thrown.

This PR adds a new WPCS native `PHP.NoSilencedErrors` sniff which will:
* not throw warnings when the error silencing operator is used in combination with one of the whitelisted functions.
* throw warnings in all other cases.
* allows for a user-defined list of additional whitelisted functions to be passed via a custom ruleset.
* displays a brief snippet of code to show the context in which the error silencing operator is being used.

To get to the current list of whitelisted functions, I've checked:
* The PHP manual for every single function in the [filesystem](http://php.net/manual/en/ref.filesystem.php), [directory](http://php.net/manual/en/ref.dir.php),  [stream](http://php.net/manual/en/ref.stream.php), [ftp](http://php.net/manual/en/ref.ftp.php), [gz](http://php.net/manual/en/ref.zlib.php) and [ssh2](http://php.net/manual/en/ref.ssh2.php) extensions.
* Ran the sniff over WP Core and used the reported metrics to verify a number of additional functions for which WP Core currently uses error silencing.

Functions for which there is a way to avoid the warning being thrown have **not** been added to the list. So, for example, the `header()` function does not qualify, as the warning could be prevented by wrapping the function call in a `headers_send()` condition.

For WP Core, the original sniff yielded 286 warnings.
This sniff gets rid of 119 of those, which should be considered unfixable, leaving 167 violations still to be addressed in WP Core. /cc @pento 

Fixes #1449

#### To do once this PR is merged:
- [ ] Add the sniff properties for this sniff to the Customizable Sniff Properties wiki page.