### PR TITLE
Build/Rulesets: Add XSD schema tags and validate rulesets against schema (PHPCS 3.2+/3.3.2+)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>The Coding standard for the WordPress Coding Standards itself.</description>
 
 	<file>.</file>

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,8 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./*/ruleset.xml; fi
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./phpcs.xml.dist.sample; fi
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml; fi
+    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample; fi
     # Check the code-style consistency of the xml files.
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress/ruleset.xml <(xmllint --format "./WordPress/ruleset.xml"); fi
     - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-Core/ruleset.xml <(xmllint --format "./WordPress-Core/ruleset.xml"); fi

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Core">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Core" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Docs">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Docs" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>WordPress Coding Standards for Inline Documentation and Comments</description>
 
 	<!--

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Extra">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Extra" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>Best practices beyond core WordPress Coding Standards</description>
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>

--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress" namespace="WordPressCS\WordPress">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>WordPress Coding Standards</description>
 
 	<autoload>./PHPCSAliases.php</autoload>

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Example Project">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
 	<!-- Exclude WP Core folders and files from being checked. -->


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS includes an XSD schema for rulesets which defines what can be used in the XML ruleset file.

In PHPCS 3.3.0 a new array format for properties was introduced and as of PHPCS 3.3.2, the new array format is now also covered by this schema.

This commit:
* Adds the schema tags to the `ruleset.xml` files, the WPCS native `.phpcs.xml.dist` file, as well as to the example ruleset.
* Adds validation against the schema for the `ruleset.xml` files and the example ruleset to the Travis build.

Note:
The schema used in the tags points to the online schema in PHPCS `master` for two reasons:
1. While WPCS now has a minimum requirement of PHPCS 3.3.1, the schema in PHPCS `master` contains the changes which were made in PHPCS 3.3.2, so we can safely validate the rulesets against the schema.
2. While installation via Composer is supported for WPCS, it is **not** the _only_ supported installation method, so pointing to the version of the XSD schema in the `vendor` directory would be presumptuous.

At the same time, using the URL in the Travis script appears to be problematic and as we're doing a composer install there anyway, we may as well use the version in the `vendor` directory for the actual validation.
As the validation is done on a build with PHPCS `master`, there will be no difference anyway.

Fixes #1477