### PR TITLE
Rulesets: minor simplifications (PHPCS 3.0+)

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -18,10 +18,7 @@
 	-->
 	<!-- Covers rule: Use single and double quotes when appropriate.
 		 If you're not evaluating anything in the string, use single quotes. -->
-	<rule ref="Squiz.Strings.DoubleQuoteUsage"/>
-	<rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-		<severity>0</severity>
-	</rule>
+	<rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 
 	<!-- Rule: Text that goes into attributes should be run through esc_attr().
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/527 -->
@@ -408,7 +405,6 @@
 	</rule>
 
 	<!-- Rule: The eval() construct is very dangerous, and is impossible to secure. ... these must not be used. -->
-	<rule ref="Squiz.PHP.Eval"/>
 	<rule ref="Squiz.PHP.Eval.Discouraged">
 		<type>error</type>
 		<message>eval() is a security risk so not allowed.</message>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -42,13 +42,6 @@
 
 	<!-- And yet more best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1143 -->
-	<rule ref="PEAR.Files.IncludingFile"/>
-	<rule ref="PEAR.Files.IncludingFile.UseInclude">
-		<severity>0</severity>
-	</rule>
-	<rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
-		<severity>0</severity>
-	</rule>
 	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
 		<type>warning</type>
 	</rule>


### PR DESCRIPTION
As of PHPCS 3.0.0, you can include individual error codes, not just complete sniffs.

Where WPCS rulesets included sniffs, but excluded more than 50% of the error codes from that sniff, it makes sense to switch them over to include individual error codes instead.

This also means that where previously, if the `type` and/or `message` of an individual error code was adjusted via the ruleset, the sniff needed to be included first and only after that, the details could be adjusted.
Now, the inclusion can just be done based on error code, providing all error codes in the sniff are adjusted.

To explain it better:
* If a sniff contained five error codes and we adjusted the message for one, there is no real advantage to changing over.
* If a sniff contained three error codes and we excluded one, and adjusted another, there is no real advantage to changing over.
* However, if a sniff contained only one error code and we'd adjust that one anyway, the new way of including just the error code gets rid of some superfluous configuration.
* Similarly, if a sniff contained five error codes, we'd exclude two and adjusted the details for the other three, changing over, again, is to our benefit.