### PR TITLE
Composer: various tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,10 @@
 	},
 	"type"       : "phpcodesniffer-standard",
 	"scripts"    : {
-		"install-codestandards": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
-		"post-install-cmd": "@install-codestandards",
-		"post-update-cmd" : "@install-codestandards"
+		"install-codestandards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
+		"check-cs"             : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+		"fix-cs"               : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+		"post-install-cmd"     : "@install-codestandards",
+		"post-update-cmd"      : "@install-codestandards"
 	}
 }


### PR DESCRIPTION
This commit adds two additional scripts and adjusts the existing one.

The additional scripts are just shortcuts to run `phpcs` and `phpcbf`.

The more important change is how the scripts are run - using the `@php` prefix ensures that the scripts are run against the same PHP version as with which Composer is called, instead of against the system default PHP version.

This is important if - as a WPCS dev - you change the PHP version for Composer to be able to test things against different PHP versions.

Ref: https://github.com/composer/composer/issues/7645