### PR TITLE
CodeAnalysis/Emptystatement: bug fix

### DIFF
--- a/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -72,6 +72,17 @@ class EmptyStatementSniff extends Sniff {
 					return;
 				}
 
+				if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+					$nested      = $this->tokens[ $stackPtr ]['nested_parenthesis'];
+					$last_closer = array_pop( $nested );
+					if ( isset( $this->tokens[ $last_closer ]['parenthesis_owner'] )
+						&& \T_FOR === $this->tokens[ $this->tokens[ $last_closer ]['parenthesis_owner'] ]['code']
+					) {
+						// Empty for() condition.
+						return;
+					}
+				}
+
 				$fix = $this->phpcsFile->addFixableWarning(
 					'Empty PHP statement detected: superfluous semi-colon.',
 					$stackPtr,

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.1.inc
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.1.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semicolons without executable code between them.
+ * Test empty statement: two consecutive semi-colons without executable code between them.
  */
 function_call(); // OK.
 
@@ -46,3 +46,7 @@ function_call();
 
 <!-- Tests with short open echo tag. -->
 <input name="<?= 'some text' ?>" /> <!-- OK. -->
+
+<?php
+// Guard against false positives for two consecutive semi-colons in a for statement.
+for ( $i = 0; ; $i++ ) {}

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.1.inc.fixed
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.1.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semicolons without executable code between them.
+ * Test empty statement: two consecutive semi-colons without executable code between them.
  */
 function_call(); // OK.
 
@@ -41,3 +41,7 @@ function_call();
 
 <!-- Tests with short open echo tag. -->
 <input name="<?= 'some text' ?>" /> <!-- OK. -->
+
+<?php
+// Guard against false positives for two consecutive semi-colons in a for statement.
+for ( $i = 0; ; $i++ ) {}


### PR DESCRIPTION
Prevent the `WordPress.CodeAnalysis.EmptyStatement` sniff from triggering on two consecutive _semi_-colons in a `for()` statement.

Includes unit test.