### PR TITLE
PHPCS 3.1+: Start using the new Tokens::$ooScopeTokens array

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1171,26 +1171,14 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		/*
-		 * Is this a method inside of a class or a trait ? If so, it is a test class/trait ?
-		 *
-		 * {@internal Once the minimum supported PHPCS version has gone up to 3.1.0, the
-		 * local array here can be replace with Tokens::$ooScopeTokens.}}
-		 */
-		$oo_tokens  = array(
-			\T_CLASS      => true,
-			\T_TRAIT      => true,
-			\T_ANON_CLASS => true,
-		);
 		$conditions = $this->tokens[ $stackPtr ]['conditions'];
-
 		foreach ( $conditions as $token => $condition ) {
 			if ( $token === $functionToken ) {
 				// Only examine the conditions the function is nested in, not those nested within the function.
 				break;
 			}
 
-			if ( isset( $oo_tokens[ $condition ] ) ) {
+			if ( isset( Tokens::$ooScopeTokens[ $condition ] ) ) {
 				$is_test_class = $this->is_test_class( $token );
 				if ( true === $is_test_class ) {
 					return true;
@@ -1218,9 +1206,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 */
 	protected function is_test_class( $stackPtr ) {
 
-		if ( ! isset( $this->tokens[ $stackPtr ] )
-			|| \in_array( $this->tokens[ $stackPtr ]['type'], array( 'T_CLASS', 'T_ANON_CLASS', 'T_TRAIT' ), true ) === false
-		) {
+		if ( isset( $this->tokens[ $stackPtr ], Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] ) === false ) {
 			return false;
 		}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -181,17 +181,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @return array
 	 */
 	public function register() {
-		$targets = array(
-			\T_NAMESPACE  => \T_NAMESPACE,
-			\T_FUNCTION   => \T_FUNCTION,
-			\T_CLASS      => \T_CLASS,
-			\T_INTERFACE  => \T_INTERFACE,
-			\T_TRAIT      => \T_TRAIT,
-			\T_CONST      => \T_CONST,
-			\T_VARIABLE   => \T_VARIABLE,
-			\T_DOLLAR     => \T_DOLLAR, // Variable variables.
-			\T_ANON_CLASS => \T_ANON_CLASS, // Only used for skipping over test classes.
+		$targets  = array(
+			\T_NAMESPACE => \T_NAMESPACE,
+			\T_FUNCTION  => \T_FUNCTION,
+			\T_CONST     => \T_CONST,
+			\T_VARIABLE  => \T_VARIABLE,
+			\T_DOLLAR    => \T_DOLLAR, // Variable variables.
 		);
+		$targets += Tokens::$ooScopeTokens; // T_ANON_CLASS is only used for skipping over test classes.
 
 		// Add function call target for hook names and constants defined using define().
 		$parent = parent::register();
@@ -259,9 +256,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Ignore test classes.
-		if ( ( \T_CLASS === $this->tokens[ $stackPtr ]['code']
-			|| \T_TRAIT === $this->tokens[ $stackPtr ]['code']
-			|| \T_ANON_CLASS === $this->tokens[ $stackPtr ]['code'] )
+		if ( isset( Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] )
 			&& true === $this->is_test_class( $stackPtr )
 		) {
 			if ( $this->tokens[ $stackPtr ]['scope_condition'] === $stackPtr && isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
@@ -345,7 +340,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			switch ( $this->tokens[ $stackPtr ]['type'] ) {
 				case 'T_FUNCTION':
 					// Methods in a class do not need to be prefixed.
-					if ( $this->phpcsFile->hasCondition( $stackPtr, array( \T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_TRAIT ) ) === true ) {
+					if ( $this->phpcsFile->hasCondition( $stackPtr, Tokens::$ooScopeTokens ) === true ) {
 						return;
 					}
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -76,19 +76,6 @@ class CapitalPDangitSniff extends Sniff {
 	);
 
 	/**
-	 * Class-like structure tokens to listen for.
-	 *
-	 * Using proper spelling in class, interface and trait names does not conflict with the naming conventions.
-	 *
-	 * @var array
-	 */
-	private $class_tokens = array(
-		\T_CLASS     => \T_CLASS,
-		\T_INTERFACE => \T_INTERFACE,
-		\T_TRAIT     => \T_TRAIT,
-	);
-
-	/**
 	 * Combined text string and comment tokens array.
 	 *
 	 * This property is set in the register() method and used for lookups.
@@ -108,7 +95,7 @@ class CapitalPDangitSniff extends Sniff {
 		// Union the arrays - keeps the array keys.
 		$this->text_and_comment_tokens = ( $this->text_string_tokens + $this->comment_text_tokens );
 
-		$targets = ( $this->text_and_comment_tokens + $this->class_tokens );
+		$targets = ( $this->text_and_comment_tokens + Tokens::$ooScopeTokens );
 
 		// Also sniff for array tokens to make skipping anything within those more efficient.
 		$targets[ \T_ARRAY ]            = \T_ARRAY;
@@ -149,7 +136,7 @@ class CapitalPDangitSniff extends Sniff {
 		 * Deal with misspellings in class/interface/trait names.
 		 * These are not auto-fixable, but need the attention of a developer.
 		 */
-		if ( isset( $this->class_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+		if ( isset( Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
 			$classname = $this->phpcsFile->getDeclarationName( $stackPtr );
 			if ( empty( $classname ) ) {
 				return;

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -49,21 +49,13 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	 * Scoped object and function structures to skip over as
 	 * variables will have a different scope within those.
 	 *
-	 * {@internal Once the minimum PHPCS version goes up to PHPCS 3.1.0,
-	 * this array can be partially created in the register() method
-	 * using the upstream `Tokens::$ooScopeTokens` array.}}
-	 *
 	 * @since 1.1.0
 	 *
 	 * @var array
 	 */
 	private $skip_over = array(
-		\T_FUNCTION   => true,
-		\T_CLOSURE    => true,
-		\T_CLASS      => true,
-		\T_ANON_CLASS => true,
-		\T_INTERFACE  => true,
-		\T_TRAIT      => true,
+		\T_FUNCTION => true,
+		\T_CLOSURE  => true,
 	);
 
 	/**
@@ -75,15 +67,18 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return array(
+		// Add the OO scope tokens to the $skip_over property.
+		$this->skip_over += Tokens::$ooScopeTokens;
+
+		$targets = array(
 			\T_GLOBAL,
 			\T_VARIABLE,
-
-			// Only used to skip over test classes.
-			\T_CLASS,
-			\T_TRAIT,
-			\T_ANON_CLASS,
 		);
+
+		// Only used to skip over test classes.
+		$targets += Tokens::$ooScopeTokens;
+
+		return $targets;
 	}
 
 	/**
@@ -102,7 +97,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		$token = $this->tokens[ $stackPtr ];
 
 		// Ignore variable overrides in test classes.
-		if ( \T_CLASS === $token['code'] || \T_TRAIT === $token['code'] || \T_ANON_CLASS === $token['code'] ) {
+		if ( isset( Tokens::$ooScopeTokens[ $token['code'] ] ) ) {
 
 			if ( true === $this->is_test_class( $stackPtr )
 				&& $token['scope_condition'] === $stackPtr

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -404,17 +404,14 @@ class ControlStructureSpacingSniff extends Sniff {
 			$firstContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
 
 			// We ignore spacing for some structures that tend to have their own rules.
-			$ignore = array(
+			$ignore  = array(
 				\T_FUNCTION             => true,
 				\T_CLOSURE              => true,
-				\T_CLASS                => true,
-				\T_ANON_CLASS           => true,
-				\T_INTERFACE            => true,
-				\T_TRAIT                => true,
 				\T_DOC_COMMENT_OPEN_TAG => true,
 				\T_CLOSE_TAG            => true,
 				\T_COMMENT              => true,
 			);
+			$ignore += Tokens::$ooScopeTokens;
 
 			if ( ! isset( $ignore[ $this->tokens[ $firstContent ]['code'] ] )
 				&& $this->tokens[ $firstContent ]['line'] > ( $this->tokens[ $scopeOpener ]['line'] + 1 )


### PR DESCRIPTION
This new token array was introduced in PHPCS 3.1.0 via squizlabs/PHP_CodeSniffer#1415 and contains `T_CLASS`, `T_ANON_CLASS`, `T_INTERFACE` and `T_TRAIT`.