### PR TITLE
Remove get_the_title() from list of autoescaped functions.

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -231,7 +231,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		'get_the_ID'                => true,
 		'get_the_post_thumbnail'    => true,
 		'get_the_term_list'         => true,
-		'get_the_title'             => true,
 		'next_comments_link'        => true,
 		'next_image_link'           => true,
 		'next_post_link'            => true,

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -285,3 +285,7 @@ echo  // phpcs:ignore WP.Secur1ty.EscapeOutput -- WPCS: XSS ok. (sniff name mang
 echo esc_html( $something ),
 	$something_else,
 	esc_html( $something_more ); // phpcs:ignore WP.Secur1ty.EscapeOutput -- WPCS: XSS ok. (sniff name mangled on purpose).
+
+echo get_the_title(); // Bad.
+echo wp_kses_post( get_the_title() ); // Ok.
+echo esc_html( get_the_title() ); // Ok.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -78,6 +78,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			263 => 1,
 			264 => 1,
 			266 => 1,
+			289 => 1,
 		);
 	}
 


### PR DESCRIPTION
Fixes #1538.