### PR TITLE
Rulesets: Start using the new XML array format (PHPCS 3.3+)

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -39,7 +39,11 @@
 			<property name="exact" value="false"/>
 			<property name="indent" value="4"/>
 			<property name="tabIndent" value="true"/>
-			<property name="ignoreIndentationTokens" type="array" value="T_HEREDOC,T_NOWDOC,T_INLINE_HTML"/>
+			<property name="ignoreIndentationTokens" type="array">
+				<element value="T_HEREDOC"/>
+				<element value="T_NOWDOC"/>
+				<element value="T_INLINE_HTML"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.Arrays.ArrayIndentation"/>

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -96,7 +96,10 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Example usage:
 	 * <rule ref="WordPress.[Subset].[Sniffname]">
 	 *  <properties>
-	 *   <property name="custom_test_class_whitelist" type="array" value="My_Plugin_First_Test_Class,My_Plugin_Second_Test_Class"/>
+	 *   <property name="custom_test_class_whitelist" type="array">
+	 *     <element value="My_Plugin_First_Test_Class"/>
+	 *     <element value="My_Plugin_Second_Test_Class"/>
+	 *   </property>
 	 *  </properties>
 	 * </rule>
 	 *

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -50,8 +50,10 @@ class PrecisionAlignmentSniff extends Sniff {
 	 *
 	 * <rule ref="WordPress.WhiteSpace.PrecisionAlignment">
 	 *    <properties>
-	 *        <property name="ignoreAlignmentTokens" type="array"
-	 *             value="T_COMMENT,T_INLINE_HTML"/>
+	 *        <property name="ignoreAlignmentTokens" type="array">
+	 *            <element value="T_COMMENT"/>
+	 *            <element value="T_INLINE_HTML"/>
+	 *        </property>
 	 *    </properties>
 	 * </rule>
 	 *

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -73,13 +73,18 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="my-textdomain,library-textdomain"/>
+			<property name="text_domain" type="array">
+				<element value="my-textdomain"/>
+				<element value="library-textdomain"/>
+			</property>
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="prefixes" type="array" value="my_prefix"/>
+			<property name="prefixes" type="array">
+				<element value="my_prefix"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
A new format for passing array elements to PHPCS properties was added in PHPCS 3.3.0.
This new array format is far more readable and less error prone than the old format.

This commit implements using this new array format throughout WPCS, wherever relevant, including in property setting examples in the documentation.

Ref:
* squizlabs/PHP_CodeSniffer#1665