### PR TITLE
Core ruleset: change behaviour for the `PEAR/FunctionCallSignature` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -217,13 +217,10 @@
 		<properties>
 			<property name="requiredSpacesAfterOpen" value="1"/>
 			<property name="requiredSpacesBeforeClose" value="1"/>
+
+			<!-- ... and for multi-line function calls, there should only be one parameter per line. -->
+			<property name="allowMultipleArguments" value="false"/>
 		</properties>
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-		<severity phpcs-only="true">0</severity>
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-		<severity phpcs-only="true">0</severity>
 	</rule>
 	<!-- Related to issue #970 / https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 -->
 	<rule ref="WordPress.Functions.FunctionCallSignatureNoParams"/>

--- a/WordPress/PHPCSAliases.php
+++ b/WordPress/PHPCSAliases.php
@@ -61,21 +61,23 @@ if ( ! \defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
 	 * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564
 	 * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591
 	 */
-	spl_autoload_register( function ( $class ) {
-		// Only try & load our own classes.
-		if ( stripos( $class, 'WordPress' ) !== 0 ) {
-			return;
-		}
+	spl_autoload_register(
+		function ( $class ) {
+			// Only try & load our own classes.
+			if ( stripos( $class, 'WordPress' ) !== 0 ) {
+				return;
+			}
 
-		// PHPCS handles the Test and Sniff classes without problem.
-		if ( stripos( $class, '\Tests\\' ) !== false || stripos( $class, '\Sniffs\\' ) !== false ) {
-			return;
-		}
+			// PHPCS handles the Test and Sniff classes without problem.
+			if ( stripos( $class, '\Tests\\' ) !== false || stripos( $class, '\Sniffs\\' ) !== false ) {
+				return;
+			}
 
-		$file = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . strtr( $class, '\\', DIRECTORY_SEPARATOR ) . '.php';
+			$file = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . strtr( $class, '\\', DIRECTORY_SEPARATOR ) . '.php';
 
-		if ( file_exists( $file ) ) {
-			include_once $file;
+			if ( file_exists( $file ) ) {
+				include_once $file;
+			}
 		}
-	} );
+	);
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -32,12 +32,34 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 		// Unset the lines related to version comments.
 		unset(
-			$errors[10], $errors[12], $errors[14], $errors[16], $errors[29],
-			$errors[55], $errors[57], $errors[59], $errors[73], $errors[76],
-			$errors[80], $errors[118], $errors[125], $errors[161], $errors[174],
-			$errors[178], $errors[210], $errors[233], $errors[251], $errors[255],
-			$errors[262], $errors[274], $errors[281], $errors[285], $errors[290],
-			$errors[295], $errors[303], $errors[310]
+			$errors[10],
+			$errors[12],
+			$errors[14],
+			$errors[16],
+			$errors[29],
+			$errors[55],
+			$errors[57],
+			$errors[59],
+			$errors[73],
+			$errors[76],
+			$errors[80],
+			$errors[118],
+			$errors[125],
+			$errors[161],
+			$errors[174],
+			$errors[178],
+			$errors[210],
+			$errors[233],
+			$errors[251],
+			$errors[255],
+			$errors[262],
+			$errors[274],
+			$errors[281],
+			$errors[285],
+			$errors[290],
+			$errors[295],
+			$errors[303],
+			$errors[310]
 		);
 
 		return $errors;
@@ -53,9 +75,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 		$warnings = array_fill( 323, 17, 1 );
 
 		// Unset the lines related to version comments.
-		unset(
-			$warnings[326], $warnings[333], $warnings[335]
-		);
+		unset( $warnings[326], $warnings[333], $warnings[335] );
 
 		return $warnings;
 	}


### PR DESCRIPTION
The `allowMultipleArguments` property of the `PEAR.Functions.FunctionCallSignature` sniff defaults to `true`.

By setting it to `false`, the sniff behaviour changes and demands that there is just one parameter on each line in a multi-line function call.
The behaviour for single-line function calls is not affected by this change.

This property has been added to the WP Core native custom ruleset in [changeset 43571](https://core.trac.wordpress.org/changeset/43571) as part of [trac ticket 44600](https://core.trac.wordpress.org/ticket/44600).

This PR now formalizes this by adding the property to the `WordPress-Core` ruleset.

Note: The WP Core handbook still needs to be adjusted to mention this change!

While this is a significant change, IMHO it is not a *breaking* change, but an enhancement, i.e. something on which WPCS previously had no opinion, will now start throwing errors.
With that in mind, I'm targeting this PR for WPCS 1.1.0.

Regarding the removal of the severity changes:
Previously these would already kick in when using the fixer, but would *not* throw an error when just checking the code with `phpcs`.

The impact of these changes is as follows:
Original code:
```php
$a = myfunction( $param1,
    $param2, $param3 );
```

... would previously have been auto-fixed as:
```php
$a = myfunction(
	$param1,
	$param2, $param3
);
```

Code layout which would still be allowed when just the property change would be applied:
```php
$a = myfunction( $param1,
    $param2,
    $param3 );
```

Code layout expected and auto-fixed as, because of the additional removal of the severity changes:
```php
$a = myfunction(
	$param1,
	$param2,
	$param3
);
```

/cc @pento 