### PR TITLE
ValidatedSanitizedInput: bug fix different quote style array keys

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1824,6 +1824,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		}
 
+		$bare_array_key = $this->strip_quotes( $array_key );
+
 		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
 
 			if ( ! \in_array( $this->tokens[ $i ]['code'], array( \T_ISSET, \T_EMPTY, \T_UNSET ), true ) ) {
@@ -1841,8 +1843,9 @@ abstract class Sniff implements PHPCS_Sniff {
 				}
 
 				// If we're checking for a specific array key (ex: 'hello' in
-				// $_POST['hello']), that must match too.
-				if ( isset( $array_key ) && $this->get_array_access_key( $i ) !== $array_key ) {
+				// $_POST['hello']), that must match too. Quote-style, however, doesn't matter.
+				if ( isset( $array_key )
+					&& $this->strip_quotes( $this->get_array_access_key( $i ) ) !== $bare_array_key ) {
 					continue;
 				}
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -178,3 +178,8 @@ function barfoo() {
 	}
 	echo sanitize_text_field( wp_unslash( $_GET['test'] ) ); // OK.
 }
+
+// Issue #1467.
+if ( isset( $_POST[ 'currentid' ] ) ){
+            $id = (int) $_POST[ "currentid" ]; // OK.
+}


### PR DESCRIPTION
Whether single or double quotes are used for the array key shouldn't matter as long as the array key itself matches.

Includes unit test.

Fixes #1467