### PR TITLE
Sniff::is_class_property: bug fix

### DIFF
--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -45,7 +45,6 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 					36  => 1,
 					54  => 1,
 					95  => 1,
-					124 => 1,
 					128 => 1,
 					133 => 1,
 					139 => 1,


### PR DESCRIPTION
When a class would be nested in parenthesis, the method did not recognize class properties properly.

To check for this without code duplication, the return of the `Sniff::valid_direct_scope()` method has changed. It used to always return a boolean. Now it will return `false` if not in a valid direct scope and the `$stackPtr` to the scope if it is.

Just like the rest of these methods, unit tested in the PHPCompatibility standard.

See also these issues for the same fix elsewhere:
* PHPCompatibility/PHPCompatibility#758
* squizlabs/PHP_CodeSniffer#2214

This fixes the false positive for line 124 in the `GlobalVariablesOverrideUnitTest.1.inc` test file.
