### PR TITLE
Move CommentedOutCode check from Docs to Extra

### DIFF
--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -86,13 +86,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
 	</rule>
 
-	<!-- Make this sniff less likely to trigger on end comments. -->
-	<rule ref="Squiz.PHP.CommentedOutCode">
-		<properties>
-			<property name="maxPercentage" value="45"/>
-		</properties>
-	</rule>
-
 	<rule ref="Generic.Commenting">
 		<!-- WP has different alignment of tag values -->
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -185,6 +185,14 @@
 		</properties>
 	</rule>
 
+	<!-- Commented out code should not be committed.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1463 -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="40"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
While this sniff analyses comments, it is *not* a documentation related sniff, but rather a best practice sniff, so IMO, it should be in the `Extra` ruleset, not in the `Docs` ruleset.

The PHPCS default for the `maxPercentage` property is 35%.
This was previously upped in WPCS to 45% to prevent false positives for the `// End ...` comments.
However, as that rule and the associated sniff, have been removed, a lower value should be fine.

As a test case, I've ran the sniff over the `wp-admin` directory of WP Core and it looks like 40% should strike a good balance.
* Some of what was found in core was correctly identified commented out.
* Some were `// end` comments which should probably be removed.
* Some were just very non-descriptive inline comments which should be improved.

If needs be, we can tinker with the `maxPercentage` number a bit more in the future if we receive reports of false positives.