### PR TITLE
WPCS 2.0.0: Remove work-arounds for PHP < 5.4 and PHPCS < 3.3.1

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -77,11 +77,6 @@ class ArbitraryParenthesesSpacingSniff extends Sniff {
 		$this->ignoreTokens[ \T_LIST ]                 = \T_LIST;
 		$this->ignoreTokens[ \T_DECLARE ]              = \T_DECLARE;
 
-		// The below two tokens have been added to the Tokens::$functionNameTokens array in PHPCS 3.1.0,
-		// so they can be removed once the minimum PHPCS requirement of WPCS has gone up.
-		$this->ignoreTokens[ \T_SELF ]   = \T_SELF;
-		$this->ignoreTokens[ \T_STATIC ] = \T_STATIC;
-
 		// Language constructs where the use of parentheses should be discouraged instead.
 		$this->ignoreTokens[ \T_THROW ]      = \T_THROW;
 		$this->ignoreTokens[ \T_YIELD ]      = \T_YIELD;

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -29,27 +29,7 @@ class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 	private $tab_width = 4;
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		// Tab width setting is only needed for the tabbed file.
-		if ( 'ArrayIndentationUnitTest.1.inc' === $testFile ) {
-			return array( '--tab-width=' . $this->tab_width );
-		}
-
-		return array();
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -32,27 +32,7 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 	private $tab_width = 4;
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		// Tab width setting is only needed for the tabbed file.
-		if ( 'MultipleStatementAlignmentUnitTest.1.inc' === $testFile ) {
-			return array( '--tab-width=' . $this->tab_width );
-		}
-
-		return array();
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.

--- a/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -56,7 +56,7 @@ class EmptyStatementUnitTest extends AbstractSniffUnitTest {
 			case 'EmptyStatementUnitTest.2.inc':
 				return array(
 					1 => 1, // Internal.NoCode warning when short open tags is off, otherwise EmptyStatement warning.
-					2 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					2 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -119,18 +119,6 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getTestFiles( $testFileBase ) {
 
-		// Work around for PHP 5.3/PHPCS 2.x.
-		if ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
-			unset( $this->expected_results['SomeView.inc'] );
-		}
-
-		// Work around for PHPCS < 3.2.0. The disables will be diregarded.
-		if ( ! \defined( '\T_PHPCS_DISABLE' ) && ! \defined( '\T_PHPCS_ENABLE' ) ) {
-			$this->expected_results['blanket-disable.inc']   = 1;
-			$this->expected_results['rule-disable.inc']      = 1;
-			$this->expected_results['wordpress-disable.inc'] = 1;
-		}
-
 		$sep        = \DIRECTORY_SEPARATOR;
 		$test_files = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
@@ -161,24 +149,10 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList( $testFile = '' ) {
-		switch ( $testFile ) {
-			case 'SomeView.inc':
-			case 'some-view.inc':
-				$expected = array();
-				if ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
-					$expected[1] = 1; // Internal.NoCode warning on PHP 5.3 icw short open tags off.
-				}
-
-				return $expected;
-
-			default:
-				return array();
-		}
+	public function getWarningList() {
+		return array();
 	}
 
 }

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -28,27 +28,7 @@ class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 	private $tab_width = 4;
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		// Tab width setting is only needed for the file with the function calls.
-		if ( 'I18nTextDomainFixerUnitTest.4.inc' === $testFile ) {
-			return array( '--tab-width=' . $this->tab_width );
-		}
-
-		return array();
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -10,7 +10,6 @@
 namespace WordPressCS\WordPress\Tests\WP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
-use WordPressCS\WordPress\PHPCSHelper;
 
 /**
  * Unit test class for the I18n sniff.
@@ -23,27 +22,7 @@ use WordPressCS\WordPress\PHPCSHelper;
 class I18nUnitTest extends AbstractSniffUnitTest {
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		// Test overruling the text domain from the command line for one test file.
-		if ( 'I18nUnitTest.3.inc' === $testFile ) {
-			PHPCSHelper::set_config_data( 'text_domain', 'something', true );
-		}
-
-		return array();
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -10,7 +10,6 @@
 namespace WordPressCS\WordPress\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
-use WordPressCS\WordPress\PHPCSHelper;
 
 /**
  * Unit test class for the ControlStructureSpacing sniff.
@@ -21,33 +20,6 @@ use WordPressCS\WordPress\PHPCSHelper;
  * @since   0.13.0     Class name changed: this class is now namespaced.
  */
 class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
-
-	/**
-	 * Get a list of all test files to check.
-	 *
-	 * @param string $testFileBase The base path that the unit tests files will have.
-	 *
-	 * @return string[]
-	 */
-	protected function getTestFiles( $testFileBase ) {
-
-		$testFiles = parent::getTestFiles( $testFileBase );
-
-		/*
-		 * Testing whether the PHPCS annotations are properly handled is only useful on
-		 * PHPCS versions which support the PHPCS annotations.
-		 * Prior to PHPCS 3.2.0 they would be treated the same as ordinary comments
-		 * for the purposes of this sniff.
-		 */
-		if ( version_compare( PHPCSHelper::get_version(), '3.2.0', '<' ) === true ) {
-			$key = array_search( $testFileBase . '2.inc', $testFiles, true );
-			if ( false !== $key ) {
-				unset( $testFiles[ $key ] );
-			}
-		}
-
-		return $testFiles;
-	}
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/DisallowInlineTabsUnitTest.php
@@ -29,22 +29,7 @@ class DisallowInlineTabsUnitTest extends AbstractSniffUnitTest {
 	private $tab_width = 4;
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		return array( '--tab-width=' . $this->tab_width );
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -10,7 +10,6 @@
 namespace WordPressCS\WordPress\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
-use WordPressCS\WordPress\PHPCSHelper;
 
 /**
  * Unit test class for the PrecisionAlignment sniff.
@@ -29,22 +28,7 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 	private $tab_width = 4;
 
 	/**
-	 * Get a list of CLI values to set before the file is tested.
-	 *
-	 * Used by PHPCS 2.x.
-	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
-	 * @return array
-	 */
-	public function getCliValues( $testFile ) {
-		return array( '--tab-width=' . $this->tab_width );
-	}
-
-	/**
 	 * Set CLI values before the file is tested.
-	 *
-	 * Used by PHPCS 3.x.
 	 *
 	 * @param string                  $testFile The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
@@ -54,35 +38,10 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 	public function setCliValues( $testFile, $config ) {
 		$config->tabWidth = $this->tab_width;
 
-		// Setting "--ignore-annotations" is only possible since PHPCS 3.0.
+		// Testing a file with "--ignore-annotations".
 		if ( 'PrecisionAlignmentUnitTest.6.inc' === $testFile ) {
 			$config->annotations = false;
 		}
-	}
-
-	/**
-	 * Get a list of all test files to check.
-	 *
-	 * @param string $testFileBase The base path that the unit tests files will have.
-	 *
-	 * @return string[]
-	 */
-	protected function getTestFiles( $testFileBase ) {
-
-		$testFiles = parent::getTestFiles( $testFileBase );
-
-		/*
-		 * Testing whether the PHPCS annotations are properly respected is only useful on
-		 * PHPCS versions which support the PHPCS annotations.
-		 */
-		if ( version_compare( PHPCSHelper::get_version(), '3.2.0', '<' ) === true ) {
-			$key = array_search( $testFileBase . '5.inc', $testFiles, true );
-			if ( false !== $key ) {
-				unset( $testFiles[ $key ] );
-			}
-		}
-
-		return $testFiles;
 	}
 
 	/**
@@ -116,11 +75,11 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 
 			case 'PrecisionAlignmentUnitTest.4.inc':
 				return array(
-					1 => 1, // Will show a `Internal.NoCodeFound` warning in PHP 5.3 with short open tags off.
-					2 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					3 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					4 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
-					5 => ( \PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) ? 0 : 1,
+					1 => 1,
+					2 => 1,
+					3 => 1,
+					4 => 1,
+					5 => 1,
 				);
 
 			case 'PrecisionAlignmentUnitTest.5.inc':
@@ -128,38 +87,19 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 					9  => 1,
 					14 => 1,
 					19 => 1,
-					24 => 0,
-					29 => 0,
+					24 => 1,
+					29 => 1,
 					34 => 1,
 					39 => 1,
 					44 => 1,
-					54 => 0,
-					56 => 0,
-					58 => 0,
+					54 => 1,
+					56 => 1,
+					58 => 1,
 				);
-
-				/*
-				 * The PHPCS 3.2.x versions contained a bug in the selective disable/enable logic
-				 * compared to the intended behaviour as documented, which prevented the particular
-				 * messages being tested on these lines from being thrown. See upstream issue #1986.
-				 */
-				if ( version_compare( PHPCSHelper::get_version(), '3.3.0', '>=' ) === true ) {
-					$warnings[24] = 1;
-					$warnings[29] = 1;
-					$warnings[54] = 1;
-					$warnings[56] = 1;
-					$warnings[58] = 1;
-				}
 
 				return $warnings;
 
 			case 'PrecisionAlignmentUnitTest.6.inc':
-				/*
-				 * {@internal Always returns 1 warning, as for PHPCS < 3.2.0, the PHPCS annotation
-				 * will be seen as a "normal" comment with precision alignment.
-				 * For PHPCS 3.2.0+, it will be seen as a PHPCS annotation, but annotations are ignored
-				 * for this test file, so the precision alignment will be reported.}}
-				 */
 				return array(
 					4 => 1,
 				);


### PR DESCRIPTION
This just removes small inline code work-arounds for PHP 5.3 / PHPCS < 3.3.1 wherever I could find them.