### PR TITLE
Sniff::is_in_isset_or_empty(): improve code-style independence

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1505,7 +1505,8 @@ abstract class Sniff implements PHPCS_Sniff {
 		end( $nested_parenthesis );
 		$open_parenthesis = key( $nested_parenthesis );
 
-		return \in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( \T_ISSET, \T_EMPTY ), true );
+		$previous_non_empty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $open_parenthesis - 1 ), null, true, null, true );
+		return in_array( $this->tokens[ $previous_non_empty ]['code'], array( \T_ISSET, \T_EMPTY ), true );
 	}
 
 	/**

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -163,3 +163,18 @@ EOD
 
 if ( ( $_POST['foo'] ?? 'post' ) === 'post' ) {} // OK.
 if ( ( $_POST['foo'] <=> 'post' ) === 0 ) {} // OK.
+
+// Test whitespace independent isset/empty detection.
+function foobar() {
+	if ( ! isset  ($_GET['test']) ) {
+		return ;
+	}
+	echo sanitize_text_field( wp_unslash( $_GET['test'] ) ); // OK.
+}
+
+function barfoo() {
+	if ( empty  ($_GET['test']) ) {
+		return ;
+	}
+	echo sanitize_text_field( wp_unslash( $_GET['test'] ) ); // OK.
+}


### PR DESCRIPTION
Includes unit tests in the ValidatedSanitizedInput test case file.

Relates to #763