### PR TITLE
.gitignore: remove IDE specific files/folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.buildpath
-.project
-.settings/
 vendor
 composer.lock
 phpunit.xml


### PR DESCRIPTION
These _ignores_ are not project specific, but user specific as they depend on which IDE the developer is using.
With that in mind, they should be added to the developer's `.git/info/exclude` file and don't belong in the project `.gitignore` file.