### PR TITLE
DeprecatedClasses: stabilize the error code

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -100,7 +100,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 			$message,
 			$stackPtr,
 			( version_compare( $this->deprecated_classes[ $class_name ]['version'], $this->minimum_supported_version, '<' ) ),
-			$this->string_to_errorcode( $matched_content . 'Found' ),
+			$this->string_to_errorcode( $class_name . 'Found' ),
 			$data
 		);
 	}


### PR DESCRIPTION
The error code for this sniff was based on the `$matched_content`, which for this sniff, would be the fully qualified class name, which may or may not contain a `\` prefix.
`$matched_content` is also in the _case_ as found in the code being analysed, while the analysis is done in a case-insensitive manner as per class name insensitivity in PHP itself.

Both these issues made the error code unstable as it could be of varying case and may or may not have a `_` at the start, depending on how the class was called.

By changing the error code to always use the lowercase class name without potential namespace separator, the error code becomes stable.

This change could be considered a BC-break, however, the previous situation was a bug. Also, as WP still supports PHP 5.2, the use of namespace separators is still rare in WP related code, so the BC-break is more theoretical than real.