### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 env:
@@ -53,6 +54,10 @@ matrix:
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
+    - php: 7.3
+      env: PHPCS_BRANCH="3.1.0"
+    - php: 7.3
+      env: PHPCS_BRANCH="2.9.0"
 
 before_install:
     # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added  PHP 7.3 to the matrix.

PHP 7.3 in combination with PHPCS < 3.3.1 should be allowed to fail as PHPCS wasn't fully compatible with PHP 7.3 until version 3.3.1.

Note: The builds will only fail on a few select (test) cases, but making exceptions for those specific cases, while we're going to be dropping support for earlier PHPCS versions in the near future anyway, seems superfluous. Allowing the builds to fail for those PHP/PHPCS combinations is the simpler solution for now.

See squizlabs/PHP_CodeSniffer#2086 for the details of the fixes made to PHPCS itself.