### PR TITLE
AlternativeFunctions: suggest using wp_(un)slash()

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -121,6 +121,25 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'mt_rand',
 				),
 			),
+
+			'addslashes' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use wp_slash() for improved handling of complex variables instead; or in the context of database queries: use prepared statements.',
+				'since'     => '3.6.0',
+				'functions' => array(
+					'addslashes',
+					'addcslashes',
+				),
+			),
+			'stripslashes' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use wp_unslash() for improved handling of complex variables instead.',
+				'since'     => '3.6.0',
+				'functions' => array(
+					'stripslashes',
+					'stripcslashes',
+				),
+			),
 		);
 	}
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -50,3 +50,8 @@ file_get_contents(MYABSPATH . 'plugin-file.json'); // Warning.
 file_get_contents( MUPLUGINDIR . 'some-file.xml' ); // OK.
 file_get_contents( plugin_dir_path( __FILE__ ) . 'subfolder/*.conf' ); // OK.
 file_get_contents(WP_Upload_Dir()['path'] . 'subdir/file.inc'); // OK.
+
+addslashes( $string );
+addcslashes( $string );
+stripslashes( $string );
+stripcslashes( $string );

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -67,6 +67,11 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			46 => 1,
 			47 => 1,
 			49 => 1,
+
+			54 => 1,
+			55 => 1,
+			56 => 1,
+			57 => 1,
 		);
 	}
 


### PR DESCRIPTION
The WP `wp_slash()` and `wp_unslash()` functions are capable of (un)slashing both strings, as well as (nested) arrays, while the PHP native functions can only handle strings.

For input variables, you typically encounter arrays in forms. For instance when a checkbox or dropdown field can accept multiple values. however, the usage of arrays in input variables is definitely not limited to those examples.

With that in mind, I'd like to suggest adding a recommendation to use these functions instead of the PHP native ones to the `AlternativeFunctions` sniff.