### PR TITLE
Wording: Change text-domain to text domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,8 +276,8 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `WordPress.VIP.CronInterval` sniff now allows for customizing the minimum allowed cron interval by [setting a property in a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#vip-croninterval-minimum-interval).
 - The `WordPress.VIP.RestrictedFunctions` sniff used to prohibit the use of certain WP native functions, recommending the use of `wpcom_vip_get_term_link()`, `wpcom_vip_get_term_by()` and `wpcom_vip_get_category_by_slug()` instead, as the WP native functions were not being cached. As the results of the relevant WP native functions are cached as of WP 4.8, the advice has now been reversed i.e. use the WP native functions instead of `wpcom...` functions.
 - The `WordPress.VIP.PostsPerPage` sniff now allows for customizing the `post_per_page` limit for which the sniff will trigger by [setting a property in a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#vip-postsperpage-post-limit).
-- The `WordPress.WP.I18n` sniff will now allow and actively encourage omitting the text-domain in I18n function calls if the text-domain passed via the `text_domain` property is `default`, i.e. the domain used by Core.
-    When `default` is one of several text-domains passed via the `text_domain` property, the error thrown when the domain is missing has been downgraded to a `warning`.
+- The `WordPress.WP.I18n` sniff will now allow and actively encourage omitting the text domain in I18n function calls if the text domain passed via the `text_domain` property is `default`, i.e. the domain used by Core.
+    When `default` is one of several text domains passed via the `text_domain` property, the error thrown when the domain is missing has been downgraded to a `warning`.
 - The `WordPress.XSS.EscapeOutput` sniff now has a separate error code `OutputNotEscapedShortEcho` and the error message texts have been updated.
 - Moved `Squiz.PHP.Eval` from the `WordPress-Extra` and `WordPress-VIP` to the `WordPress-Core` ruleset.
 - Removed two sniffs from the `WordPress-VIP` ruleset which were already included via the `WordPress-Core` ruleset.
@@ -526,7 +526,7 @@ You are also encouraged to check the file history of any WPCS classes you extend
 ## [0.10.0] - 2016-08-29
 
 ### Added
-- `WordPress.WP.I18n` sniff to the `WordPress-Core` ruleset to flag dynamic translatable strings and textdomains.
+- `WordPress.WP.I18n` sniff to the `WordPress-Core` ruleset to flag dynamic translatable strings and text domains.
 - `WordPress.PHP.DisallowAlternativePHPTags` sniff to the `WordPress-Core` ruleset to flag - and fix - ASP and `<script>` PHP open tags.
 - `WordPress.Classes.ClassOpeningStatement` sniff to the `WordPress-Core` ruleset to flag - and fix - class opening brace placement.
 - `WordPress.NamingConventions.ValidHookName` sniff to the `WordPress-Core` ruleset to flag filter and action hooks which don't comply with the guideline of lowercase letters and underscores. For maintaining backward-compatibility of hook names an `additionalWordDelimiters` property can be added via a custom ruleset.

--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ This sniff category contains some tools which, generally speaking, will only be 
 The sniffs in this category are disabled by default and can only be activated by adding some properties for each sniff via a custom ruleset.
 
 At this moment, WPCS offer the following tools:
-* `WordPress.Utils.I18nTextDomainFixer` - This sniff can replace the text-domain used in a code-base.
-    The sniff will fix the text-domains in both I18n function calls as well as in a plugin/theme header.
+* `WordPress.Utils.I18nTextDomainFixer` - This sniff can replace the text domain used in a code-base.
+    The sniff will fix the text domains in both I18n function calls as well as in a plugin/theme header.
     Passing the following properties will activate the sniff:
-    - `old_text_domain`: an array with one or more (old) text-domain names which need to be replaced;
-    - `new_text_domain`: the correct (new) text-domain as a string.
+    - `old_text_domain`: an array with one or more (old) text domain names which need to be replaced;
+    - `new_text_domain`: the correct (new) text domain as a string.
 
 
 ## Contributing

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -16,8 +16,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Comprehensive I18n text domain fixer tool.
  *
  * This sniff can:
- * - Add missing `text-domain`s.
- * - Replace `text-domain`s based on an array of `old` values to a `new` value.
+ * - Add missing text domains.
+ * - Replace text domains based on an array of `old` values to a `new` value.
  *
  * Note: Without a user-defined configuration in a custom ruleset, this sniff will be ignored.
  *
@@ -303,7 +303,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 
 			if ( 'default' === $this->new_text_domain ) {
 				$this->phpcsFile->addWarning(
-					'The "default" text-domain is reserved for WordPress core use and should not be used by plugins or themes',
+					'The "default" text domain is reserved for WordPress core use and should not be used by plugins or themes',
 					0,
 					'ReservedNewDomain',
 					array( $this->new_text_domain )
@@ -314,7 +314,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 
 			if ( preg_match( '`^[a-z0-9-]+$`', $this->new_text_domain ) !== 1 ) {
 				$this->phpcsFile->addWarning(
-					'The text-domain should be a simple lowercase text string with words separated by dashes. "%s" appears invalid',
+					'The text domain should be a simple lowercase text string with words separated by dashes. "%s" appears invalid',
 					0,
 					'InvalidNewDomain',
 					array( $this->new_text_domain )

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -23,7 +23,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @since   0.10.0
  * @since   0.11.0 - Now also checks for translators comments.
- *                 - Now has the ability to handle text-domain set via the command-line
+ *                 - Now has the ability to handle text domain set via the command-line
  *                   as a comma-delimited list.
  *                   `phpcs --runtime-set text_domain my-slug,default`
  * @since   0.13.0 Class name changed: this class is now namespaced.
@@ -483,7 +483,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 				if ( true === $this->text_domain_is_default && 'default' === $stripped_content ) {
 					$fixable    = false;
-					$error      = 'No need to supply the text domain when the only accepted text-domain is "default".';
+					$error      = 'No need to supply the text domain when the only accepted text domain is "default".';
 					$error_code = 'SuperfluousDefaultTextDomain';
 
 					if ( $tokens[0]['token_index'] === $stack_ptr ) {

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -150,7 +150,7 @@ EOD
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
 __( "String default text domain.", "my-slug" ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
-__( "String default text domain.", 'something' ); // Bad, text-domain mismatch.
+__( "String default text domain.", 'something' ); // Bad, text domain mismatch.
 __( 'String default text domain.' ); // Warning, use default.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain default

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -150,7 +150,7 @@ EOD
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
 __( "String default text domain.", "my-slug" ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
-__( "String default text domain.", 'something' ); // Bad, text-domain mismatch.
+__( "String default text domain.", 'something' ); // Bad, text domain mismatch.
 __( 'String default text domain.' ); // Warning, use default.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain default


### PR DESCRIPTION
Only strings, comments and documentation was changed.

Instances inside test files were not touched.

Fixes #1526.

(We have no instance of any variation of meta box.)