### PR TITLE
Sniff::get_declared_namespace_name(): improve code-style independence

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2369,12 +2369,12 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		if ( \T_NS_SEPARATOR === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( \T_NS_SEPARATOR === $this->tokens[ $nextToken ]['code'] ) {
 			// Not a namespace declaration, but use of, i.e. `namespace\someFunction();`.
 			return false;
 		}
 
-		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
 		if ( \T_OPEN_CURLY_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
 			// Declaration for global namespace when using multiple namespaces in a file.
 			// I.e.: `namespace {}`.
@@ -2382,16 +2382,18 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Ok, this should be a namespace declaration, so get all the parts together.
-		$validTokens = array(
+		$acceptedTokens = array(
 			\T_STRING       => true,
 			\T_NS_SEPARATOR => true,
-			\T_WHITESPACE   => true,
 		);
+		$validTokens = $acceptedTokens + Tokens::$emptyTokens;
 
 		$namespaceName = '';
 		while ( isset( $validTokens[ $this->tokens[ $nextToken ]['code'] ] ) ) {
-			$namespaceName .= trim( $this->tokens[ $nextToken ]['content'] );
-			$nextToken++;
+			if ( isset( $acceptedTokens[ $this->tokens[ $nextToken ]['code'] ] ) ) {
+				$namespaceName .= trim( $this->tokens[ $nextToken ]['content'] );
+			}
+			++$nextToken;
 		}
 
 		return $namespaceName;

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
@@ -1,0 +1,14 @@
+<?php
+
+// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist My\NameSp\TestClass
+
+namespace My \ /* comment */ NameSp;
+
+class Test_Class_D extends TestClass {
+
+	public function test_something() {
+		global $tabs;
+		$tabs = 50; // Ok.
+	}
+}
+// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist false


### PR DESCRIPTION
A namespace declaration can contain whitespace and comments and PHP will just ignore the whitespace and comments when reading the code. Also see: squizlabs/PHP_CodeSniffer#2150

While it is rare to encounter such code, this utility method should handle it correctly.

As for the `$namespaceName` to be returned by the method, this should not contain any whitespace or comments encountered. That way the namespace name will be "clean" for examination by sniffs.

Includes unit test via the `GlobalVariablesOverride` sniff.

Related to #763