### PR TITLE
PHPCS 3.2.3+: Remove the Sniff::$phpcsCommentTokens property

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -782,32 +782,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * The token "type" values for the PHPCS 3.2+ whitelist comments.
-	 *
-	 * PHPCS cross-version compatibility layer to allow sniffs to
-	 * allow for the new PHPCS annotation comments without breaking in older
-	 * PHPCS versions.
-	 *
-	 * @internal Can be replaced with using the PHPCS native Token::$phpcsCommentTokens
-	 *           array once the minimum WPCS requirement for PHPCS has gone up
-	 *           to PHPCS 3.2.3.
-	 *           Note: The PHPCS native property uses the constants/ token "code",
-	 *           so code referring to this property will need to be adjusted when
-	 *           the property is removed.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var array
-	 */
-	protected $phpcsCommentTokens = array(
-		'T_PHPCS_ENABLE'      => true,
-		'T_PHPCS_DISABLE'     => true,
-		'T_PHPCS_SET'         => true,
-		'T_PHPCS_IGNORE'      => true,
-		'T_PHPCS_IGNORE_FILE' => true,
-	);
-
-	/**
 	 * The current file being sniffed.
 	 *
 	 * @since 0.4.0
@@ -1122,8 +1096,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 			if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 					&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
-					|| ( isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] )
-					&& 'T_PHPCS_SET' !== $this->tokens[ $lastPtr ]['type'] ) )
+					|| ( isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] )
+					&& \T_PHPCS_SET !== $this->tokens[ $lastPtr ]['code'] ) )
 				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
 				&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 			) {
@@ -1138,8 +1112,8 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 				&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
-				|| ( isset( $this->phpcsCommentTokens[ $this->tokens[ $lastPtr ]['type'] ] )
-				&& 'T_PHPCS_SET' !== $this->tokens[ $lastPtr ]['type'] ) )
+				|| ( isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] )
+				&& \T_PHPCS_SET !== $this->tokens[ $lastPtr ]['code'] ) )
 			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']
 			&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 		) {

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -384,7 +384,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 
 			// Ignore comments after array items if the next real content starts on a new line.
 			if ( \T_COMMENT === $this->tokens[ $first_content ]['code']
-				|| isset( $this->phpcsCommentTokens[ $this->tokens[ $first_content ]['type'] ] )
+				|| isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $first_content ]['code'] ] )
 			) {
 				$next = $this->phpcsFile->findNext(
 					array( \T_WHITESPACE, \T_DOC_COMMENT_WHITESPACE ),

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -169,7 +169,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 							$spaces += $this->tokens[ $i ]['length'];
 						}
 					} elseif ( \T_COMMENT === $this->tokens[ $i ]['code']
-						|| isset( $this->phpcsCommentTokens[ $this->tokens[ $i ]['type'] ] )
+						|| isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $i ]['code'] ] )
 					) {
 						break;
 					}
@@ -202,7 +202,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 							$this->phpcsFile->fixer->replaceToken( $i, '' );
 
 						} elseif ( \T_COMMENT === $this->tokens[ $i ]['code']
-							|| isset( $this->phpcsCommentTokens[ $this->tokens[ $i ]['type'] ] )
+							|| isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $i ]['code'] ] )
 						) {
 							// We need to move the comma to before the comment.
 							$this->phpcsFile->fixer->addContent( $last_content, ',' );
@@ -248,7 +248,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 					|| ( false === $single_line
 						&& $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $maybe_comma ]['line']
 						&& ( \T_COMMENT === $this->tokens[ $next_non_whitespace ]['code']
-							|| isset( $this->phpcsCommentTokens[ $this->tokens[ $next_non_whitespace ]['type'] ] ) ) )
+							|| isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $next_non_whitespace ]['code'] ] ) ) )
 				) {
 					continue;
 				}

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -474,7 +474,7 @@ class ControlStructureSpacingSniff extends Sniff {
 								 * conflict.
 								 */
 								if ( \T_COMMENT !== $this->tokens[ $lastContent ]['code']
-									&& ! isset( $this->phpcsCommentTokens[ $this->tokens[ $lastContent ]['type'] ] ) ) {
+									&& ! isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastContent ]['code'] ] ) ) {
 									$this->phpcsFile->fixer->addNewlineBefore( $j );
 								}
 
@@ -500,7 +500,7 @@ class ControlStructureSpacingSniff extends Sniff {
 		}
 
 		if ( \T_COMMENT === $this->tokens[ $trailingContent ]['code']
-			|| isset( $this->phpcsCommentTokens[ $this->tokens[ $trailingContent ]['type'] ] )
+			|| isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $trailingContent ]['code'] ] )
 		) {
 			// Special exception for code where the comment about
 			// an ELSE or ELSEIF is written between the control structures.
@@ -561,7 +561,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
 					if ( \T_COMMENT !== $this->tokens[ $scopeCloser ]['code']
-						&& isset( $this->phpcsCommentTokens[ $this->tokens[ $scopeCloser ]['type'] ] ) === false
+						&& isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $scopeCloser ]['code'] ] ) === false
 					) {
 						$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );
 					}

--- a/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WhiteSpace;
 
 use WordPressCS\WordPress\Sniff;
 use WordPressCS\WordPress\PHPCSHelper;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Warn on line indentation ending with spaces for precision alignment.
@@ -96,18 +97,18 @@ class PrecisionAlignmentSniff extends Sniff {
 		$ignoreAlignmentTokens = $this->merge_custom_array( $this->ignoreAlignmentTokens );
 
 		$check_tokens  = array(
-			'T_WHITESPACE'             => true,
-			'T_INLINE_HTML'            => true,
-			'T_DOC_COMMENT_WHITESPACE' => true,
-			'T_COMMENT'                => true,
+			\T_WHITESPACE             => true,
+			\T_INLINE_HTML            => true,
+			\T_DOC_COMMENT_WHITESPACE => true,
+			\T_COMMENT                => true,
 		);
-		$check_tokens += $this->phpcsCommentTokens;
+		$check_tokens += Tokens::$phpcsCommentTokens;
 
 		for ( $i = 0; $i < $this->phpcsFile->numTokens; $i++ ) {
 
 			if ( 1 !== $this->tokens[ $i ]['column'] ) {
 				continue;
-			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['type'] ] ) === false
+			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) === false
 				|| ( isset( $this->tokens[ ( $i + 1 ) ] )
 					&& \T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code'] )
 				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar


### PR DESCRIPTION
The (protected) `Sniff::$phpcsCommentTokens` property was a work-around for the `Tokens::$phpcsCommentTokens` array not being available prior to PHPCS 3.2.3.

This work-around is no longer needed now the minimum PHPCS version is 3.3.1.

Note:
This is a BC-break for external standards extending the WordPressCS `Sniff` class which may be using this property. They should adjust their code to use the PHPCS native `Tokens::$phpcsCommentTokens` array instead.