### PR TITLE
PrefixAllGlobals: use separate errorcodes for warning vs error

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -794,9 +794,15 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 			$data       = array( 'Global constants defined' );
 			$error_code = 'NonPrefixedConstantFound';
+			if ( false === $is_error ) {
+				$error_code = 'VariableConstantNameFound';
+			}
 		} else {
 			$data       = array( 'Hook names invoked' );
 			$error_code = 'NonPrefixedHooknameFound';
+			if ( false === $is_error ) {
+				$error_code = 'DynamicHooknameFound';
+			}
 		}
 
 		$data[] = $raw_content;


### PR DESCRIPTION
While cleaning up a plugin, I noticed that the issue count for the `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound` error code was different if I ran phpcs with the `-n` flag (no warnings).

Error codes should be unique. Having the same error code for something which is mandatory (`error`) and recommended (`warning`) is bad practice and does not properly allow for modular disabling of notices.

This PR fixes this.

This is a breaking change as for the warnings, `<exclude>`s for the old errorcode currently in custom rulesets will be invalidated by it.