### PR TITLE
ValidFunctionName: Add additional unit test for interfaces extending multiple interfaces

### DIFF
--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -104,3 +104,8 @@ class My_Soap extends somethingElse {
 }
 
 function __MyTemplateTags() {} // Bad x 2.
+
+// Verify that interfaces which extend multiple other interfaces do not throw unnecessary errors.
+interface MyInterface extends InterfaceA, InterfaceB {
+	function __MyTemplateTags(); // OK.
+}


### PR DESCRIPTION
Interfaces can extend multiple other interfaces. Looking at the sniff code, no changes are needed in the sniff to account for this, however, adding an additional unit test to warrant against sniff changes in the future which may not take this into account.

N.B.: I've verified all other usages of the `T_INTERFACE` token in the whole of WPCS and this was the only one which looked at `extends/implements`, so the only one for which interfaces extending multiple other interfaces could be problematic.

See:
* http://php.net/manual/en/language.oop5.interfaces.php#example-208

Loosely related to:
* https://github.com/squizlabs/PHP_CodeSniffer/pull/2128