### PR TITLE
PrefixAllGlobals: improve error position precision

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -801,7 +801,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		$data[] = $raw_content;
 
-		$recorded = $this->addMessage( self::ERROR_MSG, $parameters[1]['start'], $is_error, $error_code, $data );
+		$recorded = $this->addMessage( self::ERROR_MSG, $first_non_empty, $is_error, $error_code, $data );
 
 		if ( true === $recorded ) {
 			$this->record_potential_prefix_metric( $stackPtr, $raw_content );

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -409,4 +409,19 @@ apply_filters( 'my_wordpress_plugin_filtername', $var ); // OK.
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes test-this
 do_action( 'Test-THIS-hookname' ); // OK.
 
+// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa
+// Issue #1495 - throw the error on the line with the non-prefixed name.
+$acronym = apply_filters(
+	'content-types-post-types', // Bad.
+	[
+		PostType\Post::NAME => PostType\Post::class,
+	]
+);
+
+define(
+	/* comment */
+	'SOME_GLOBAL', // Bad.
+	[ 1, 2, 3 ]
+);
+
 // @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -68,6 +68,8 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					387 => 1,
 					389 => 1,
 					403 => 1,
+					415 => 1,
+					423 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':


### PR DESCRIPTION
... for hook names and constant names when declared using `define()`.

The sniff would throw the error message on the line which contained the first token regarded as part of the parameter - which might be end of line whitespace on the line before the actual hook name or constant name  in a multi-line function call.

This minor change improves the line number precision for these situations.

Fixed #1495