### PR TITLE
PrecisionAlignment: bug fix

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -91,7 +91,7 @@ class PrecisionAlignmentSniff extends Sniff {
 		}
 
 		// Handle any custom ignore tokens received from a ruleset.
-		$this->ignoreAlignmentTokens = $this->merge_custom_array( $this->ignoreAlignmentTokens );
+		$ignoreAlignmentTokens = $this->merge_custom_array( $this->ignoreAlignmentTokens );
 
 		$check_tokens  = array(
 			'T_WHITESPACE'             => true,
@@ -109,9 +109,9 @@ class PrecisionAlignmentSniff extends Sniff {
 				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
 					&& \T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] )
 				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar
-				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
+				|| isset( $ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
 				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
-					&& isset( $this->ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] ) )
+					&& isset( $ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] ) )
 			) {
 				continue;
 			}

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -19,24 +19,24 @@
 	/**
 	 * OK: Doc comments are indented with tabs and one space.
 	 *
-	  * @var string  <= Bad.
+	  * @var string  <= Bad, but not reported as token type is whitelisted.
 	 * @access private
 	 */
 
 	/*
 	 * OK: Multi-line comments are indented with tabs and one space.
 	 *
-	   * <= Bad.
+	   * <= Bad, but not reported as token type is whitelisted
 	 */
 
-	 function exampleFunctionD() {} // Bad: [tab][space].
-	  function exampleFunctionE() {} // Bad: [tab][space][space].
-	   function exampleFunctionF() {} // Bad: [tab][space][space][space].
+	 function exampleFunctionD() {} // Bad, but not reported as token type is whitelisted.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is whitelisted.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is whitelisted.
 
 ?>
 
 	<p>
-	  Bad: Some text with precision alignment.
+	  Bad: Some text with precision alignment, but not reported as token type is whitelisted.
 	</p>
 
 <?php

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
@@ -1,0 +1,15 @@
+@codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_COMMENT,T_FUNCTION
+
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 7a, 7b and 7c test files together test (against) the issue.
+ */
+
+  // Bad, but not reported as token type is whitelisted.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is whitelisted.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is whitelisted.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is whitelisted.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7b.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7b.inc
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 7a, 7b and 7c test files together test (against) the issue.
+ *
+ * This file should inherit the property settings from the 7a test case file.
+ */
+
+  // Bad, but not reported as token type is whitelisted.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) whitelisted.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) whitelisted.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) whitelisted.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Testing issue as reported upstream in
+ * https://github.com/squizlabs/PHP_CodeSniffer/issues/2179#issuecomment-437634372.
+ *
+ * This is an issue concerning property handling across multiple files, so the
+ * 7a, 7b and 7c test files together test (against) the issue.
+ *
+ * This file should inherit the property settings from the 7a test case file.
+ */
+
+  // Bad, but not reported as token type is whitelisted.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) whitelisted.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) whitelisted.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) whitelisted.
+
+// @codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_NONE


### PR DESCRIPTION
This issue was discovered through a report upstream in issue squizlabs/PHP_CodeSniffer#2179#issuecomment-437634372.

What it comes down to is that if the `ignoreAlignmentTokens` property would be set, the `merge_custom_array()` call in the `process_token()` would override it with a flipped array with values `false` and for the next file, would override it again, flipping the array again etc etc.

This in effect made the custom property only work for the first file, not for subsequent files.

This has now been fixed.

Includes unit tests to guard against the issue.

Additionally, I've improved the inline comments to clarify what's being tested in test case file 2.