### PR TITLE
Fix duplicate error being thrown / space after cast

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -52,14 +52,6 @@ class CastStructureSpacingSniff extends Sniff {
 				$this->phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
 			}
 		}
-
-		if ( \T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
-			$error = 'No space after closing casting parenthesis is prohibited';
-			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
-			if ( true === $fix ) {
-				$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
-			}
-		}
 	}
 
 }

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
@@ -1,22 +1,22 @@
 <?php
 
-$array1 = (array) $array; // Bad.
+$array1 = (array)$array; // Bad.
 $array2 = (array) $array; // Ok.
 
-$bool1 = (bool) $bool; // Bad.
+$bool1 = (bool)$bool; // Bad.
 $bool2 = (bool) $bool; // Ok.
 
-$int1 = (int) $int; // Bad.
+$int1 = (int)$int; // Bad.
 $int2 = (int) $int; // Ok.
 
-$obj1 = ( object ) $object; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
+$obj1 = ( object )$object; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
 $obj2 = (object) $object; // Ok.
 
-$str1 = (string) $string; // Bad.
+$str1 = (string)$string; // Bad.
 $str2 = (string) $string; // Ok.
 
-$unset1 = ( unset) $unset; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
+$unset1 = ( unset)$unset; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
 $unset2 = (unset) $unset; // Ok.
 
-$float1 = (float ) $float; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
+$float1 = (float )$float; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
 $float2 = (float) $float; // Ok.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -28,13 +28,13 @@ class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			3  => 2,
-			6  => 2,
-			9  => 2,
-			12 => 2,
-			15 => 2,
-			18 => 2,
-			21 => 2,
+			3  => 1,
+			6  => 1,
+			9  => 1,
+			12 => 1,
+			15 => 1,
+			18 => 1,
+			21 => 1,
 		);
 	}
 


### PR DESCRIPTION
Given the following test code:
```php
<?php
$a = (bool) $b;
$a = (bool)$b;
$a = (bool)       $b;
```

The current sniffs/ruleset would result in the following errors related to cast spacing:
```
 3 | ERROR | [x] No space after closing casting parenthesis is prohibited
   |       |     (WordPress.WhiteSpace.CastStructureSpacing.NoSpaceAfterCloseParenthesis)
 3 | ERROR | [x] A cast statement must be followed by a single space
   |       |     (Generic.Formatting.SpaceAfterCast.NoSpace)
 4 | ERROR | [x] A cast statement must be followed by a single space
   |       |     (Generic.Formatting.SpaceAfterCast.TooMuchSpace)
```

The errors for line 3 are basically duplicates.
Additionally, as shown by line 4, as the upstream sniff also checks the width of the space after a type cast, that sniff is the better choice.

So in this PR, I'm removing the code which generated the `WordPress.WhiteSpace.CastStructureSpacing.NoSpaceAfterCloseParenthesis` error.

Includes adjusted unit test `fixed` file.