### PR TITLE
PrecisionAlignment: prevent false positive for inline javascript comments

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -167,6 +167,15 @@ class PrecisionAlignmentSniff extends Sniff {
 						$whitespace = str_replace( $content, '', $this->tokens[ $i ]['content'] );
 						$spaces     = ( \strlen( $whitespace ) % $this->tab_width );
 					}
+
+					/*
+					 * Prevent triggering on multi-line /*-style inline javascript comments.
+					 * This may cause false negatives as there is no check for being in a
+					 * <script> tag, but that will be rare.
+					 */
+					if ( isset( $content[0] ) && '*' === $content[0] && 0 !== $spaces ) {
+						--$spaces;
+					}
 					break;
 			}
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.1.inc
@@ -54,3 +54,15 @@
 	/*
 	* Provision some options
 	*/
+
+?>
+
+<script type="text/javascript">
+	/*
+	 * Multi-line javascript comment should not trigger this sniff.
+	 */
+	alert('OK');
+	  alert('bad');
+</script>
+
+<?php

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -111,6 +111,7 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 					31 => 1,
 					32 => 1,
 					39 => 1,
+					65 => 1,
 				);
 
 			case 'PrecisionAlignmentUnitTest.4.inc':


### PR DESCRIPTION
Inline HTML can contain javascript `<script>` blocks, which in turn can contain multi-line `/* */` style comments.

This sniff should not throw errors for those.

The implemented solution is quite simplistic, but determining whether or not we are within a `<script>` block can be quite complicated as - what with going into and out of PHP - the opener or closer may be in a PHP `echo` statement.

The simple solution implemented now may cause some false negatives, but that is preferable over false positives in this case.

Includes unit test.