### PR TITLE
PrefixAllGlobals: minor improvements to the prefix validation

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -880,6 +880,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$this->previous_prefixes = $this->prefixes;
 
 		// Validate the passed prefix(es).
+		$prefixes    = array();
 		$ns_prefixes = array();
 		foreach ( $this->prefixes as $key => $prefix ) {
 			$prefixLC = strtolower( $prefix );
@@ -891,7 +892,6 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					'ForbiddenPrefixPassed',
 					array( $prefix )
 				);
-				unset( $this->prefixes[ $key ] );
 				continue;
 			}
 
@@ -903,11 +903,10 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					'InvalidPrefixPassed',
 					array( $prefix )
 				);
-				continue;
 			}
 
 			// Lowercase the prefix to allow for direct compare.
-			$this->prefixes[ $key ] = $prefixLC;
+			$prefixes[ $key ] = $prefixLC;
 
 			/*
 			 * Replace non-word characters in the prefix with a regex snippet, but only if the
@@ -926,7 +925,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Set the validated prefixes caches.
-		$this->validated_prefixes           = $this->prefixes;
+		$this->validated_prefixes           = $prefixes;
 		$this->validated_namespace_prefixes = $ns_prefixes;
 	}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -406,4 +406,7 @@ function somethingelse_do_something() {} // OK.
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes my_wordpress_plugin
 apply_filters( 'my_wordpress_plugin_filtername', $var ); // OK.
 
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes test-this
+do_action( 'Test-THIS-hookname' ); // OK.
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -96,7 +96,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
-					1   => 2, // 2 x warning for potentially incorrect prefix passed.
+					1   => 3, // 3 x warning for potentially incorrect prefix passed.
 					249 => 1,
 					250 => 1,
 					253 => 1,


### PR DESCRIPTION
* Don't tamper with the values in the `$prefixes` property to allow for the comparison with the previous set of prefixes to work properly.
* Allow for case-insensitive prefix check, even when the prefix has unconventional word separators.