### PR TITLE
 Sniff::is_token_in_test_method(): allow for anonymous classes

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -166,13 +166,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function register() {
 		$targets = array(
-			\T_FUNCTION  => \T_FUNCTION,
-			\T_CLASS     => \T_CLASS,
-			\T_INTERFACE => \T_INTERFACE,
-			\T_TRAIT     => \T_TRAIT,
-			\T_CONST     => \T_CONST,
-			\T_VARIABLE  => \T_VARIABLE,
-			\T_DOLLAR    => \T_DOLLAR, // Variable variables.
+			\T_FUNCTION   => \T_FUNCTION,
+			\T_CLASS      => \T_CLASS,
+			\T_INTERFACE  => \T_INTERFACE,
+			\T_TRAIT      => \T_TRAIT,
+			\T_CONST      => \T_CONST,
+			\T_VARIABLE   => \T_VARIABLE,
+			\T_DOLLAR     => \T_DOLLAR, // Variable variables.
+			\T_ANON_CLASS => \T_ANON_CLASS, // Only used for skipping over test classes.
 		);
 
 		// Add function call target for hook names and constants defined using define().
@@ -241,11 +242,20 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Ignore test classes.
-		if ( \T_CLASS === $this->tokens[ $stackPtr ]['code'] && true === $this->is_test_class( $stackPtr ) ) {
+		if ( ( \T_CLASS === $this->tokens[ $stackPtr ]['code']
+			|| \T_TRAIT === $this->tokens[ $stackPtr ]['code']
+			|| \T_ANON_CLASS === $this->tokens[ $stackPtr ]['code'] )
+			&& true === $this->is_test_class( $stackPtr )
+		) {
 			if ( $this->tokens[ $stackPtr ]['scope_condition'] === $stackPtr && isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 				// Skip forward to end of test class.
 				return $this->tokens[ $stackPtr ]['scope_closer'];
 			}
+			return;
+		}
+
+		if ( \T_ANON_CLASS === $this->tokens[ $stackPtr ]['code'] ) {
+			// Token was only registered to allow skipping over test classes.
 			return;
 		}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -383,4 +383,19 @@ const SCRIPT_DEBUG = $develop_src;
 do_action( 'test-this-hookname' ); // OK.
 apply_filters( 'myplugin\filtername', $var ); // OK.
 
+// Non-prefixed constant and action within a (nested) anonymous test class is fine.
+class Some_Test_Class extends NonTestClass { // Bad.
+	public function some_test_method() {
+		define( 'SOME_GLOBAL', '4.0.0' ); // Bad.
+
+		return new class extends \PHPUnit_Framework_TestCase {
+			public function testPass() {
+				define( 'SOME_GLOBAL', '4.0.0' ); // OK.
+
+				do_action( 'some-action', $something ); // OK.
+			}
+		};
+	}
+}
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.3.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.3.inc
@@ -12,4 +12,13 @@ class Some_Test extends \PHPUnit_Framework_TestCase {
 	}
 }
 
+$acronym_test = new class extends \PHPUnit_Framework_TestCase {
+
+	public function testPass() {
+		define( 'SOME_GLOBAL', '4.0.0' );
+
+		do_action( 'some-action', $something );
+	}
+};
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -65,6 +65,8 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					349 => 1,
 					352 => 1,
 					357 => 1,
+					387 => 1,
+					389 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.2.inc':


### PR DESCRIPTION
While since #883, the `Sniff::is_test_class()` method already allowed for anonymous classes, the `Sniff::is_token_in_test_method()` did not.

Also, as OO structures can be nested in PHP, all relevant structures within which the test method is nested should be examined, not just the first encountered.

Note: examination of nested extended classes based on the class they extend is currently afflicted by a bug in PHPCS itself. I expect the bugfix I pulled for that to be included in the 3.3.2 release.
See: https://github.com/squizlabs/PHP_CodeSniffer/pull/2127

This PR also adjusts the `PrefixAllGlobals` sniff to allow for anonymous test classes and traits extending test classes. Includes unit tests for this particular change.