### PR TITLE
NonceVerification: use separate errorcodes for warning vs error

### DIFF
--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -155,12 +155,17 @@ class NonceVerificationSniff extends Sniff {
 			return;
 		}
 
+		$error_code = 'Missing';
+		if ( false === $this->superglobals[ $instance['content'] ] ) {
+			$error_code = 'Recommended';
+		}
+
 		// If we're still here, no nonce-verification function was found.
 		$this->addMessage(
 			'Processing form data without nonce verification.',
 			$stackPtr,
 			$this->superglobals[ $instance['content'] ],
-			'NoNonceVerification'
+			$error_code
 		);
 	}
 


### PR DESCRIPTION
While cleaning up a plugin, I noticed that the issue count for the `WordPress.Security.NonceVerification.NoNonceVerification` error code was different if I ran phpcs with the `-n` flag (no warnings).

Error codes should be unique. Having the same error code for something which is mandatory (`error`) and recommended (`warning`) is bad practice and does not properly allow for modular disabling of notices.

This PR fixes this.

As the error code is changing anyhow, I figured it made sense to also remove the duplication of the sniff name from the code.

This is a breaking change as `<exclude>`s for the old errorcode currently in custom rulesets will be invalidated by it, as well as inline annotations using the error code, so this PR should go into WPCS 2.0.0.

N.B.: The ruleset change is only necessary until the deprecated sniffs have been removed.