### PR TITLE
Docs: Remove and update VIP link references

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can use the following as standard names when invoking `phpcs` to select snif
   - `WordPress-Extra` - extended ruleset for recommended best practices, not sufficiently covered in the WordPress core coding standards
     - includes `WordPress-Core`
 
-**Notes:** This WPCS package contains the sniffs for another ruleset, `WordPress-VIP`. This ruleset was originally intended to aid with the [WordPress.com VIP coding requirements](https://vip.wordpress.com/documentation/code-review-what-we-look-for/), but this is no longer used or recommended by the WordPress.com VIP team or their clients, since they prefer to use their [official VIP coding standards](https://github.com/Automattic/VIP-Coding-Standards) ruleset instead.
+**Notes:** This WPCS package contains the sniffs for another ruleset, `WordPress-VIP`. This ruleset was originally intended to aid with the [WordPress.com VIP coding requirements](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/), but this is no longer used or recommended by the WordPress.com VIP team or their clients, since they prefer to use their [official VIP coding standards](https://github.com/Automattic/VIP-Coding-Standards) ruleset instead.
 
 Before WPCS `1.0.0`, the WordPress-VIP ruleset was included as part of the complete `WordPress` ruleset. **As of `1.0.0` the `WordPress-VIP` ruleset is not part of the WordPress ruleset, and it is deprecated**. The remaining `WordPress-VIP` sniffs may still be referenced in custom rulesets, so to maintain some backwards compatibility, they will remain in WPCS until `2.0.0`. See [#1309](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1309) for more information.
 

--- a/WordPress-VIP/ruleset.xml
+++ b/WordPress-VIP/ruleset.xml
@@ -1,73 +1,50 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress VIP">
-	<description>Deprecated WordPress.com VIP Coding Standards, use the official VIP coding standards instead, these can be found at https://github.com/Automattic/VIP-Coding-Standards</description>
+	<description>Deprecated WordPress.com VIP Coding Standards. Use the official VIP coding standards instead which can be found at https://github.com/Automattic/VIP-Coding-Standards</description>
+
+	<!-- For info on WPCOM requirements: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/ -->
+	<!-- For info on VIP-Go requirements: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/ -->
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>
 
 	<rule ref="WordPress-Core"/>
 
-	<!-- Covers:
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#removing-the-admin-bar
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#filesystem-writes
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#uncached-functions
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#flush_rewrite_rules
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#session_start-and-other-session-related-functions
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#functions-that-use-joins-taxonomy-relation-queries-cat-tax-queries-subselects-or-api-calls
-		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#querying-on-meta_value
-	-->
 	<rule ref="WordPress.VIP"/>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#validation-sanitization-and-escaping -->
-	<!-- https://vip.wordpress.com/documentation/best-practices/security/validating-sanitizing-escaping/ -->
 	<rule ref="WordPress.Security.EscapeOutput"/>
 	<rule ref="WordPress.Security.NonceVerification"/>
 
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69 -->
 	<rule ref="WordPress.Security.ValidatedSanitizedInput"/>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-instead-of -->
 	<rule ref="WordPress.PHP.StrictComparisons"/>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
 	<rule ref="Squiz.PHP.CommentedOutCode">
 		<properties>
 			<property name="maxPercentage" value="45"/>
 		</properties>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#serializing-data -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#encoding-values-used-when-creating-a-url-or-passed-to-add_query_arg -->
-	<!-- https://github.com/Automattic/vip-scanner/blob/master/vip-scanner/checks/ForbiddenPHPFunctionsCheck.php -->
 	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
 		<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/633#issuecomment-266634811 -->
 		<properties>
 			<property name="exclude" type="array" value="obfuscation"/>
 		</properties>
 	</rule>
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
 	<rule ref="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration">
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
 	<rule ref="WordPress.PHP.DevelopmentFunctions"/>
 	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log">
 		<type>error</type>
 	</rule>
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
 	<rule ref="WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure">
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
 	<rule ref="WordPress.PHP.StrictInArray"/>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_parse_url-instead-of-parse_url -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_json_encode-over-json_encode -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls -->
 	<rule ref="WordPress.WP.AlternativeFunctions"/>
 	<!-- VIP recommends other functions -->
 	<rule ref="WordPress.WP.AlternativeFunctions.curl">
@@ -77,11 +54,8 @@
 		<message>%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.</message>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-theme-constants -->
 	<rule ref="WordPress.WP.DiscouragedConstants"/>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#direct-database-queries -->
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#database-alteration -->
 	<rule ref="WordPress.DB.DirectDatabaseQuery"/>
 	<rule ref="WordPress.DB.DirectDatabaseQuery.SchemaChange">
 		<type>error</type>
@@ -92,27 +66,21 @@
 		<message>Usage of a direct database call without caching is prohibited on the VIP platform. Use wp_cache_get / wp_cache_set or wp_cache_delete.</message>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#uncached-pageload -->
 	<rule ref="WordPress.DB.SlowDBQuery"/>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#using-__file__-for-page-registration -->
 	<rule ref="WordPress.Security.PluginMenuSlug"/>
 	<rule ref="WordPress.Security.PluginMenuSlug.Using__FILE__">
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events -->
 	<rule ref="WordPress.WP.CronInterval"/>
 	<rule ref="WordPress.WP.CronInterval.CronSchedulesInterval">
 		<type>error</type>
 		<message>Scheduling crons at %s sec ( less than %s minutes ) is prohibited.</message>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#manipulating-the-timezone-server-side -->
-	<!-- https://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/ -->
 	<rule ref="WordPress.WP.TimezoneChange"/>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#no-limit-queries -->
 	<rule ref="WordPress.WP.PostsPerPage"/>
 	<rule ref="WordPress.WP.PostsPerPage.posts_per_page_posts_per_page">
 		<type>error</type>
@@ -121,7 +89,6 @@
 		<type>error</type>
 	</rule>
 
-	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_safe_redirect-instead-of-wp_redirect -->
 	<rule ref="WordPress.Security.SafeRedirect"/>
 
 	<!--

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -15,8 +15,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Flag Database direct queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#direct-database-queries
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#database-alteration
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#direct-database-queries
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag potentially slow queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#uncached-pageload
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionParameterSniff;
 /**
  * Flag calling in_array(), array_search() and array_keys() without true as the third parameter.
  *
- * @link    https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-in_array-without-strict-parameter
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionParameterSniff;
 /**
  * Warn about __FILE__ for page registration.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#using-__file__-for-page-registration
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-__file__-for-page-registration
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Discourages removal of the admin bar.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#removing-the-admin-bar
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#removing-the-admin-bar
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Flag cron schedules less than 15 minutes.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cron-schedules-less-than-15-minutes-or-expensive-events
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -13,10 +13,9 @@ use WordPress\Sniff;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Flag Database direct queries.
+ * Flag direct database queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#direct-database-queries
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#database-alteration
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#direct-database-queries
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Disallow Filesystem writes.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#filesystem-operations
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag using orderby => rand.
  *
- * @link    https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#order-by-rand
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionParameterSniff;
 /**
  * Warn about __FILE__ for page registration.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#using-__file__-for-page-registration
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-__file__-for-page-registration
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag returning high or infinite posts_per_page.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#no-limit-queries
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#no-limit-queries
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -63,7 +63,8 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 		return array(
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#switch_to_blog
+			// @link WordPress.com: https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#switch_to_blog
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#switch_to_blog
 			'switch_to_blog' => array(
 				'type'      => 'error',
 				'message'   => '%s() is not something you should ever need to do in a VIP theme context. Instead use an API (XML-RPC, REST) to interact with other sites if needed.',
@@ -136,7 +137,8 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#remote-calls
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#remote-calls
 			'wp_remote_get' => array(
 				'type'      => 'warning',
 				'message'   => '%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.',
@@ -145,7 +147,8 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#custom-roles
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#custom-roles
 			'custom_role' => array(
 				'type'      => 'error',
 				'message'   => 'Use wpcom_vip_add_role() instead of %s()',
@@ -154,7 +157,8 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#caching-constraints
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#custom-roles
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cache-constraints
 			'cookies' => array(
 				'type'      => 'warning',
 				'message'   => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
@@ -163,7 +167,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#working-with-wp_users-and-user_meta
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta
 			'user_meta' => array(
 				'type'      => 'error',
 				'message'   => '%s() usage is highly discouraged, check VIP documentation on "Working with wp_users"',
@@ -230,7 +234,8 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#mobile-detection
+			// @link WordPress.com: https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#mobile-detection
+			// @link VIP Go: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#mobile-detection
 			'wp_is_mobile' => array(
 				'type'      => 'error',
 				'message'   => '%s() found. When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',

--- a/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -14,8 +14,6 @@ use WordPress\AbstractVariableRestrictionsSniff;
 /**
  * Restricts usage of some variables in VIP context.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/
- *
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
@@ -56,7 +54,7 @@ class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 	 */
 	public function getGroups() {
 		return array(
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#working-with-wp_users-and-user_meta
+			// @link https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#wp_users-and-user_meta
 			'user_meta' => array(
 				'type'        => 'error',
 				'message'     => 'Usage of users/usermeta tables is highly discouraged in VIP context, For storing user additional user metadata, you should look at User Attributes.',
@@ -66,7 +64,7 @@ class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
 				),
 			),
 
-			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#caching-constraints
+			// @link https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#caching-constraints
 			'cache_constraints' => array(
 				'type'          => 'warning',
 				'message'       => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',

--- a/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Discourages the use of session functions.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#session-start-and-other-session-functions
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -15,7 +15,7 @@ use WordPress\Sniff;
  * Discourages the use of the session variable.
  * Creating a session writes a file to the server and is unreliable in a multi-server environment.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/#session-start-and-other-session-functions
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag potentially slow queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#uncached-pageload
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Disallow the changing of timezone.
  *
- * @link    https://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#manipulating-the-timezone-server-side
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Flag cron schedules less than 15 minutes.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cron-schedules-less-than-15-minutes-or-expensive-events
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag returning high or infinite posts_per_page.
  *
- * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#no-limit-queries
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#no-limit-queries
  *
  * @package WPCS\WordPressCodingStandards
  *

--- a/WordPress/Sniffs/WP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/WP/TimezoneChangeSniff.php
@@ -14,7 +14,7 @@ use WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Disallow the changing of timezone.
  *
- * @link    https://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#manipulating-the-timezone-server-side
  *
  * @package WPCS\WordPressCodingStandards
  *


### PR DESCRIPTION
The WordPress.com VIP team moved their coding standards documentation around, since they now have different documents for their different platforms:

- [WPCOM platform](https://lobby.vip.wordpress.com/wordpress-com-documentation/code-review-what-we-look-for/) (only available to those with VIP Lobby access)
- [VIP-Go platform](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)

Many of the existing link references were out of date and pointed to pages or page anchors that didn't exist. Since our `WordPress-VIP` standard is deprecated, and will be removed in `2.0.0`, it's easier to remove all of the link references in the `VIP` category ruleset and sniffs. I've added links to the above two pages into the ruleset.

The only references that remain are ones that are used as references for sniffs typically found in `WordPress-Extra` (outside of the `VIP` category). They have been updated as necessary.