### PR TITLE
WordPress.PHP.TypeCasts: recognize casts independently of inside cast spacing

### DIFF
--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -49,7 +49,7 @@ class TypeCastsSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		$token_code  = $this->tokens[ $stackPtr ]['code'];
-		$typecast    = $this->tokens[ $stackPtr ]['content'];
+		$typecast    = str_replace( ' ', '', $this->tokens[ $stackPtr ]['content'] );
 		$typecast_lc = strtolower( $typecast );
 
 		$this->phpcsFile->recordMetric( $stackPtr, 'Typecast encountered', $typecast );

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc
@@ -47,3 +47,19 @@ $a = (ARRAY) $b;
 $a = (OBJECT) $b;
 $a = (UNSET) $b; // + discouraged.
 $a = (BINARY) $b; // + discouraged.
+
+// Test recognition with whitespace within the cast.
+// OK.
+$a = (  bool  ) $b;
+$a = ( int ) $b;
+$a = ( float) $b;
+$a = (string ) $b;
+$a = (          array) $b;
+$a = (object      ) $b;
+
+$a = (     boolean          ) $b; // Error.
+$a = (  integer) $b; // Error.
+$a = (double ) $b; // Error.
+$a = ( real ) $b; // Error.
+$a = (  unset ) $b; // Warning.
+$a = ( binary ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
@@ -47,3 +47,19 @@ $a = (array) $b;
 $a = (object) $b;
 $a = (unset) $b; // + discouraged.
 $a = (binary) $b; // + discouraged.
+
+// Test recognition with whitespace within the cast.
+// OK.
+$a = (  bool  ) $b;
+$a = ( int ) $b;
+$a = ( float) $b;
+$a = (string ) $b;
+$a = (          array) $b;
+$a = (object      ) $b;
+
+$a = (bool) $b; // Error.
+$a = (int) $b; // Error.
+$a = (float) $b; // Error.
+$a = (float) $b; // Error.
+$a = (  unset ) $b; // Warning.
+$a = ( binary ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -56,6 +56,10 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 			47 => 1,
 			48 => 1,
 			49 => 1,
+			60 => 1,
+			61 => 1,
+			62 => 1,
+			63 => 1,
 		);
 	}
 
@@ -74,6 +78,8 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 			35 => 1,
 			48 => 1,
 			49 => 1,
+			64 => 1,
+			65 => 1,
 		);
 	}
 }


### PR DESCRIPTION
Type casts can have spaces within the cast structure. The upstream `Squiz.WhiteSpace.CastSpacing` sniff in the `Core` ruleset guards against this.

However, the `WordPress.PHP.TypeCasts` should function independently of that sniff and should not throw errors (false positives) for type casts using the correct short form, but with superfluous whitespace within the parentheses.

This PR fixes this. Includes unit tests.