### PR TITLE
Compatibility-fix for PHPCS 3.4.0

### DIFF
--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc
@@ -17,7 +17,7 @@ $a = (real) $b;
 // Warning: Discouraged casts.
 $a = (unset) $b; // Warning.
 $a = (binary) $b; // Warning.
-$a = b"binary string"; // Warning. Currently false negative. Related to PHPCS bug report #1574.
+$a = b"binary string"; // Warning.
 $a = b"binary $string"; // Warning.
 
 // Error: Mixed case.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
@@ -17,7 +17,7 @@ $a = (float) $b;
 // Warning: Discouraged casts.
 $a = (unset) $b; // Warning.
 $a = (binary) $b; // Warning.
-$a = b"binary string"; // Warning. Currently false negative. Related to PHPCS bug report #1574.
+$a = b"binary string"; // Warning.
 $a = b"binary $string"; // Warning.
 
 // Error: Mixed case.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -10,6 +10,7 @@
 namespace WordPress\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use WordPress\PHPCSHelper;
 
 /**
  * Unit test class for the TypeCasts sniff.
@@ -67,7 +68,7 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 		return array(
 			18 => 1,
 			19 => 1,
-			// 20 => 1,
+			20 => ( version_compare( PHPCSHelper::get_version(), '3.4.0', '<' ) === true ? 0 : 1 ),
 			21 => 1,
 			34 => 1,
 			35 => 1,

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.inc
@@ -135,3 +135,10 @@ function is_windows() {
 if ( $something == ( false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : 0 === stripos( PHP_OS, 'WIN' ) ) ) {} // Bad.
 
 if ( ( false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : 0 === stripos( PHP_OS, 'WIN' ) ) === $something ) {} // OK.
+
+// Test with binary casts.
+if ( (binary) $binary === b"binary $foo" ) { // Bad x 1.
+	echo 'True';
+} elseif ( b"binary $foo" === (binary) $binary ) { // Good.
+	echo 'False';
+}

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -46,6 +46,7 @@ class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 			119 => 1,
 			125 => 1,
 			135 => 1,
+			140 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
@@ -49,3 +49,9 @@ wp_enqueue_script( 'someScript-js' ); // OK.
 
 wp_register_style( 'someScript-js' ); // OK.
 wp_enqueue_style( 'someScript-js' ); // OK.
+
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (bool) 1, true ); // OK.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (bool) 0, true ); // Error - 0, false or NULL are not allowed.
+
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (binary) 123, true ); // OK.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), b'0', true ); // Error - 0, false or NULL are not allowed.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -39,6 +39,8 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			39 => 1,
 			42 => 1,
 			45 => 1,
+			54 => 1,
+			57 => 1,
 		);
 	}
 


### PR DESCRIPTION
A fix for upstream issue squizlabs/PHP_CodeSniffer#1574 - tokenize binary casts as `T_BINARY_CAST` - has been committed to PHPCS and will be included in the PHPCS 3.4.0 release.

* The upstream change fixes a false negative in the `PHP.TypeCasts` sniff.
* There are two more sniffs which look at cast tokens `PHP.YodaConditions` and `WP.EnqueuedResourceParameters`.
    - For the first, I've just added a unit test documenting the behaviour.
    - For the second, I realized that while the sniff handled cast tokens, this specific situation wasn't tested at all. So I've added tests to that effect, including tests using binary casts.