### PR TITLE
PrefixAllGlobals: verify that namespace names use a prefix

### DIFF
--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -314,7 +314,7 @@ define( '\OtherNameSpace\PLUGIN_FILE', __FILE__ ); // OK.
 define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 define( '\PLUGIN_FILE', __FILE__ );
 
-namespace Testing {
+namespace TGMPA\Testing {
 	define( 'MY' . __NAMESPACE__, __FILE__ ); // Error, not actually namespaced.
 	define( 'MY\\' . __NAMESPACE__, __FILE__ ); // OK, even though strangely setup, the constant is in a namespace.
 }

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.4.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.4.inc
@@ -1,0 +1,30 @@
+<?php
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa,test_this,test\that
+
+namespace TGMPA;
+
+namespace Acronym\B\C;
+
+namespace AcronymPlugin\B\C;
+
+namespace Test_This\C;
+
+namespace Test\This\C;
+
+namespace Test\That\C;
+
+namespace Test \ /* comment */ This \ C;
+
+namespace A\B\C; // Bad.
+
+use namespace\DEF; // Not our target.
+namespace\cname::method(); // Not our target.
+$acronym_result = namespace \ blah \ mine();  // Not our target.
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress
+namespace wordpress\myplugin;
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress\myplugin
+namespace wordpress\myplugin;
+
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -70,6 +70,12 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					403 => 1,
 				);
 
+			case 'PrefixAllGlobalsUnitTest.4.inc':
+				return array(
+					1  => 1, // 1 x error for blacklisted prefix passed.
+					18 => 1,
+				);
+
 			case 'PrefixAllGlobalsUnitTest.2.inc':
 				// Namespaced - all OK, fall through to the default case.
 			case 'PrefixAllGlobalsUnitTest.3.inc':
@@ -90,7 +96,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
-					1   => 3, // 3 x error for potentially incorrect prefix passed.
+					1   => 2, // 2 x warning for potentially incorrect prefix passed.
 					249 => 1,
 					250 => 1,
 					253 => 1,


### PR DESCRIPTION
Until now, namespaced classes, functions and constants would be exempt from the "prefix all globals" rule, but the namespace name _itself_ was not examined.

As namespace names can, of course, also conflict, the namespace name should be prefixed with a plugin/theme specific prefix.

This PR adds that feature to the sniff. The PR builds onto the changes made in PR #1491 and #1492.

Notes:
* The sniff allows for underscores and (other) non-word characters in a passed prefix to be converted to namespace separators when used in a namespace name.
    In other words, if a prefix of `my_plugin` is passed as the value of the custom property, a namespace name of `My\Plugin` will be accepted automatically.
* Passing a prefix property value containing namespace separators will now also be allowed and will no longer trigger a warning.