### PR TITLE
PHPUnit: add Composer script to run the tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,16 +97,11 @@ N.B.: _If you used Composer to install the WordPress Coding Standards, you can s
 
 For the unit tests to work, you need to make sure PHPUnit can find your `PHP_CodeSniffer` install.
 
-The easiest way to do this is to add a `phpunit.xml` file to the root of your WPCS installation and set a `PHPCS_DIR` environment variable from within this file. Make sure to adjust the path to reflect your local setup.
+The easiest way to do this is to add a `phpunit.xml` file to the root of your WPCS installation and set a `PHPCS_DIR` environment variable from within this file. Copy the existing `phpunit.xml.dist` file and add the below `<env>` directive within the `<php>` section. Make sure to adjust the path to reflect your local setup.
 ```xml
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-	beStrictAboutTestsThatDoNotTestAnything="false"
-	backupGlobals="true">
 	<php>
 		<env name="PHPCS_DIR" value="/path/to/PHP_CodeSniffer/"/>
 	</php>
-</phpunit>
 ```
 
 ## Running the unit tests
@@ -119,6 +114,9 @@ The easiest way to do this is to add a `phpunit.xml` file to the root of your WP
 * To run the unit tests:
     ```sh
     phpunit --filter WordPress --bootstrap="/path/to/PHP_CodeSniffer/tests/bootstrap.php" /path/to/PHP_CodeSniffer/tests/AllTests.php
+
+    # Or if you've installed WPCS with Composer:
+    composer run-tests
     ```
 
 Expected output:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"squizlabs/php_codesniffer": "^3.3.1"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^9.0"
+		"phpcompatibility/php-compatibility": "^9.0",
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -30,7 +31,8 @@
 		"post-update-cmd": "@install-codestandards",
 		"check-cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
 		"fix-cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-		"install-codestandards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility"
+		"install-codestandards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
+		"run-tests": "@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 	},
 	"support": {
 		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,17 @@
 	backupGlobals="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true">
+
+	<testsuites>
+		<testsuite name="WordPress">
+			<directory suffix="UnitTest.php">./WordPress/Tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<php>
+		<!-- This line prevents issues with PHPCS trying to load sniff files for
+			 standards which we aren't testing.
+			 Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/1146 -->
+		<env name="PHPCS_IGNORE_TESTS" value="Generic,MySource,PEAR,PSR1,PSR2,PSR12,Squiz,Zend,PHPCompatibility"/>
+	</php>
 </phpunit>


### PR DESCRIPTION
A `dev` requirement of `phpunit/phpunit` has been added to the `composer.json` file, as well as a script to run the unit tests.
While PHPUnit is not strictly speaking a dependency of WPCS (but of PHPCS), this just makes life easier on WPCS developers who use the Composer install for development.

If - as a WPCS sniff developer - you've installed WPCS using Composer, you can now run the unit tests, like so:
```bash
composer run-tests
```

A note to this effect has been added to the `CONTRIBUTING.MD` file as well.

Additionally:
* While not strictly necessary, a `testsuite` directive has been added to the `phpunit.xml.dist` file to document where the tests are located and how they are named.
* As `PHPCompatibility` will also be installed when using Composer to install WPCS and PHPCompatibility uses its own test setup, we need to prevent PHPCS from trying to load the test files for PHPCompatibility.
    The `PHPCS_IGNORE_TEST` environment variable in the `phpunit.xml.dist` file does just that.
    For more information about this, see squizlabs/PHP_CodeSniffer#1146