### PR TITLE
Update for PHPCompatibility 9.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -38,18 +38,18 @@
 	<config name="testVersion" value="5.3-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_yieldFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_ellipsisFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_powFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_pow_equalFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_spaceshipFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesceFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_coalesce_equalFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_yield_fromFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
 
 		<!-- Unclear how, but appears to be back-filled anyhow, could be that PHP did so before the token was in use. -->
-		<exclude name="PHPCompatibility.PHP.NewConstants.t_traitFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_traitFound"/>
 	</rule>
 
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -539,7 +539,7 @@ You are also encouraged to check the file history of any WPCS classes you extend
 - Ability to use a whitelist comment for tax queries for the `WordPress.VIP.SlowDBQuery` sniff.
 - Instructions on how to use WPCS with Atom and SublimeLinter to the Readme.
 - Reference to the [wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki) to the Readme.
-- Recommendation to also use the [PHPCompatibility](https://github.com/wimg/PHPCompatibility) ruleset to the Readme.
+- Recommendation to also use the [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset to the Readme.
 
 ### Changed
 - The minimum required PHP_CodeSniffer version to 2.6.0.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2015,8 +2015,8 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it
 	 * will detect whether the array has values or is empty.
 	 *
-	 * @link https://github.com/wimg/PHPCompatibility/issues/120
-	 * @link https://github.com/wimg/PHPCompatibility/issues/152
+	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/120
+	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/152
 	 *
 	 * @since 0.11.0
 	 *
@@ -2082,9 +2082,9 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
 	 * it will return the number of values in the array.
 	 *
-	 * @link https://github.com/wimg/PHPCompatibility/issues/111
-	 * @link https://github.com/wimg/PHPCompatibility/issues/114
-	 * @link https://github.com/wimg/PHPCompatibility/issues/151
+	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/111
+	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/114
+	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/151
 	 *
 	 * @since 0.11.0
 	 *

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -328,7 +328,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							break;
 
 						case 'T_TRAIT':
-							// phpcs:ignore PHPCompatibility.PHP.NewFunctions.trait_existsFound
+							// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.trait_existsFound
 							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native trait.
 								return;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "*"
+		"phpcompatibility/php-compatibility": "^9.0"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -48,14 +48,16 @@
 
 	<!-- Check for PHP cross-version compatibility. -->
 	<!--
-	To enable this, the PHPCompatibility standard needs
+	To enable this, the PHPCompatibilityWP standard needs
 	to be installed.
 	See the readme for installation instructions:
-	https://github.com/wimg/PHPCompatibility
+	https://github.com/PHPCompatibility/PHPCompatibilityWP
+	For more information, also see:
+	https://github.com/PHPCompatibility/PHPCompatibility
 	-->
 	<!--
 	<config name="testVersion" value="5.2-"/>
-	<rule ref="PHPCompatibility"/>
+	<rule ref="PHPCompatibilityWP"/>
 	-->
 
 	<!--


### PR DESCRIPTION
[PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) has just been released and renames all sniffs.

* Updated the version restrictions in `composer.json`.
    As the sniff names have changed, set minimum version.
    Note: PHPCompatibility 9.0.0 is still compatible with PHPCS 2.3.0 up to current, so this doesn't make a difference for running the CS check.
* Updated the WPCS native PHPCS ruleset for the new PHPCompatibility sniff codes.
* Updated the inline annotations for the new PHPCompatibility sniff codes.
* Updated the `phpcs.xml.dist.sample` to favour the `PHPCompatibilityWP` ruleset (was missed in PR #1426).
* Updated a few more links to the PHPCompatibility repo for the move to an organisation (which were missed in PR #1426).