### PR TITLE
Move the WPCS `WordPress.CodeAnalysis.EmptyStatement` from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -442,6 +442,9 @@
 		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1691 -->
 	<rule ref="WordPress.WhiteSpace.SemicolonSpacing"/>
 
+	<!-- There should be no empty statements, i.e. lone semi-colons or open/close tags without content. -->
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
 	<!-- Lowercase PHP constants, like true, false and null. -->
 	<!-- https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions -->
 	<rule ref="Generic.PHP.LowerCaseConstant"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -22,7 +22,6 @@
 			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
-	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
 		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 -->


### PR DESCRIPTION
This sniff has been in the [WP Core native custom ruleset](https://core.trac.wordpress.org/browser/trunk/phpcs.xml.dist) from the start as it was essential for the auto-fixers to work properly.

This PR now formalizes this by adding the sniff to the `WordPress-Core` ruleset.

The sniff was added to WPCS in PR #980 in response to issue #975.

The sniff checks for the following violations:
* Two semi-colons with no executable code in between.
* An empty PHP open - close tag combination.

The sniff has also been pulled to PHPCS upstream in https://github.com/squizlabs/PHP_CodeSniffer/pull/1814 (PR opened in December 2017 and still open).

/cc @pento 