### PR TITLE
PrefixAllGlobals: add "WordPress" to the prefix blacklist

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -49,8 +49,9 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @var string[]
 	 */
 	protected $prefix_blacklist = array(
-		'wp' => true,
-		'_'  => true,
+		'wordpress' => true,
+		'wp'        => true,
+		'_'         => true,
 	);
 
 	/**

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -398,4 +398,11 @@ class Some_Test_Class extends NonTestClass { // Bad.
 	}
 }
 
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress,somethingelse
+function wordpress_do_something() {} // OK, but error on line 1 about blacklisted prefix.
+function somethingelse_do_something() {} // OK.
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes my_wordpress_plugin
+apply_filters( 'my_wordpress_plugin_filtername', $var ); // OK.
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -399,7 +399,8 @@ class Some_Test_Class extends NonTestClass { // Bad.
 }
 
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress,somethingelse
-function wordpress_do_something() {} // OK, but error on line 1 about blacklisted prefix.
+// The above line adds an issue to line 1 about a blacklisted prefix.
+function wordpress_do_something() {} // Bad.
 function somethingelse_do_something() {} // OK.
 
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes my_wordpress_plugin

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -32,7 +32,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
-					1   => 1, // 1 x error for blacklisted prefix passed.
+					1   => 2, // 1 x error for blacklisted prefix passed.
 					10  => 1,
 					18  => 1,
 					21  => 1,

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -67,6 +67,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					357 => 1,
 					387 => 1,
 					389 => 1,
+					403 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.2.inc':


### PR DESCRIPTION
While the word "WordPress" can be used as _part of a prefix_, the word on its own should not be allowed as a prefix.

Includes unit test.