### PR TITLE
Sniff::has_whitelist_comment(): Minor bug fix

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1197,7 +1197,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 					&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
 					|| ( isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] )
-					&& T_PHPCS_SET !== $this->tokens[ $lastPtr ]['type'] ) )
+					&& 'T_PHPCS_SET' !== $this->tokens[ $lastPtr ]['type'] ) )
 				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
 				&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 			) {
@@ -1213,7 +1213,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 				&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
 				|| ( isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] )
-				&& T_PHPCS_SET !== $this->tokens[ $lastPtr ]['type'] ) )
+				&& 'T_PHPCS_SET' !== $this->tokens[ $lastPtr ]['type'] ) )
 			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']
 			&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 		) {


### PR DESCRIPTION
As the `T_PHPCS_SET` token was only introduced in PHPCS 3.2.0, the check should be done against `type`, which is a string, not `code`, which is the integer constant.

The `type` part was correct, the `string` part wasn't.

Bug introduced in PR #1493 and not yet in any released version.