### PR TITLE
Update default minimum_supported_version to WP 4.7

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -82,7 +82,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '4.6';
+	public $minimum_supported_version = '4.7';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -315,14 +315,14 @@ get_comments_popup_template();
 get_currentuserinfo();
 is_comments_popup();
 use function popuplinks as something_else; // Related to issue #1306.
-
-/*
- * Warning.
- */
 /* ============ WP 4.6 ============ */
 post_form_autocomplete_off();
 wp_embed_handler_googlevideo();
 wp_get_sites();
+
+/*
+ * Warning.
+ */
 /* ============ WP 4.7 ============ */
 _sort_nav_menu_items();
 _usort_terms_by_ID();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 
-		$errors = array_fill( 8, 310, 1 );
+		$errors = array_fill( 8, 314, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
@@ -59,7 +59,8 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[290],
 			$errors[295],
 			$errors[303],
-			$errors[310]
+			$errors[310],
+			$errors[318]
 		);
 
 		return $errors;
@@ -72,7 +73,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 323, 17, 1 );
+		$warnings = array_fill( 326, 14, 1 );
 
 		// Unset the lines related to version comments.
 		unset( $warnings[326], $warnings[333], $warnings[335] );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -60,7 +60,7 @@ wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 4.5.
+// All will give an WARNING as they have been deprecated after WP 4.7.
 
 get_category_parents( '', '', '', '', array( 'deprecated') );
 unregister_setting( '', '', '', 'deprecated' );

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -69,7 +69,7 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.6"/>
+	<config name="minimum_supported_wp_version" value="4.7"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 5.0 having come out last week, it should now be 4.7.

I've used @JDGrimes 's deprecated code scanner and done a scan against the `5.0` tag for functions deprecated in WP 5.0 and this came up empty, so we should be good.

Running the tool against `trunk` *does* throw up some new deprecated functions, but I suspect that the documentation of those needs to be adjusted to `5.1`, what with the non-standard way in which `5.0` was eventually committed with `trunk` closed, while it already contained commits.
This has been reported in: https://core.trac.wordpress.org/ticket/45657