### PR TITLE
New `I18nTextDomainFixer` utility sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 * [Running your code through WPCS automatically using CI tools](#running-your-code-through-wpcs-automatically-using-ci-tools)
     + [Travis CI](#travis-ci)
 * [Fixing errors or whitelisting them](#fixing-errors-or-whitelisting-them)
+    + [Tools shipped with WPCS](#tools-shipped-with-wpcs)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -268,6 +269,21 @@ More examples and advice about integrating PHPCS in your Travis build tests can 
 ## Fixing errors or whitelisting them
 
 You can find information on how to deal with some of the more frequent issues in the [wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki).
+
+### Tools shipped with WPCS
+
+Since version 1.2.0, WPCS has a special sniff category `Utils`.
+
+This sniff category contains some tools which, generally speaking, will only be needed to be run once over a codebase and for which the fixers can be considered _risky_, i.e. very careful review by a developer is needed before accepting the fixes made by these sniffs.
+
+The sniffs in this category are disabled by default and can only be activated by adding some properties for each sniff via a custom ruleset.
+
+At this moment, WPCS offer the following tools:
+* `WordPress.Utils.I18nTextDomainFixer` - This sniff can replace the text-domain used in a code-base.
+    The sniff will fix the text-domains in both I18n function calls as well as in a plugin/theme header.
+    Passing the following properties will activate the sniff:
+    - `old_text_domain`: an array with one or more (old) text-domain names which need to be replaced;
+    - `new_text_domain`: the correct (new) text-domain as a string.
 
 
 ## Contributing

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -1,0 +1,725 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Utils;
+
+use WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Comprehensive I18n text domain fixer tool.
+ *
+ * This sniff can:
+ * - Add missing `text-domain`s.
+ * - Replace `text-domain`s based on an array of `old` values to a `new` value.
+ *
+ * Note: Without a user-defined configuration in a custom ruleset, this sniff will be ignored.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.2.0
+ */
+class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'CSS',
+	);
+
+	/**
+	 * Old text domain(s) to replace.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string[]|string
+	 */
+	public $old_text_domain;
+
+	/**
+	 * New text domain.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	public $new_text_domain = '';
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'i18nfixer';
+
+	/**
+	 * The WP Internationalization related functions to target for the replacements.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array <string function name> => <int parameter position>
+	 */
+	protected $target_functions = array(
+		'load_textdomain'                        => 1,
+		'load_plugin_textdomain'                 => 1,
+		'load_muplugin_textdomain'               => 1,
+		'load_theme_textdomain'                  => 1,
+		'load_child_theme_textdomain'            => 1,
+		'unload_textdomain'                      => 1,
+
+		'__'                                     => 2,
+		'_e'                                     => 2,
+		'_x'                                     => 3,
+		'_ex'                                    => 3,
+		'_n'                                     => 4,
+		'_nx'                                    => 5,
+		'_n_noop'                                => 3,
+		'_nx_noop'                               => 4,
+		'translate_nooped_plural'                => 3,
+		'_c'                                     => 2, // Deprecated.
+
+		'esc_html__'                             => 2,
+		'esc_html_e'                             => 2,
+		'esc_html_x'                             => 3,
+		'esc_attr__'                             => 2,
+		'esc_attr_e'                             => 2,
+		'esc_attr_x'                             => 3,
+
+		'is_textdomain_loaded'                   => 1,
+		'get_translations_for_domain'            => 1,
+
+		// Shouldn't be used by plugins/themes.
+		'translate'                              => 2,
+		'translate_with_gettext_context'         => 3,
+
+		// WP private functions. Shouldn't be used by plugins/themes.
+		'_load_textdomain_just_in_time'          => 1,
+		'_get_path_to_translation_from_lang_dir' => 1,
+		'_get_path_to_translation'               => 1,
+	);
+
+	/**
+	 * Whether a valid new text-domain was found.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $is_valid = false;
+
+	/**
+	 * The new text-domain as validated.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $validated_textdomain = '';
+
+	/**
+	 * Whether the plugin/theme header has been seen and fixed yet.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $header_found = false;
+
+	/**
+	 * Possible headers for a theme.
+	 *
+	 * @link https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array Array key is the header name, the value indicated whether it is a
+	 *            required (true) or optional (false) header.
+	 */
+	private $theme_headers = array(
+		'Theme Name'  => true,
+		'Theme URI'   => false,
+		'Author'      => true,
+		'Author URI'  => false,
+		'Description' => true,
+		'Version'     => true,
+		'License'     => true,
+		'License URI' => true,
+		'Tags'        => false,
+		'Text Domain' => true,
+		'Domain Path' => false,
+	);
+
+	/**
+	 * Possible headers for a plugin.
+	 *
+	 * @link https://developer.wordpress.org/plugins/the-basics/header-requirements/
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array Array key is the header name, the value indicated whether it is a
+	 *            required (true) or optional (false) header.
+	 */
+	private $plugin_headers = array(
+		'Plugin Name' => true,
+		'Plugin URI'  => false,
+		'Description' => false,
+		'Version'     => false,
+		'Author'      => false,
+		'Author URI'  => false,
+		'License'     => false,
+		'License URI' => false,
+		'Text Domain' => false,
+		'Domain Path' => false,
+		'Network'     => false,
+	);
+
+	/**
+	 * Regex template to match theme/plugin headers.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $header_regex_template = '`^(?:\s*(?:(?:\*|//)\s*)?)?(%s)\s*:\s*([^\r\n]+)`';
+
+	/**
+	 * Regex to match theme headers.
+	 *
+	 * Set from within the register() method.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $theme_header_regex;
+
+	/**
+	 * Regex to match plugin headers.
+	 *
+	 * Set from within the register() method.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var string
+	 */
+	private $plugin_header_regex;
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var integer
+	 */
+	private $tab_width = null;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$headers                  = array_map(
+			'preg_quote',
+			array_keys( $this->theme_headers ),
+			array_fill( 0, \count( $this->theme_headers ), '`' )
+		);
+		$this->theme_header_regex = sprintf( $this->header_regex_template, implode( '|', $headers ) );
+
+		$headers                   = array_map(
+			'preg_quote',
+			array_keys( $this->plugin_headers ),
+			array_fill( 0, \count( $this->plugin_headers ), '`' )
+		);
+		$this->plugin_header_regex = sprintf( $this->header_regex_template, implode( '|', $headers ) );
+
+		$targets = parent::register();
+
+		$targets[] = \T_DOC_COMMENT_OPEN_TAG;
+		$targets[] = \T_COMMENT;
+
+		return $targets;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( \T_COMMENT === $this->tokens[ $stackPtr ]['code']
+			&& strpos( $this->tokens[ $stackPtr ]['content'], '@codingStandardsChangeSetting' ) !== false
+		) {
+			return;
+		}
+
+		// Check if the old/new properties are correctly set. If not, bow out.
+		if ( ! is_string( $this->new_text_domain )
+			|| '' === $this->new_text_domain
+		) {
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		if ( isset( $this->old_text_domain ) ) {
+			$this->old_text_domain = $this->merge_custom_array( $this->old_text_domain, array(), false );
+
+			if ( ! is_array( $this->old_text_domain )
+				|| array() === $this->old_text_domain
+			) {
+				return ( $this->phpcsFile->numTokens + 1 );
+			}
+		}
+
+		// Only validate and throw warning about the text domain once.
+		if ( $this->new_text_domain !== $this->validated_textdomain ) {
+			$this->is_valid             = false;
+			$this->validated_textdomain = $this->new_text_domain;
+			$this->header_found         = false;
+
+			if ( 'default' === $this->new_text_domain ) {
+				$this->phpcsFile->addWarning(
+					'The "default" text-domain is reserved for WordPress core use and should not be used by plugins or themes',
+					0,
+					'ReservedNewDomain',
+					array( $this->new_text_domain )
+				);
+
+				return ( $this->phpcsFile->numTokens + 1 );
+			}
+
+			if ( preg_match( '`^[a-z0-9-]+$`', $this->new_text_domain ) !== 1 ) {
+				$this->phpcsFile->addWarning(
+					'The text-domain should be a simple lowercase text string with words separated by dashes. "%s" appears invalid',
+					0,
+					'InvalidNewDomain',
+					array( $this->new_text_domain )
+				);
+
+				return ( $this->phpcsFile->numTokens + 1 );
+			}
+
+			// If the text-domain passed both validations, it should be considered valid.
+			$this->is_valid = true;
+
+		} elseif ( false === $this->is_valid ) {
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		if ( isset( $this->tab_width ) === false ) {
+			if ( isset( $this->phpcsFile->config->tabWidth ) === false
+				|| 0 === $this->phpcsFile->config->tabWidth
+			) {
+				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
+				$this->tab_width = 4;
+			} else {
+				$this->tab_width = $this->phpcsFile->config->tabWidth;
+			}
+		}
+
+		if ( \T_DOC_COMMENT_OPEN_TAG === $this->tokens[ $stackPtr ]['code']
+			|| \T_COMMENT === $this->tokens[ $stackPtr ]['code']
+		) {
+			// Examine for plugin/theme file header.
+			return $this->process_comments( $stackPtr );
+
+		} elseif ( 'CSS' !== $this->phpcsFile->tokenizerType ) {
+			// Examine a T_STRING token in a PHP file as a function call.
+			return parent::process_token( $stackPtr );
+		}
+	}
+
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$target_param = $this->target_functions[ $matched_content ];
+
+		if ( isset( $parameters[ $target_param ] ) === false && 1 !== $target_param ) {
+			$error_msg  = 'Missing $domain arg';
+			$error_code = 'MissingArgDomain';
+
+			if ( isset( $parameters[ ( $target_param - 1 ) ] ) ) {
+				$fix = $this->phpcsFile->addFixableError( $error_msg, $stackPtr, $error_code );
+
+				if ( true === $fix ) {
+					$start_previous = $parameters[ ( $target_param - 1 ) ]['start'];
+					$end_previous   = $parameters[ ( $target_param - 1 ) ]['end'];
+					if ( \T_WHITESPACE === $this->tokens[ $start_previous ]['code']
+						&& $this->tokens[ $start_previous ]['content'] === $this->phpcsFile->eolChar
+					) {
+						// Replicate the new line + indentation of the previous item.
+						$replacement = ',';
+						for ( $i = $start_previous; $i <= $end_previous; $i++ ) {
+							if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+
+							if ( isset( $this->tokens[ $i ]['orig_content'] ) ) {
+								$replacement .= $this->tokens[ $i ]['orig_content'];
+							} else {
+								$replacement .= $this->tokens[ $i ]['content'];
+							}
+						}
+
+						$replacement .= "'{$this->new_text_domain}'";
+					} else {
+						$replacement = ", '{$this->new_text_domain}'";
+					}
+
+					if ( \T_WHITESPACE === $this->tokens[ $end_previous ]['code'] ) {
+						$this->phpcsFile->fixer->addContentBefore( $end_previous, $replacement );
+					} else {
+						$this->phpcsFile->fixer->addContent( $end_previous, $replacement );
+					}
+				}
+			} else {
+				$error_msg .= ' and preceding argument(s)';
+				$error_code = 'MissingArgs';
+
+				// Expected preceeding param also missing, just throw the warning.
+				$this->phpcsFile->addWarning( $error_msg, $stackPtr, $error_code );
+			}
+
+			return;
+		}
+
+		// Target parameter found. Let's examine it.
+		$domain_param_start = $parameters[ $target_param ]['start'];
+		$domain_param_end   = $parameters[ $target_param ]['end'];
+		$domain_token       = null;
+
+		for ( $i = $domain_param_start; $i <= $domain_param_end; $i++ ) {
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				continue;
+			}
+
+			if ( \T_CONSTANT_ENCAPSED_STRING !== $this->tokens[ $i ]['code'] ) {
+				// Unexpected token found, not our concern. This is handled by the I18n sniff.
+				return;
+			}
+
+			if ( isset( $domain_token ) ) {
+				// More than one T_CONSTANT_ENCAPSED_STRING found, not our concern. This is handled by the I18n sniff.
+				return;
+			}
+
+			$domain_token = $i;
+		}
+
+		// If we're still here, this means only one T_CONSTANT_ENCAPSED_STRING was found.
+		$old_domain = $this->strip_quotes( $this->tokens[ $domain_token ]['content'] );
+
+		if ( ! \in_array( $old_domain, $this->old_text_domain, true ) ) {
+			// Not a text-domain targetted for replacement, ignore.
+			return;
+		}
+
+		$fix = $this->phpcsFile->addFixableError(
+			'Mismatched text domain. Expected \'%s\' but found \'%s\'',
+			$domain_token,
+			'TextDomainMismatch',
+			array( $this->new_text_domain, $old_domain )
+		);
+
+		if ( true === $fix ) {
+			$replacement = str_replace( $old_domain, $this->new_text_domain, $this->tokens[ $domain_token ]['content'] );
+			$this->phpcsFile->fixer->replaceToken( $domain_token, $replacement );
+		}
+	}
+
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+
+		$target_param = $this->target_functions[ $matched_content ];
+
+		if ( 1 !== $target_param ) {
+			// Only process the no param case as fixable if the text-domain is expected to be the first parameter.
+			$this->phpcsFile->addWarning( 'Missing $domain arg and preceding argument(s)', $stackPtr, 'MissingArgs' );
+			return;
+		}
+
+		$opener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $opener ]['code']
+			|| isset( $this->tokens[ $opener ]['parenthesis_closer'] ) === false
+		) {
+			// Parse error or live coding.
+			return;
+		}
+
+		$fix = $this->phpcsFile->addFixableError( 'Missing $domain arg', $stackPtr, 'MissingArgDomain' );
+		if ( true === $fix ) {
+			$closer      = $this->tokens[ $opener ]['parenthesis_closer'];
+			$replacement = " '{$this->new_text_domain}' ";
+
+			if ( $this->tokens[ $opener ]['line'] !== $this->tokens[ $closer ]['line'] ) {
+				$replacement = trim( $replacement );
+				$addBefore   = ( $closer - 1 );
+				if ( \T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
+					&& $this->tokens[ $closer - 1 ]['line'] === $this->tokens[ $closer ]['line']
+				) {
+					if ( isset( $this->tokens[ ( $closer - 1 ) ]['orig_content'] ) ) {
+						$replacement = $this->tokens[ ( $closer - 1 ) ]['orig_content']
+							. "\t"
+							. $replacement;
+					} else {
+						$replacement = $this->tokens[ ( $closer - 1 ) ]['content']
+							. str_repeat( ' ', $this->tab_width )
+							. $replacement;
+					}
+
+					--$addBefore;
+				} else {
+					// We don't know whether the code uses tabs or spaces, so presume WPCS, i.e. tabs.
+					$replacement = "\t" . $replacement;
+				}
+
+				$replacement = $this->phpcsFile->eolChar . $replacement;
+
+				$this->phpcsFile->fixer->addContentBefore( $addBefore, $replacement );
+
+			} elseif ( \T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code'] ) {
+				$this->phpcsFile->fixer->replaceToken( ( $closer - 1 ), $replacement );
+			} else {
+				$this->phpcsFile->fixer->addContentBefore( $closer, $replacement );
+			}
+		}
+	}
+
+
+	/**
+	 * Process comments to find the plugin/theme headers.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_comments( $stackPtr ) {
+		if ( true === $this->header_found && ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+			return;
+		}
+
+		$regex   = $this->plugin_header_regex;
+		$headers = $this->plugin_headers;
+		$type    = 'plugin';
+		$skip_to = $stackPtr;
+
+		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		if ( 'STDIN' === $file ) {
+			return;
+		}
+
+		$file_name = basename( $file );
+		if ( 'CSS' === $this->phpcsFile->tokenizerType ) {
+			if ( 'style.css' !== $file_name && ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+				// CSS files only need to be examined for the file header.
+				return ( $this->phpcsFile->numTokens + 1 );
+			}
+
+			$regex   = $this->theme_header_regex;
+			$headers = $this->theme_headers;
+			$type    = 'theme';
+		}
+
+		$comment_details = array(
+			'required_header_found' => false,
+			'headers_found'         => 0,
+			'text_domain_ptr'       => false,
+			'text_domain_found'     => '',
+			'last_header_ptr'       => false,
+			'last_header_matches'   => array(),
+		);
+
+		if ( \T_COMMENT === $this->tokens[ $stackPtr ]['code'] ) {
+			$block_comment = false;
+			if ( substr( $this->tokens[ $stackPtr ]['content'], 0, 2 ) === '/*' ) {
+				$block_comment = true;
+			}
+
+			$current = $stackPtr;
+			do {
+				if ( false === $comment_details['text_domain_ptr']
+					|| false === $comment_details['required_header_found']
+					|| $comment_details['headers_found'] < 3
+				) {
+					$comment_details = $this->examine_comment_line( $current, $regex, $headers, $comment_details );
+				}
+
+				if ( true === $block_comment && substr( $this->tokens[ $current ]['content'], -2 ) === '*/' ) {
+					++$current;
+					break;
+				}
+
+				++$current;
+			} while ( isset( $this->tokens[ $current ] ) && \T_COMMENT === $this->tokens[ $current ]['code'] );
+
+			$skip_to = $current;
+
+		} else {
+			if ( ! isset( $this->tokens[ $stackPtr ]['comment_closer'] ) ) {
+				return;
+			}
+
+			$closer  = $this->tokens[ $stackPtr ]['comment_closer'];
+			$current = $stackPtr;
+
+			while ( ( $current = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, ( $current + 1 ), $closer ) ) !== false ) {
+				$comment_details = $this->examine_comment_line( $current, $regex, $headers, $comment_details );
+
+				if ( false !== $comment_details['text_domain_ptr']
+					&& true === $comment_details['required_header_found']
+					&& $comment_details['headers_found'] >= 3
+				) {
+					// No need to look at the rest of the docblock.
+					break;
+				}
+			}
+
+			$skip_to = $closer;
+		}
+
+		// So, was this the plugin/theme header ?
+		if ( true === $comment_details['required_header_found']
+			&& $comment_details['headers_found'] >= 3
+		) {
+			$this->header_found = true;
+
+			$text_domain_ptr   = $comment_details['text_domain_ptr'];
+			$text_domain_found = $comment_details['text_domain_found'];
+
+			if ( false !== $text_domain_ptr ) {
+				if ( $this->new_text_domain !== $text_domain_found
+					&& ( \in_array( $text_domain_found, $this->old_text_domain, true ) )
+				) {
+					$fix = $this->phpcsFile->addFixableError(
+						'Mismatched text domain in %s header. Expected \'%s\' but found \'%s\'',
+						$text_domain_ptr,
+						'TextDomainHeaderMismatch',
+						array(
+							$type,
+							$this->new_text_domain,
+							$text_domain_found,
+						)
+					);
+
+					if ( true === $fix ) {
+						$replacement = str_replace(
+							$text_domain_found,
+							$this->new_text_domain,
+							$this->tokens[ $text_domain_ptr ]['content']
+						);
+
+						$this->phpcsFile->fixer->replaceToken( $text_domain_ptr, $replacement );
+					}
+				}
+			} else {
+				$last_header_ptr     = $comment_details['last_header_ptr'];
+				$last_header_matches = $comment_details['last_header_matches'];
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Missing "Text Domain" in %s header',
+					$last_header_ptr,
+					'MissingTextDomainHeader',
+					array( $type )
+				);
+
+				if ( true === $fix ) {
+					$replacement = $this->tokens[ $last_header_ptr ]['content'];
+					$replacement = str_replace( $last_header_matches[1], 'Text Domain', $replacement );
+					$replacement = str_replace( $last_header_matches[2], $this->new_text_domain, $replacement );
+
+					if ( \T_DOC_COMMENT_OPEN_TAG === $this->tokens[ $stackPtr ]['code'] ) {
+						for ( $i = ( $last_header_ptr - 1 ); ; $i-- ) {
+							if ( $this->tokens[ $i ]['line'] !== $this->tokens[ $last_header_ptr ]['line'] ) {
+								++$i;
+								break;
+							}
+						}
+
+						$replacement = $this->phpcsFile->eolChar
+							. $this->phpcsFile->getTokensAsString( $i, ( $last_header_ptr - $i ), true )
+							. $replacement;
+					}
+
+					$this->phpcsFile->fixer->addContent( $comment_details['last_header_ptr'], $replacement );
+				}
+			}
+		}
+
+		return $skip_to;
+	}
+
+	/**
+	 * Examine an individual token in a larger comment for plugin/theme headers.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $regex           The regex to use to examine the comment line.
+	 * @param array  $headers         Valid headers for a plugin or theme.
+	 * @param array  $comment_details The information collected so far.
+	 *
+	 * @return array Adjusted $comment_details array
+	 */
+	protected function examine_comment_line( $stackPtr, $regex, $headers, $comment_details ) {
+		if ( preg_match( $regex, $this->tokens[ $stackPtr ]['content'], $matches ) === 1 ) {
+			++$comment_details['headers_found'];
+
+			if ( true === $headers[ $matches[1] ] ) {
+				$comment_details['required_header_found'] = true;
+			}
+
+			if ( 'Text Domain' === $matches[1] ) {
+				$comment_details['text_domain_ptr']   = $stackPtr;
+				$comment_details['text_domain_found'] = trim( $matches[2] );
+			}
+
+			$comment_details['last_header_ptr']     = $stackPtr;
+			$comment_details['last_header_matches'] = $matches;
+		}
+
+		return $comment_details;
+	}
+}

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.1.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.1.inc
@@ -1,0 +1,6 @@
+<?php
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain default
+// Comment just to trigger the sniff to report the invalid text domain.
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.2.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.2.inc
@@ -1,0 +1,6 @@
+<?php
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain Some_thing
+// Comment just to trigger the sniff to report the invalid text domain.
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
@@ -1,0 +1,119 @@
+<?php
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
+
+/*
+Plugin Name: Correct text domain, multi-line comment, minimal headers.
+Description: Make sure your plugins and themes are compatible with newer PHP versions.
+Text Domain: php-compatibility-checker
+*/
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+/**
+ * Not the plugin header.
+ *
+ * bbPress is forum software with a twist from the creators of WordPress.
+ *
+ * $Id: bbpress.php 6699 2017-09-13 21:35:09Z johnjamesjacoby $
+ *
+ * @package bbPress
+ * @subpackage Main
+ */
+
+/**
+ * Plugin Name: Text domain which should be fixed, docblock format.
+ * Plugin URI:  https://bbpress.org
+ * Description: bbPress is forum software with a twist from the creators of WordPress.
+ * Author:      The bbPress Contributors
+ * Author URI:  https://bbpress.org
+ * Version:     2.6-rc-5
+ * Text Domain: bbpress
+ * Domain Path: /languages/
+ * License:     GPLv2 or later (license.txt)
+ */
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar
+
+/*
+ Plugin Name: Text domain which should be fixed, multi-line comment, minimal headers.
+ Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
+ Text Domain: debug-bar
+ */
+
+/***
+ * Not the plugin header, don't get confused with consecutive comments.
+ *
+ * When logged in as a super admin, these functions will run to provide
+ * debugging information when specific super admin menu items are selected.
+ *
+ * They are not used when a regular user is logged in.
+ */
+class Debug_Bar {
+
+	/**
+	 * Not the plugin header.
+	 *
+	 * @var string Text Domain: let's make sure not the sniff doesn't confuse docblocks.
+	 */
+	const VERSION = '0.9.1-alpha';
+}
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar-constants
+
+/**
+ * Text domain which should be fixed, docblock format with PHP doc tags.
+ *
+ * @package     WordPress\Plugins\Debug Bar Constants
+ * @author      Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ * @link        https://github.com/jrfnl/Debug-Bar-Constants
+ * @version     2.0.0
+ *
+ * @copyright   2013-2018 Juliette Reinders Folmer
+ * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
+ *
+ * @wordpress-plugin
+ * Plugin Name: Debug Bar Constants
+ * Plugin URI:  https://wordpress.org/plugins/debug-bar-constants/
+ * Description: Debug Bar Constants adds new panels to Debug Bar that display all the defined constants for the current request. Requires "Debug Bar" plugin.
+ * Version:     2.0.0
+ * Author:      Juliette Reinders Folmer
+ * Author URI:  http://www.adviesenzo.nl/
+ * Depends:     Debug Bar
+ * Text Domain: debug-bar-constants
+ * Domain Path: /languages
+ * Copyright:   2013-2018 Juliette Reinders Folmer
+ */
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain a2-optimized
+
+//  Plugin Name: Text domain which should be fixed, multi-line //-style comment.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+//  Version: 2.0.1
+//  Author: A2 Hosting
+//  Author URI: https://www.a2hosting.com/
+//  Description: A2 Optimized - WordPress Optimization Plugin
+//  Text Domain: a2-optimized
+//  License: GPLv2 or Later
+
+//  Plugin Name: Not enough headers to verify this is the header.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+
+/**
+ * Plugin Name: Missing text domain, docblock format.
+ * Plugin URI: http://www.bigvoodoo.com
+ * Description: Ensures the Git repositories are kept current and up to date with uploads made within WordPress.
+ * Author: Big Voodoo Interactive
+ * Version: 0.1.0
+ * Author URI: http://www.bigvoodoo.com
+ * @author Big Voodoo Interactive
+ * @TODO error reporting
+ */
+
+//  Plugin Name: Missing text domain, multi-line //-style comment, minimal headers.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+//  Version: 2.0.1
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
@@ -1,0 +1,121 @@
+<?php
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
+
+/*
+Plugin Name: Correct text domain, multi-line comment, minimal headers.
+Description: Make sure your plugins and themes are compatible with newer PHP versions.
+Text Domain: php-compatibility-checker
+*/
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+/**
+ * Not the plugin header.
+ *
+ * bbPress is forum software with a twist from the creators of WordPress.
+ *
+ * $Id: bbpress.php 6699 2017-09-13 21:35:09Z johnjamesjacoby $
+ *
+ * @package bbPress
+ * @subpackage Main
+ */
+
+/**
+ * Plugin Name: Text domain which should be fixed, docblock format.
+ * Plugin URI:  https://bbpress.org
+ * Description: bbPress is forum software with a twist from the creators of WordPress.
+ * Author:      The bbPress Contributors
+ * Author URI:  https://bbpress.org
+ * Version:     2.6-rc-5
+ * Text Domain: something-else
+ * Domain Path: /languages/
+ * License:     GPLv2 or later (license.txt)
+ */
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar
+
+/*
+ Plugin Name: Text domain which should be fixed, multi-line comment, minimal headers.
+ Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
+ Text Domain: something-else
+ */
+
+/***
+ * Not the plugin header, don't get confused with consecutive comments.
+ *
+ * When logged in as a super admin, these functions will run to provide
+ * debugging information when specific super admin menu items are selected.
+ *
+ * They are not used when a regular user is logged in.
+ */
+class Debug_Bar {
+
+	/**
+	 * Not the plugin header.
+	 *
+	 * @var string Text Domain: let's make sure not the sniff doesn't confuse docblocks.
+	 */
+	const VERSION = '0.9.1-alpha';
+}
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar-constants
+
+/**
+ * Text domain which should be fixed, docblock format with PHP doc tags.
+ *
+ * @package     WordPress\Plugins\Debug Bar Constants
+ * @author      Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ * @link        https://github.com/jrfnl/Debug-Bar-Constants
+ * @version     2.0.0
+ *
+ * @copyright   2013-2018 Juliette Reinders Folmer
+ * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
+ *
+ * @wordpress-plugin
+ * Plugin Name: Debug Bar Constants
+ * Plugin URI:  https://wordpress.org/plugins/debug-bar-constants/
+ * Description: Debug Bar Constants adds new panels to Debug Bar that display all the defined constants for the current request. Requires "Debug Bar" plugin.
+ * Version:     2.0.0
+ * Author:      Juliette Reinders Folmer
+ * Author URI:  http://www.adviesenzo.nl/
+ * Depends:     Debug Bar
+ * Text Domain: something-else
+ * Domain Path: /languages
+ * Copyright:   2013-2018 Juliette Reinders Folmer
+ */
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain a2-optimized
+
+//  Plugin Name: Text domain which should be fixed, multi-line //-style comment.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+//  Version: 2.0.1
+//  Author: A2 Hosting
+//  Author URI: https://www.a2hosting.com/
+//  Description: A2 Optimized - WordPress Optimization Plugin
+//  Text Domain: something-else
+//  License: GPLv2 or Later
+
+//  Plugin Name: Not enough headers to verify this is the header.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+
+/**
+ * Plugin Name: Missing text domain, docblock format.
+ * Plugin URI: http://www.bigvoodoo.com
+ * Description: Ensures the Git repositories are kept current and up to date with uploads made within WordPress.
+ * Author: Big Voodoo Interactive
+ * Version: 0.1.0
+ * Author URI: http://www.bigvoodoo.com
+ * Text Domain: something-else
+ * @author Big Voodoo Interactive
+ * @TODO error reporting
+ */
+
+//  Plugin Name: Missing text domain, multi-line //-style comment, minimal headers.
+//  Plugin URI: https://wordpress.org/plugins/a2-optimized/
+//  Version: 2.0.1
+//  Text Domain: something-else
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -1,0 +1,199 @@
+<?php
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+/*
+ * The test cases in this file have a variety of whitespace for indentation and around
+ * function call parameters to test that the whitespace is not unnecessarily affected
+ * by the fixer.
+ *
+ * This test case file also tests passing several domains to the `old_text_domain` property.
+ */
+
+/*
+ * Correct text-domain, no replacement needed.
+ */
+load_textdomain( 'something-else', '/path/to/file.mo' );
+load_plugin_textdomain( 'something-else', false, '/languages/' );
+load_muplugin_textdomain( 'something-else', '/languages/' );
+load_theme_textdomain( 'something-else', '/path/to/languages/' );
+load_child_theme_textdomain( 'something-else', '/path/to/languages/' );
+unload_textdomain( 'something-else' );
+
+__( $text, 'something-else' );
+_e( $text, 'something-else' );
+_x( $text, $context, 'something-else' );
+_ex( $text, $context, 'something-else' );
+_n( $single, $plural, $number, 'something-else' );
+_nx(
+	$single,
+	$plural,
+	$number,
+	$context,
+	'something-else',
+); // PHP 7.3 trailing comma in function call.
+_n_noop( $singular, $plural, 'something-else' );
+_nx_noop( $singular, $plural, $context, 'something-else' );
+translate_nooped_plural( $nooped_plural, $count, 'something-else' );
+_c( $text, 'something-else' );
+
+esc_html__( $text, 'something-else' );
+esc_html_e( $text, 'something-else' );
+esc_html_x($text, $context, 'something-else');
+esc_attr__  ( /* comment */ $text, 'something-else' );
+esc_attr_e( $text, 'something-else' );
+esc_attr_x( $text, $context, 'something-else' );
+
+is_textdomain_loaded( "something-else" );
+get_translations_for_domain( 'something-else' );
+
+translate( $text, 'something-else' );
+translate_with_gettext_context( $text, $context, 'something-else' );
+
+_load_textdomain_just_in_time('something-else');
+_get_path_to_translation_from_lang_dir( 'something-else' );
+_get_path_to_translation( 'something-else', true );
+
+/*
+ * Situations which are not our concern and should be ignored.
+ */
+$this->translate( $text, 'third-text-domain' );
+self::translate( $text, 'third-text-domain' );
+MyNameSpace\Second\translate( $text, 'third-text-domain' );
+
+__( $text, "a $interpolated string" );
+_e( $text, 'concatenated' . 'string' );
+_x( $text, $context, $variableTextdomain );
+_ex( $text, $context, CONSTANT_TEXTDOMAIN );
+
+/*
+ * Text domains *not* in the whitelisted "old" domain list should be ignored.
+ */
+load_plugin_textdomain( 'tgmpa', false, '/languages/' );
+_e( $text, 'default' );
+is_textdomain_loaded( 'some-other-plugin' );
+
+/*
+ * Incorrect text-domain, should be replaced.
+ */
+load_textdomain( 'text-domain', '/path/to/file.mo' );
+load_plugin_textdomain( 'text-domain', false, '/languages/' );
+load_muplugin_textdomain( 'other-text-domain', '/languages/' );
+load_theme_textdomain( 'third-text-domain', '/path/to/languages/' );
+load_child_theme_textdomain( 'text-domain', '/path/to/languages/' );
+unload_textdomain( 'text-domain' );
+
+__( $text, 'text-domain' );
+_e( $text, 'text-domain' );
+_x( $text, $context, 'text-domain' );
+_ex( $text, $context, 'third-text-domain' );
+_n($single,$plural,$number,'text-domain');
+_nx( $single, $plural, $number, $context, 'text-domain' );
+_n_noop( $singular, $plural, 'other-text-domain' );
+_nx_noop( $singular,
+	$plural,
+	$context, 'text-domain' );
+translate_nooped_plural( $nooped_plural, $count, "text-domain" );
+_c( $text, 'text-domain' );
+
+esc_html__( $text, 'third-text-domain' );
+esc_html_e( $text, 'text-domain' );
+esc_html_x($text, $context, 'text-domain');
+esc_attr__( $text, 'text-domain' );
+esc_attr_e( $text, 'other-text-domain' );
+esc_attr_x(
+	$text,
+	$context,
+	'text-domain'
+);
+
+is_textdomain_loaded( 'text-domain' );
+get_translations_for_domain( 'other-text-domain' );
+
+translate( $text, 'third-text-domain' );
+translate_with_gettext_context(
+	$text,
+	$context,
+	'text-domain',
+);
+
+_load_textdomain_just_in_time( 'third-text-domain' );
+_get_path_to_translation_from_lang_dir( 'text-domain' );
+_get_path_to_translation( 'other-text-domain', true );
+
+/*
+ * Missing text-domain, should be added.
+ */
+load_textdomain();
+load_plugin_textdomain( /* everything missing, but has a comment */ );
+load_muplugin_textdomain(    );
+load_theme_textdomain();
+		load_child_theme_textdomain(
+		);
+unload_textdomain();
+
+__( $text );
+_e( $text );
+_x( $text, $context, ); // PHP 7.3 trailing comma in function call.
+_ex( $text, $context );
+_n( $single, $plural, $number );
+_nx( $single, $plural, $number, $context );
+_n_noop( $singular, $plural );
+_nx_noop( $singular, $plural, $context );
+translate_nooped_plural( $nooped_plural, $count );
+_c( $text );
+
+esc_html__($text);
+esc_html_e( $text );
+esc_html_x(
+    $text,
+    $context,
+); // PHP 7.3 trailing comma in multi-line function call.
+esc_attr__( $text);
+esc_attr_e($text );
+esc_attr_x(
+	$text,
+	$context );
+
+is_textdomain_loaded(
+);
+get_translations_for_domain();
+
+translate( $text);
+translate_with_gettext_context( $text, $context);
+
+_load_textdomain_just_in_time();
+_get_path_to_translation_from_lang_dir();
+_get_path_to_translation();
+
+/*
+ * Missing text-domain and preceeding args, only throw warning.
+ */
+__();
+_e(   /* comment */  );
+_x(    );
+_ex();
+_n( $single, $plural );
+_nx( $single, $plural );
+_n_noop($singular);
+_nx_noop(
+);
+translate_nooped_plural( $nooped_plural );
+_c();
+
+esc_html__();
+esc_html_e(  );
+esc_html_x(
+    $text,
+); // PHP 7.3 trailing comma in multi-line function call.
+esc_attr__();
+esc_attr_e();
+esc_attr_x(
+	$text,
+);
+
+translate();
+translate_with_gettext_context( $text);
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -1,0 +1,203 @@
+<?php
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+/*
+ * The test cases in this file have a variety of whitespace for indentation and around
+ * function call parameters to test that the whitespace is not unnecessarily affected
+ * by the fixer.
+ *
+ * This test case file also tests passing several domains to the `old_text_domain` property.
+ */
+
+/*
+ * Correct text-domain, no replacement needed.
+ */
+load_textdomain( 'something-else', '/path/to/file.mo' );
+load_plugin_textdomain( 'something-else', false, '/languages/' );
+load_muplugin_textdomain( 'something-else', '/languages/' );
+load_theme_textdomain( 'something-else', '/path/to/languages/' );
+load_child_theme_textdomain( 'something-else', '/path/to/languages/' );
+unload_textdomain( 'something-else' );
+
+__( $text, 'something-else' );
+_e( $text, 'something-else' );
+_x( $text, $context, 'something-else' );
+_ex( $text, $context, 'something-else' );
+_n( $single, $plural, $number, 'something-else' );
+_nx(
+	$single,
+	$plural,
+	$number,
+	$context,
+	'something-else',
+); // PHP 7.3 trailing comma in function call.
+_n_noop( $singular, $plural, 'something-else' );
+_nx_noop( $singular, $plural, $context, 'something-else' );
+translate_nooped_plural( $nooped_plural, $count, 'something-else' );
+_c( $text, 'something-else' );
+
+esc_html__( $text, 'something-else' );
+esc_html_e( $text, 'something-else' );
+esc_html_x($text, $context, 'something-else');
+esc_attr__  ( /* comment */ $text, 'something-else' );
+esc_attr_e( $text, 'something-else' );
+esc_attr_x( $text, $context, 'something-else' );
+
+is_textdomain_loaded( "something-else" );
+get_translations_for_domain( 'something-else' );
+
+translate( $text, 'something-else' );
+translate_with_gettext_context( $text, $context, 'something-else' );
+
+_load_textdomain_just_in_time('something-else');
+_get_path_to_translation_from_lang_dir( 'something-else' );
+_get_path_to_translation( 'something-else', true );
+
+/*
+ * Situations which are not our concern and should be ignored.
+ */
+$this->translate( $text, 'third-text-domain' );
+self::translate( $text, 'third-text-domain' );
+MyNameSpace\Second\translate( $text, 'third-text-domain' );
+
+__( $text, "a $interpolated string" );
+_e( $text, 'concatenated' . 'string' );
+_x( $text, $context, $variableTextdomain );
+_ex( $text, $context, CONSTANT_TEXTDOMAIN );
+
+/*
+ * Text domains *not* in the whitelisted "old" domain list should be ignored.
+ */
+load_plugin_textdomain( 'tgmpa', false, '/languages/' );
+_e( $text, 'default' );
+is_textdomain_loaded( 'some-other-plugin' );
+
+/*
+ * Incorrect text-domain, should be replaced.
+ */
+load_textdomain( 'something-else', '/path/to/file.mo' );
+load_plugin_textdomain( 'something-else', false, '/languages/' );
+load_muplugin_textdomain( 'something-else', '/languages/' );
+load_theme_textdomain( 'something-else', '/path/to/languages/' );
+load_child_theme_textdomain( 'something-else', '/path/to/languages/' );
+unload_textdomain( 'something-else' );
+
+__( $text, 'something-else' );
+_e( $text, 'something-else' );
+_x( $text, $context, 'something-else' );
+_ex( $text, $context, 'something-else' );
+_n($single,$plural,$number,'something-else');
+_nx( $single, $plural, $number, $context, 'something-else' );
+_n_noop( $singular, $plural, 'something-else' );
+_nx_noop( $singular,
+	$plural,
+	$context, 'something-else' );
+translate_nooped_plural( $nooped_plural, $count, "something-else" );
+_c( $text, 'something-else' );
+
+esc_html__( $text, 'something-else' );
+esc_html_e( $text, 'something-else' );
+esc_html_x($text, $context, 'something-else');
+esc_attr__( $text, 'something-else' );
+esc_attr_e( $text, 'something-else' );
+esc_attr_x(
+	$text,
+	$context,
+	'something-else'
+);
+
+is_textdomain_loaded( 'something-else' );
+get_translations_for_domain( 'something-else' );
+
+translate( $text, 'something-else' );
+translate_with_gettext_context(
+	$text,
+	$context,
+	'something-else',
+);
+
+_load_textdomain_just_in_time( 'something-else' );
+_get_path_to_translation_from_lang_dir( 'something-else' );
+_get_path_to_translation( 'something-else', true );
+
+/*
+ * Missing text-domain, should be added.
+ */
+load_textdomain( 'something-else' );
+load_plugin_textdomain( /* everything missing, but has a comment */ 'something-else' );
+load_muplugin_textdomain( 'something-else' );
+load_theme_textdomain( 'something-else' );
+		load_child_theme_textdomain(
+			'something-else'
+		);
+unload_textdomain( 'something-else' );
+
+__( $text, 'something-else' );
+_e( $text, 'something-else' );
+_x( $text, $context, 'something-else', ); // PHP 7.3 trailing comma in function call.
+_ex( $text, $context, 'something-else' );
+_n( $single, $plural, $number, 'something-else' );
+_nx( $single, $plural, $number, $context, 'something-else' );
+_n_noop( $singular, $plural, 'something-else' );
+_nx_noop( $singular, $plural, $context, 'something-else' );
+translate_nooped_plural( $nooped_plural, $count, 'something-else' );
+_c( $text, 'something-else' );
+
+esc_html__($text, 'something-else');
+esc_html_e( $text, 'something-else' );
+esc_html_x(
+    $text,
+    $context,
+    'something-else',
+); // PHP 7.3 trailing comma in multi-line function call.
+esc_attr__( $text, 'something-else');
+esc_attr_e($text, 'something-else' );
+esc_attr_x(
+	$text,
+	$context,
+	'something-else' );
+
+is_textdomain_loaded(
+	'something-else'
+);
+get_translations_for_domain( 'something-else' );
+
+translate( $text, 'something-else');
+translate_with_gettext_context( $text, $context, 'something-else');
+
+_load_textdomain_just_in_time( 'something-else' );
+_get_path_to_translation_from_lang_dir( 'something-else' );
+_get_path_to_translation( 'something-else' );
+
+/*
+ * Missing text-domain and preceeding args, only throw warning.
+ */
+__();
+_e(   /* comment */  );
+_x(    );
+_ex();
+_n( $single, $plural );
+_nx( $single, $plural );
+_n_noop($singular);
+_nx_noop(
+);
+translate_nooped_plural( $nooped_plural );
+_c();
+
+esc_html__();
+esc_html_e(  );
+esc_html_x(
+    $text,
+); // PHP 7.3 trailing comma in multi-line function call.
+esc_attr__();
+esc_attr_e();
+esc_attr_x(
+	$text,
+);
+
+translate();
+translate_with_gettext_context( $text);
+
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
@@ -1,0 +1,159 @@
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
+
+/*
+Theme Name: Correct text-domain.
+Theme URI: https://wordpress.org/themes/twentyten/
+Description: The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
+Author: the WordPress team
+Author URI: https://wordpress.org/
+Version: 2.5
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header
+Text Domain: twentyten
+*/
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
+
+/*!
+Theme Name: Text domain which should be fixed and checking that consecutive comments don't get mixed up.
+Theme URI: https://underscores.me/
+Author: Automattic
+Author URI: https://automattic.com/
+Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: LICENSE
+Text Domain: _s
+Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+
+_s is based on Underscores https://underscores.me/, (C) 2012-2017 Automattic, Inc.
+Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Normalizing styles have been helped along thanks to the fine work of
+Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
+*/
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+# Normalize
+# Typography
+# Elements
+# Forms
+# Navigation
+	## Links
+	## Menus
+# Accessibility
+# Alignments
+# Clearings
+# Widgets
+# Content
+	## Posts and pages
+	## Comments
+# Infinite scroll
+# Media
+	## Captions
+	## Galleries
+--------------------------------------------------------------*/
+/*--------------------------------------------------------------
+# Normalize
+--------------------------------------------------------------*/
+/* normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+	 ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+	line-height: 1.15; /* 1 */
+	-webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
+
+/*
+Theme Name: Missing text domain.
+Theme URI: https://wordpress.org/themes/twentyseventeen/
+Author: the WordPress team
+Author URI: https://wordpress.org/
+Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
+Version: 1.6
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+*/
+
+/*
+ * Theme Name : Missing text domain, different comment format.
+ * Theme URI  : https://wordpress.org/themes/twentyseventeen/
+ * Author     : the WordPress team
+ * Author URI : https://wordpress.org/
+ * Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
+ * Version    : 1.6
+ * License    : GNU General Public License v2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * Tags       : one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
+ *
+ * This theme, like WordPress, is licensed under the GPL.
+ * Use it to make something cool, have fun, and share what you've learned with others.
+ */
+
+/*
+ * Theme Name: Not the theme header (not enough headers found.
+ */
+
+/*
+Theme Name: Missing text domain. Minimum headers.
+Theme URI: http://protected
+Description: http://thisshouldntbeaurl
+*/
+
+/*
+  Theme Name:       Missing text domain, different comment format, additional non-standard headers.
+  Theme URI:        https://protected
+  Author:           Lacy Morrow
+  Author URI:       http://protected
+  Description:      A Ghost-like WordPress theme. Casper (for WordPress) is a simple yet beautiful theme for bloggers. Inspired by the Ghost blogging platform, Casper is a WordPress port of the default theme by the same name. The goal of this project is to emulate the gorgeous theme while taking advantage of features exclusive to the WordPress framework. There are plenty of customization options included, accessible through the WordPress Customizer. Already included are hooks to serve responsive images appropriately and media queries to provide a fast and seamless experience from desktop to mobile. For questions, support, development instructions, or to contribute to the project visit [https://github.com/lacymorrow/casper]
+  Version:          1.1.5
+  License:          GNU General Public License v2.0
+  License URI:      http://www.gnu.org/licenses/gpl-2.0.html
+  Domain Path:      /languages/
+  Tags:             responsive-layout, black, white, one-column, fluid-layout, custom-header, custom-menu, editor-style
+  GitHub Theme URI: https://github.com/protected
+  GitHub Branch:    master
+  Casper is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
+*/
+
+/**
+ * Theme Name: Missing text domain. Docblock format.
+ * Theme URI: https://github.com/WordPress/twentynineteen
+ * Author: the WordPress team
+ * Author URI: https://wordpress.org/
+ * Description: A new Gutenberg-ready theme.
+ * Requires at least: WordPress 4.9.6
+ * Version: 1.0
+ * License: GNU General Public License v2 or later
+ * License URI: LICENSE
+ * Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
+ * This theme, like WordPress, is licensed under the GPL.
+ * Use it to make something cool, have fun, and share what you've learned with others.
+ * Twenty Nineteen is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+ * Underscores is distributed under the terms of the GNU GPL v2 or later.
+ * Normalizing styles have been helped along thanks to the fine work of
+ * Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
+ */
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
@@ -1,0 +1,164 @@
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
+
+/*
+Theme Name: Correct text-domain.
+Theme URI: https://wordpress.org/themes/twentyten/
+Description: The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
+Author: the WordPress team
+Author URI: https://wordpress.org/
+Version: 2.5
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header
+Text Domain: twentyten
+*/
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
+
+/*!
+Theme Name: Text domain which should be fixed and checking that consecutive comments don't get mixed up.
+Theme URI: https://underscores.me/
+Author: Automattic
+Author URI: https://automattic.com/
+Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: LICENSE
+Text Domain: something-else
+Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+
+_s is based on Underscores https://underscores.me/, (C) 2012-2017 Automattic, Inc.
+Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Normalizing styles have been helped along thanks to the fine work of
+Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
+*/
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+# Normalize
+# Typography
+# Elements
+# Forms
+# Navigation
+	## Links
+	## Menus
+# Accessibility
+# Alignments
+# Clearings
+# Widgets
+# Content
+	## Posts and pages
+	## Comments
+# Infinite scroll
+# Media
+	## Captions
+	## Galleries
+--------------------------------------------------------------*/
+/*--------------------------------------------------------------
+# Normalize
+--------------------------------------------------------------*/
+/* normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+	 ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+	line-height: 1.15; /* 1 */
+	-webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
+
+/*
+Theme Name: Missing text domain.
+Theme URI: https://wordpress.org/themes/twentyseventeen/
+Author: the WordPress team
+Author URI: https://wordpress.org/
+Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
+Version: 1.6
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
+Text Domain: twentyseventeen
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+*/
+
+/*
+ * Theme Name : Missing text domain, different comment format.
+ * Theme URI  : https://wordpress.org/themes/twentyseventeen/
+ * Author     : the WordPress team
+ * Author URI : https://wordpress.org/
+ * Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
+ * Version    : 1.6
+ * License    : GNU General Public License v2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * Tags       : one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
+ * Text Domain       : twentyseventeen
+ *
+ * This theme, like WordPress, is licensed under the GPL.
+ * Use it to make something cool, have fun, and share what you've learned with others.
+ */
+
+/*
+ * Theme Name: Not the theme header (not enough headers found.
+ */
+
+/*
+Theme Name: Missing text domain. Minimum headers.
+Theme URI: http://protected
+Description: http://thisshouldntbeaurl
+Text Domain: twentyseventeen
+*/
+
+/*
+  Theme Name:       Missing text domain, different comment format, additional non-standard headers.
+  Theme URI:        https://protected
+  Author:           Lacy Morrow
+  Author URI:       http://protected
+  Description:      A Ghost-like WordPress theme. Casper (for WordPress) is a simple yet beautiful theme for bloggers. Inspired by the Ghost blogging platform, Casper is a WordPress port of the default theme by the same name. The goal of this project is to emulate the gorgeous theme while taking advantage of features exclusive to the WordPress framework. There are plenty of customization options included, accessible through the WordPress Customizer. Already included are hooks to serve responsive images appropriately and media queries to provide a fast and seamless experience from desktop to mobile. For questions, support, development instructions, or to contribute to the project visit [https://github.com/lacymorrow/casper]
+  Version:          1.1.5
+  License:          GNU General Public License v2.0
+  License URI:      http://www.gnu.org/licenses/gpl-2.0.html
+  Domain Path:      /languages/
+  Tags:             responsive-layout, black, white, one-column, fluid-layout, custom-header, custom-menu, editor-style
+  Text Domain:             twentyseventeen
+  GitHub Theme URI: https://github.com/protected
+  GitHub Branch:    master
+  Casper is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
+*/
+
+/**
+ * Theme Name: Missing text domain. Docblock format.
+ * Theme URI: https://github.com/WordPress/twentynineteen
+ * Author: the WordPress team
+ * Author URI: https://wordpress.org/
+ * Description: A new Gutenberg-ready theme.
+ * Requires at least: WordPress 4.9.6
+ * Version: 1.0
+ * License: GNU General Public License v2 or later
+ * License URI: LICENSE
+ * Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
+ * Text Domain: twentyseventeen
+ * This theme, like WordPress, is licensed under the GPL.
+ * Use it to make something cool, have fun, and share what you've learned with others.
+ * Twenty Nineteen is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+ * Underscores is distributed under the terms of the GNU GPL v2 or later.
+ * Normalizing styles have been helped along thanks to the fine work of
+ * Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
+ */
+
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
+/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Tests\Utils;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the I18nTextDomainFixer sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   1.2.0
+ */
+class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * The tab width to use during testing.
+	 *
+	 * @var int
+	 */
+	private $tab_width = 4;
+
+	/**
+	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * Used by PHPCS 2.x.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array
+	 */
+	public function getCliValues( $testFile ) {
+		// Tab width setting is only needed for the file with the function calls.
+		if ( 'I18nTextDomainFixerUnitTest.4.inc' === $testFile ) {
+			return array( '--tab-width=' . $this->tab_width );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Set CLI values before the file is tested.
+	 *
+	 * Used by PHPCS 3.x.
+	 *
+	 * @param string                  $testFile The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $testFile, $config ) {
+		// Tab width setting is only needed for the file with the function calls.
+		if ( 'I18nTextDomainFixerUnitTest.4.inc' === $testFile ) {
+			$config->tabWidth = $this->tab_width;
+		} else {
+			$config->tabWidth = 0;
+		}
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+
+		switch ( $testFile ) {
+			case 'I18nTextDomainFixerUnitTest.css':
+				return array(
+					29  => 1,
+					92  => 1,
+					107 => 1,
+					120 => 1,
+					133 => 1,
+					149 => 1,
+				);
+
+			case 'I18nTextDomainFixerUnitTest.3.inc':
+				return array(
+					32  => 1,
+					42  => 1,
+					84  => 1,
+					97  => 1,
+					109 => 1,
+					116 => 1,
+				);
+
+			case 'I18nTextDomainFixerUnitTest.4.inc':
+				return array(
+					79  => 1,
+					80  => 1,
+					81  => 1,
+					82  => 1,
+					83  => 1,
+					84  => 1,
+					86  => 1,
+					87  => 1,
+					88  => 1,
+					89  => 1,
+					90  => 1,
+					91  => 1,
+					92  => 1,
+					95  => 1,
+					96  => 1,
+					97  => 1,
+					99  => 1,
+					100 => 1,
+					101 => 1,
+					102 => 1,
+					103 => 1,
+					107 => 1,
+					110 => 1,
+					111 => 1,
+					113 => 1,
+					117 => 1,
+					120 => 1,
+					121 => 1,
+					122 => 1,
+					127 => 1,
+					128 => 1,
+					129 => 1,
+					130 => 1,
+					131 => 1,
+					133 => 1,
+					135 => 1,
+					136 => 1,
+					137 => 1,
+					138 => 1,
+					139 => 1,
+					140 => 1,
+					141 => 1,
+					142 => 1,
+					143 => 1,
+					144 => 1,
+					146 => 1,
+					147 => 1,
+					148 => 1,
+					152 => 1,
+					153 => 1,
+					154 => 1,
+					158 => 1,
+					160 => 1,
+					162 => 1,
+					163 => 1,
+					165 => 1,
+					166 => 1,
+					167 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'I18nTextDomainFixerUnitTest.1.inc':
+			case 'I18nTextDomainFixerUnitTest.2.inc':
+				return array(
+					1 => 1,
+				);
+
+			case 'I18nTextDomainFixerUnitTest.4.inc':
+				return array(
+					172 => 1,
+					173 => 1,
+					174 => 1,
+					175 => 1,
+					176 => 1,
+					177 => 1,
+					178 => 1,
+					179 => 1,
+					181 => 1,
+					182 => 1,
+					184 => 1,
+					185 => 1,
+					186 => 1,
+					189 => 1,
+					190 => 1,
+					191 => 1,
+					195 => 1,
+					196 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+}


### PR DESCRIPTION
This sniff can replace the text-domain used in a code-base.
The sniff will fix the text-domains in both I18n function calls as well as in a plugin/theme header.
The sniff is disabled by default.

Passing the following properties will activate the sniff:
- `old_text_domain`: an array with one or more (old) text-domain names which need to be replaced;
- `new_text_domain`: the correct (new) text-domain as a string.

Notes:
* The sniff will do a comprehensive find & replace for the text-domains in *all* internationalization related functions, including deprecated/internal use functions and the `load_text_domain()` functions.
* The sniff will add the (new) text-domain if it is missing and all the preceding function call arguments are in place.
     If any of the preceding function call arguments is (also) missing, the sniff will throw a warning, but will not run the fixer.
* For a scaffold plugin/theme which doesn't use placeholder text-domains to use this sniff to add the text-domain, the `old_text_domain` property *does* still need to be passed.
     In that case, just putting anything in it, will do, i.e. `<property name="old_text_domain" type="array" value="ignore"/>`.
* The `default` text-domain is not allowed as the "new" text-domain as it is reserved for WP Core.
* The sniff will search for the plugin/theme header and fix the `Text Domain: ...` header if found, or add it, if it is missing.
    For a comment to be recognized as the plugin/theme header:
    - At least one required header has to be present.
    - At least three of the possible headers have to be present.
* The sniff will examine all comments to find the plugin/theme header, with these caveats:
    - For CSS, It will only examine the file if it is called `style.css`.
    - It will keep track of whether or not the plugin/theme header has been found already and bow out from examining further comments as soon as it has found the header.
        This is an efficiency mechanism as examining all comments in a code base while we're only looking for one particular one, would make the sniff unnecessarily slow.
        This also means that running this sniff over two or more plugins/themes in one go will not work, at least not for the fixing of the plugin/theme header.
     - The sniff does not know in advance whether a plugin or a theme is being examined, so it will look for the header in every file (save non-`style.css` CSS files).
    - For the unit test files, an exception is build in to prevent us having to have 20+ unit test files just to test the recognition of the headers.

Fixes #1174