### PR TITLE
Fix missing check for infinite posts_per_page

### DIFF
--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -68,7 +68,7 @@ class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		$this->posts_per_page = (int) $this->posts_per_page;
 
-		if ( $val > $this->posts_per_page ) {
+		if ( $val > $this->posts_per_page || '-1' === $val ) {
 			return 'Detected high pagination limit, `%s` is set to `%s`';
 		}
 

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -2,7 +2,7 @@
 
 $args = array(
 	'posts_per_page' => 999, // Bad.
-	'posts_per_page' => -1, // OK.
+	'posts_per_page' => -1, // Bad.
 	'posts_per_page' => 1, // OK.
 	'posts_per_page' => '1', // OK.
 );
@@ -13,7 +13,8 @@ _query_posts( 'numberposts=999' ); // Bad.
 $query_args['posts_per_page'] = 999; // Bad.
 $query_args['posts_per_page'] = 1; // OK.
 $query_args['posts_per_page'] = '1'; // OK.
-$query_args['numberposts'] = '-1'; // OK.
+$query_args['posts_per_page'] = '-1'; // Bad.
+$query_args['numberposts'] = '-1'; // Bad.
 
 $query_args['my_posts_per_page'] = -1; // OK.
 

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -41,13 +41,16 @@ class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array(
 			4  => 1,
+			5  => 1,
 			10 => 1,
 			11 => 1,
 			13 => 1,
-			22 => 1,
+			16 => 1,
+			17 => 1,
 			23 => 1,
 			24 => 1,
-			29 => 1,
+			25 => 1,
+			30 => 1,
 		);
 	}
 


### PR DESCRIPTION
Hi, 

the class description says "Flag returning high or infinite posts_per_page.". It was missing this last check:  `'-1' === $val`, which i added it here:

```php
if ( $val > $this->posts_per_page || '-1' === $val ) {
	return 'Detected high pagination limit, `%s` is set to `%s`';
}
```

This infinite (-1) limit is worse that high fixed limit. Like [other have mentioned](https://10up.github.io/Engineering-Best-Practices/php/), this fix should be reintroduced.

This will fix #1379 in cases where the value is not a variable.


I also introduced a new test:

```php
$query_args['posts_per_page'] = '-1'; // Bad.
```

Not sure if i should add more cases, as they are missing.

Also, i didn't touch the wrong indentation on the last tests. There's a space at the beginning of each line. Can i remove it?

```php
// @codingStandardsChangeSetting WordPress.WP.PostsPerPage posts_per_page 50
 $query_args['posts_per_page'] = 50; // OK.
 $query_args['posts_per_page'] = 100; // Bad.
 $query_args['posts_per_page'] = 200; // Bad.
 $query_args['posts_per_page'] = 300; // Bad.
// @codingStandardsChangeSetting WordPress.WP.PostsPerPage posts_per_page 200
 $query_args['posts_per_page'] = 50; // OK.
 $query_args['posts_per_page'] = 100; // OK.
 $query_args['posts_per_page'] = 200; // OK.
 $query_args['posts_per_page'] = 300; // Bad.
```

All tests look good:
```script

$phpunit --bootstrap="./Test/phpcs3-bootstrap.php" --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

................................................................. 65 / 80 ( 81%)
...............                                                   80 / 80 (100%)

Tests generated 580 unique error codes; 52 were fixable (8.97%)

Time: 2.58 seconds, Memory: 36.00MB

OK (80 tests, 0 assertions)
```

thanks, let me know if i missed something.