### PR TITLE
PHPCS 3.2+: Update unit test case annotations

### DIFF
--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc
@@ -103,12 +103,12 @@ $fields = array(
 $bad = array('key' => 'value'); // Bad, spacing around parenthesis.
 $bad = array(     'key' => 'value'     ); // Bad, spacing around parenthesis.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
 
 $bad = array( 'key' => 'value' ); // Bad.
 $bad = array( 'key1' => 'value1', 'key2' => 'value2' ); // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
 
 $foo = array(
 	'meta_key'   => 'foo', // phpcs:ignore Standard.Category.SniffName.ErrorCode

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.1.inc.fixed
@@ -153,7 +153,7 @@ $fields = array(
 $bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
 $bad = array( 'key' => 'value' ); // Bad, spacing around parenthesis.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
 
 $bad = array(
 'key' => 'value'
@@ -163,7 +163,7 @@ $bad = array(
 'key2' => 'value2'
 ); // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
 
 $foo = array(
 	'meta_key'   => 'foo', // phpcs:ignore Standard.Category.SniffName.ErrorCode

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
@@ -86,12 +86,12 @@ $fields = [
 $bad = ['key' => 'value']; // Bad, spacing around parenthesis.
 $bad = [     'key' => 'value'     ]; // Bad, spacing around parenthesis.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
 
 $bad = [ 'key' => 'value' ]; // Bad.
 $bad = [ 'key1' => 'value1', 'key2' => 'value2' ]; // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
 
 $foo = [
 	'meta_key'   => 'foo', // phpcs:ignore Standard.Category.SniffName.ErrorCode

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
@@ -137,7 +137,7 @@ $fields = [
 $bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
 $bad = [ 'key' => 'value' ]; // Bad, spacing around parenthesis.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays false
 
 $bad = [
 'key' => 'value'
@@ -147,7 +147,7 @@ $bad = [
 'key2' => 'value2'
 ]; // Bad.
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
+// phpcs:set WordPress.Arrays.ArrayDeclarationSpacing allow_single_item_single_line_associative_arrays true
 
 $foo = [
 	'meta_key'   => 'foo', // phpcs:ignore Standard.Category.SniffName.ErrorCode

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent false
+// phpcs:set WordPress.Arrays.ArrayIndentation tabIndent false
 $ok = array(
     'value',
     123,
@@ -429,4 +429,4 @@ $my_array = [
     'something_else',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true
+// phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent false
+// phpcs:set WordPress.Arrays.ArrayIndentation tabIndent false
 $ok = array(
     'value',
     123,
@@ -429,4 +429,4 @@ $my_array = [
     'something_else',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.ArrayIndentation tabIndent true
+// phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
@@ -70,7 +70,7 @@ $array = array(
 		=> 'h',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
 $array = array(
 	'a'        => 'b',
 );
@@ -95,7 +95,7 @@ $array = array(
 	'g'
 		      => 'h',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
 
 
 /*
@@ -107,17 +107,17 @@ $array = array(
 	'ccc'
 		=> 'd',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = array(
 	'a'
 		=> 'b', // Bad.
 	'ccc'
 		=> 'd', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = array(
 	'a'     => 'b',
@@ -147,14 +147,14 @@ $array = array(
 	'g'
 		      => 'h', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
  * Test with maxColumn value set.
  */
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 $array = array(
 	'a'   => 'b',
 	'ccc' => 'd',
@@ -177,10 +177,10 @@ $array = array(
 	'ee'           => 'f', // Bad.
 	'gggggggggg'   => 'h', // Bad - too much space before.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 // Test combined maxColumn value set + exact false.
 $array = array(
 	'a' => 'b',
@@ -220,12 +220,12 @@ $array = array(
 	'ee'       => 'f', // Bad.
 	'gggggggggg' => 'h',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = array(
 	'a'    => 'b',
@@ -267,9 +267,9 @@ $array = array(
 	'kkkkkkkkkkkk'
 				 => 'l', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -330,7 +330,7 @@ $deprecated_functions = array(
 	),
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
 
 // OK - alignments to the expected column.
 $deprecated_functions = array(
@@ -381,24 +381,24 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
 
 // OK - alignments to the expected column.
 $deprecated_functions = array(
@@ -462,7 +462,7 @@ $deprecated_functions = array(
 					string', // Bad - no space.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
 // Test with value 50 and test validation for incorrectly passed % sign.
 
 $deprecated_functions = array(
@@ -523,7 +523,7 @@ $deprecated_functions = array(
 					string', // Bad - no space.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
 
 $deprecated_functions = array(
 	'single1' => 'something', // Bad.
@@ -571,4 +571,4 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
@@ -70,7 +70,7 @@ $array = array(
 		=> 'h',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
 $array = array(
 	'a'        => 'b',
 );
@@ -95,7 +95,7 @@ $array = array(
 	'g'
 		      => 'h',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
 
 
 /*
@@ -107,15 +107,15 @@ $array = array(
 	'ccc'
 		=> 'd',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = array(
 	'a'   => 'b', // Bad.
 	'ccc' => 'd', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = array(
 	'a'     => 'b',
@@ -141,14 +141,14 @@ $array = array(
 	'ee'    => 'f',
 	'g'     => 'h', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
  * Test with maxColumn value set.
  */
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 $array = array(
 	'a'   => 'b',
 	'ccc' => 'd',
@@ -171,10 +171,10 @@ $array = array(
 	'ee'  => 'f', // Bad.
 	'gggggggggg' => 'h', // Bad - too much space before.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 // Test combined maxColumn value set + exact false.
 $array = array(
 	'a' => 'b',
@@ -214,12 +214,12 @@ $array = array(
 	'ee'  => 'f', // Bad.
 	'gggggggggg' => 'h',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = array(
 	'a'    => 'b',
@@ -253,9 +253,9 @@ $array = array(
 	'i'   => 'j', // Bad.
 	'kkkkkkkkkkkk' => 'l', // Bad.
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -316,7 +316,7 @@ $deprecated_functions = array(
 	),
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
 
 // OK - alignments to the expected column.
 $deprecated_functions = array(
@@ -367,24 +367,24 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
 // Test invalid property value error.
 $array = array(
 	'a' => 'b',
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
 
 // OK - alignments to the expected column.
 $deprecated_functions = array(
@@ -448,7 +448,7 @@ $deprecated_functions = array(
 					string', // Bad - no space.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
 // Test with value 50 and test validation for incorrectly passed % sign.
 
 $deprecated_functions = array(
@@ -509,7 +509,7 @@ $deprecated_functions = array(
 					string', // Bad - no space.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
 
 $deprecated_functions = array(
 	'single1'                     => 'something', // Bad.
@@ -557,4 +557,4 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
@@ -70,7 +70,7 @@ $array = [
         => 'h',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
 $array = [
     'a'        => 'b',
 ];
@@ -95,7 +95,7 @@ $array = [
     'g'
               => 'h',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
 
 
 /*
@@ -107,17 +107,17 @@ $array = [
     'ccc'
         => 'd',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = [
     'a'
         => 'b', // Bad.
     'ccc'
         => 'd', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = [
     'a'     => 'b',
@@ -147,14 +147,14 @@ $array = [
     'g'
               => 'h', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
  * Test with maxColumn value set.
  */
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 $array = [
     'a'   => 'b',
     'ccc' => 'd',
@@ -177,10 +177,10 @@ $array = [
     'ee'           => 'f', // Bad.
     'gggggggggg'   => 'h', // Bad - too much space before.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 // Test combined maxColumn value set + exact false.
 $array = [
     'a' => 'b',
@@ -220,12 +220,12 @@ $array = [
     'ee'       => 'f', // Bad.
     'gggggggggg' => 'h',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = [
     'a'    => 'b',
@@ -267,9 +267,9 @@ $array = [
     'kkkkkkkkkkkk'
                  => 'l', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -330,7 +330,7 @@ $deprecated_functions = [
     ),
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
 
 // OK - alignments to the expected column.
 $deprecated_functions = [
@@ -381,24 +381,24 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
 
 // OK - alignments to the expected column.
 $deprecated_functions = [
@@ -462,7 +462,7 @@ $deprecated_functions = [
                     string', // Bad - no space.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
 // Test with value 50 and test validation for incorrectly passed % sign.
 
 $deprecated_functions = [
@@ -523,7 +523,7 @@ $deprecated_functions = [
                     string', // Bad - no space.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
 
 $deprecated_functions = [
     'single1' => 'something', // Bad.
@@ -571,4 +571,4 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
@@ -70,7 +70,7 @@ $array = [
         => 'h',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
 $array = [
     'a'        => 'b',
 ];
@@ -95,7 +95,7 @@ $array = [
     'g'
               => 'h',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
 
 
 /*
@@ -107,15 +107,15 @@ $array = [
     'ccc'
         => 'd',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 $array = [
     'a'   => 'b', // Bad.
     'ccc' => 'd', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined ignore new lines false + exact false.
 $array = [
     'a'     => 'b',
@@ -141,14 +141,14 @@ $array = [
     'ee'    => 'f',
     'g'     => 'h', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
  * Test with maxColumn value set.
  */
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 $array = [
     'a'   => 'b',
     'ccc' => 'd',
@@ -171,10 +171,10 @@ $array = [
     'ee'  => 'f', // Bad.
     'gggggggggg' => 'h', // Bad - too much space before.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
 // Test combined maxColumn value set + exact false.
 $array = [
     'a' => 'b',
@@ -214,12 +214,12 @@ $array = [
     'ee'  => 'f', // Bad.
     'gggggggggg' => 'h',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact false
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 12
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact false
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 12
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines false
 // Test combined maxColumn value set + exact false + ignore new lines false.
 $array = [
     'a'    => 'b',
@@ -253,9 +253,9 @@ $array = [
     'i'   => 'j', // Bad.
     'kkkkkkkkkkkk' => 'l', // Bad.
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment exact true
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment exact true
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment maxColumn 1000
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment ignoreNewlines true
 
 
 /*
@@ -316,7 +316,7 @@ $deprecated_functions = [
     ),
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems never
 
 // OK - alignments to the expected column.
 $deprecated_functions = [
@@ -367,24 +367,24 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems sometimes
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems =103
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !50
 // Test invalid property value error.
 $array = [
     'a' => 'b',
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <25
 
 // OK - alignments to the expected column.
 $deprecated_functions = [
@@ -448,7 +448,7 @@ $deprecated_functions = [
                     string', // Bad - no space.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems <=50%
 // Test with value 50 and test validation for incorrectly passed % sign.
 
 $deprecated_functions = [
@@ -509,7 +509,7 @@ $deprecated_functions = [
                     string', // Bad - no space.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems !=100
 
 $deprecated_functions = [
     'single1'                     => 'something', // Bad.
@@ -557,4 +557,4 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
-// @codingStandardsChangeSetting WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always
+// phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -119,9 +119,9 @@ $b = function () {
 /*
  * Test using custom properties, setting & unsetting (resetting).
  */
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheGetFunctions my_cacheget
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheSetFunctions my_cacheset,my_other_cacheset
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions my_cachedel
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[] my_cacheget
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset,my_other_cacheset
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[] my_cachedel
 function cache_customA() {
 	global $wpdb;
 
@@ -149,8 +149,8 @@ function cache_customC() {
 	my_cachedel( 'key', 'group' );
 }
 
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheSetFunctions my_cacheset
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions false
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[]
 
 function cache_customD() {
 	global $wpdb;
@@ -179,8 +179,8 @@ function cache_customF() {
 	my_cachedel( 'key', 'group' );
 }
 
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheGetFunctions false
-// @codingStandardsChangeSetting WordPress.DB.DirectDatabaseQuery customCacheSetFunctions false
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[]
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[]
 
 function cache_customG() {
 	global $wpdb;

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
@@ -45,21 +45,21 @@ $db9 = new \My\DBlayer;
  * Test exclude property.
  */
 // Exclude one group:
-// @codingStandardsChangeSetting WordPress.DB.RestrictedClasses exclude test
+// phpcs:set WordPress.DB.RestrictedClasses exclude[] test
 $db9 = new \My\DBlayer; // Ok - within excluded group.
 
 echo mysqli::$affected_rows; // Error.
 class YourMysqliA extends \mysqli {} // Error.
 
 // Exclude all groups:
-// @codingStandardsChangeSetting WordPress.DB.RestrictedClasses exclude test,mysql
+// phpcs:set WordPress.DB.RestrictedClasses exclude[] test,mysql
 $db9 = new \My\DBlayer; // Ok - within excluded group.
 
 echo mysqli::$affected_rows; // Ok - within excluded group.
 class YourMysqliB extends \mysqli {} // Ok - within excluded group.
 
 // Reset group exclusions.
-// @codingStandardsChangeSetting WordPress.DB.RestrictedClasses exclude false
+// phpcs:set WordPress.DB.RestrictedClasses exclude[]
 $db9 = new \My\DBlayer; // Error.
 
 echo mysqli::$affected_rows; // Error.

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName strict_class_file_names false
 
 <?php
 
 class Non_Strict_Class {}
 
-// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+// phpcs:set WordPress.Files.FileName strict_class_file_names true

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName strict_class_file_names false
 
 <?php
 
 class Non_Strict_Class {}
 
-// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+// phpcs:set WordPress.Files.FileName strict_class_file_names true

--- a/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names false
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName strict_class_file_names false
 
 <?php
 
 class My_Class {}
 
-// @codingStandardsChangeSetting WordPress.Files.FileName strict_class_file_names true
+// phpcs:set WordPress.Files.FileName strict_class_file_names true

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist My_TestClass
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] My_TestClass
 <?php
 
 class TestSample extends My_TestClass {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends \TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends \TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 namespace Some\Other;
 
 class TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 class TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 namespace Some\OtherName;
 
 class TestCase extends TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
@@ -1,7 +1,8 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 class TestCase extends TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
@@ -1,5 +1,6 @@
-@codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist Some\Name\TestSample
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
 class TestCase extends \Some\Name\TestSample {}
-/* @codingStandardsChangeSetting WordPress.Files.FileName custom_test_class_whitelist false */
+/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/FrontPage.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/FrontPage.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/application_flash.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/application_flash.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/archive-post_type.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/archive-post_type.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/author-nice_name.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/author-nice_name.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-another_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-another_slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/category-slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/content-another_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/content-another_slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/content-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/content-slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/embed-post_type-post_format.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/embed-post_type-post_format.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/embed-post_type.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/embed-post_type.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/front-page.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/front-page.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/front_page.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/front_page.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/page-slug_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/page-slug_slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post-type.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post-type.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post_type-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post_type-slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post_type.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/single-post_type.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-another_slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-another_slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-slug.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/tag-slug.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-my_taxonomy-term.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-my_taxonomy-term.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-my_taxonomy.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-my_taxonomy.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-post_format-post-format-link.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-post_format-post-format-link.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-post_format.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/taxonomy-post_format.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/text.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/text.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/text_plain.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/ThemeExceptions/text_plain.inc
@@ -1,3 +1,4 @@
-@codingStandardsChangeSetting WordPress.Files.FileName is_theme true
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set WordPress.Files.FileName is_theme true
 <?php
-/* @codingStandardsChangeSetting WordPress.Files.FileName is_theme false */
+/* phpcs:set WordPress.Files.FileName is_theme false */

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -3,14 +3,14 @@
 /*
  * Bad: invalid prefix passed
  */
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wp
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wp
 function wp_do_something() {}
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes ^%&
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ^%&
 function ^%&_do_something() {}
 
 // Now let's set the real prefixes we want to test for.
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
 
 /*
  * Bad - not prefixed.
@@ -181,7 +181,7 @@ class Example extends WP_UnitTestCase {
 	function do_something() {}
 }
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist My_TestClass
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist[] My_TestClass
 class Test_Class_D extends My_TestClass {
 
 	const SOME_CONSTANT = 'value';
@@ -190,7 +190,7 @@ class Test_Class_D extends My_TestClass {
 
 	function do_something() {}
 }
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist false
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist[]
 
 
 /*
@@ -379,7 +379,7 @@ define( 'FORCE_SSL_ADMIN', true );
 const SCRIPT_DEBUG = $develop_src;
 
 // Allow for hook name prefixes with less conventional separators.
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes test-this,myplugin\
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] test-this,myplugin\
 do_action( 'test-this-hookname' ); // OK.
 apply_filters( 'myplugin\filtername', $var ); // OK.
 
@@ -398,18 +398,18 @@ class Some_Test_Class extends NonTestClass { // Bad.
 	}
 }
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress,somethingelse
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wordpress,somethingelse
 // The above line adds an issue to line 1 about a blacklisted prefix.
 function wordpress_do_something() {} // Bad.
 function somethingelse_do_something() {} // OK.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes my_wordpress_plugin
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] my_wordpress_plugin
 apply_filters( 'my_wordpress_plugin_filtername', $var ); // OK.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes test-this
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] test-this
 do_action( 'Test-THIS-hookname' ); // OK.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
 // Issue #1495 - throw the error on the line with the non-prefixed name.
 $acronym = apply_filters(
 	'content-types-post-types', // Bad.
@@ -424,4 +424,4 @@ define(
 	[ 1, 2, 3 ]
 );
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.2.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.2.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
 
 /*
  * OK - not in the global namespace.
@@ -17,4 +17,4 @@ trait T_Example {}
 // Issue #1056.
 define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.3.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.3.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
 
 namespace Acronym\Tests;
 
@@ -21,4 +21,4 @@ $acronym_test = new class extends \PHPUnit_Framework_TestCase {
 	}
 };
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.4.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.4.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes acronym,tgmpa,test_this,test\that
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa,test_this,test\that
 
 namespace TGMPA;
 
@@ -21,10 +21,10 @@ use namespace\DEF; // Not our target.
 namespace\cname::method(); // Not our target.
 $acronym_result = namespace \ blah \ mine();  // Not our target.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wordpress
 namespace wordpress\myplugin;
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes wordpress\myplugin
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wordpress\myplugin
 namespace wordpress\myplugin;
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.PrefixAllGlobals prefixes false
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.2.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.2.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters -
+// phpcs:set WordPress.NamingConventions.ValidHookName additionalWordDelimiters -
 
 // These should now be ok.
 do_action( "admin_head-$hook_suffix" );
@@ -14,4 +14,4 @@ do_action( 'admin_head.media.upload_popup' ); // Warning - use underscore.
 apply_filters( "bulk_actions {$this->screen->id}", $this->_actions ); // Warning - use underscore.
 apply_filters( "current_theme/supports-{$feature}", true, $args, $_wp_theme_features[$feature] ); // Warning - use underscore.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters _
+// phpcs:set WordPress.NamingConventions.ValidHookName additionalWordDelimiters _

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.3.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.3.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters -/.
+// phpcs:set WordPress.NamingConventions.ValidHookName additionalWordDelimiters -/.
 
 // These should now be ok.
 do_action( "admin_head-$hook_suffix" );
@@ -14,4 +14,4 @@ do_action( 'admin_head&media+upload_popup' ); // Warning - use underscore.
 apply_filters( "bulk_actions {$this->screen->id}", $this->_actions ); // Warning - use underscore.
 apply_filters( "current_theme#supports-{$feature}", true, $args, $_wp_theme_features[$feature] ); // Warning - use underscore.
 
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidHookName additionalWordDelimiters _
+// phpcs:set WordPress.NamingConventions.ValidHookName additionalWordDelimiters _

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -129,11 +129,11 @@ echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.
 /*
  * Unit test whitelisting.
  */
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist varName,DOMProperty
+// phpcs:set WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist[] varName,DOMProperty
 echo MyClass::$varName; // Ok, whitelisted.
 echo $this->DOMProperty; // Ok, whitelisted.
 echo $object->varName;  // Ok, whitelisted.
-// @codingStandardsChangeSetting WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist false
+// phpcs:set WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist[]
 
 echo $object->varName;  // Bad, no longer whitelisted.
 

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.inc
@@ -19,16 +19,16 @@ error_reporting(); // Error.
  * Test exclude property.
  */
 // Exclude one group:
-// @codingStandardsChangeSetting WordPress.PHP.DevelopmentFunctions exclude error_log
+// phpcs:set WordPress.PHP.DevelopmentFunctions exclude[] error_log
 trigger_error(); // Ok - within excluded group.
 phpinfo(); // Error.
 
 // Exclude all groups:
-// @codingStandardsChangeSetting WordPress.PHP.DevelopmentFunctions exclude error_log,prevent_path_disclosure
+// phpcs:set WordPress.PHP.DevelopmentFunctions exclude[] error_log,prevent_path_disclosure
 trigger_error(); // Ok - within excluded group.
 phpinfo(); // Ok - within excluded group.
 
 // Reset group exclusions.
-// @codingStandardsChangeSetting WordPress.PHP.DevelopmentFunctions exclude false
+// phpcs:set WordPress.PHP.DevelopmentFunctions exclude[]
 trigger_error(); // Error.
 phpinfo(); // Error.

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -39,11 +39,11 @@ if ( @ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0 ) ) { // Bad.
 }
 @ftp_close($conn_id); // Bad.
 
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist fgetcsv,hex2bin
+// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[] fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
 echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
+// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[]
 
 $decoded = @hex2bin( $data ); // Bad.
 
@@ -73,10 +73,10 @@ $files1 = @ & scandir($dir); // Bad.
 /*
  * Custom whitelist will be respected even when `use_default_whitelist` is set to false.
  */
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist fgetcsv,hex2bin
+// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[] fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
 echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
+// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[]
 
 // phpcs:set WordPress.PHP.NoSilencedErrors use_default_whitelist true

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -52,7 +52,7 @@ $unserialized = @unserialize( $str );
 /*
  * ... and test the same principle again, but now without using the whitelist.
  */
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors use_default_whitelist false
+// phpcs:set WordPress.PHP.NoSilencedErrors use_default_whitelist false
 
 // File extension.
 if ( @&file_exists( $filename ) && @ /*comment*/ is_readable( $filename ) ) { // Bad x2.
@@ -79,4 +79,4 @@ echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
 // @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors custom_whitelist false
 
-// @codingStandardsChangeSetting WordPress.PHP.NoSilencedErrors use_default_whitelist true
+// phpcs:set WordPress.PHP.NoSilencedErrors use_default_whitelist true

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -186,21 +186,21 @@ echo add_filter( get_the_excerpt( get_the_ID() ) ; // Bad, but ignored as code c
 /*
  * Test using custom properties, setting & unsetting (resetting).
  */
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customPrintingFunctions to_screen,my_print
+// phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[] to_screen,my_print
 to_screen( $var1, esc_attr( $var2 ) ); // Bad x 1.
 my_print( $var1, $var2 ); // Bad x 2.
 
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customEscapingFunctions esc_form_field
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customAutoEscapedFunctions post_info,cpt_info
+// phpcs:set WordPress.Security.EscapeOutput customEscapingFunctions[] esc_form_field
+// phpcs:set WordPress.Security.EscapeOutput customAutoEscapedFunctions[] post_info,cpt_info
 
 echo esc_form_field( $var ); // Ok.
 echo post_info( $post_id, 'field' ); // Ok.
 echo cpt_info( $post_type, 'query' ); // Ok.
 to_screen( esc_form_field( $var1), esc_attr( $var2 ) ); // Ok.
 
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customPrintingFunctions false
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customEscapingFunctions false
-// @codingStandardsChangeSetting WordPress.Security.EscapeOutput customAutoEscapedFunctions false
+// phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[]
+// phpcs:set WordPress.Security.EscapeOutput customEscapingFunctions[]
+// phpcs:set WordPress.Security.EscapeOutput customAutoEscapedFunctions[]
 
 echo esc_form_field( $var ); // Bad.
 echo post_info( $post_id, 'field' ); // Bad.

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -129,9 +129,9 @@ $b = function () {
 /*
  * Test using custom properties, setting & unsetting (resetting).
  */
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customNonceVerificationFunctions my_nonce_check
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customSanitizingFunctions sanitize_pc,sanitize_twitter
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customUnslashingSanitizingFunctions do_something
+// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[] my_nonce_check
+// phpcs:set WordPress.Security.NonceVerification customSanitizingFunctions[] sanitize_pc,sanitize_twitter
+// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[] do_something
 
 function foo_6() {
 
@@ -140,8 +140,8 @@ function foo_6() {
 	my_nonce_check( do_something( $_POST['tweet'] ) ); // OK.
 }
 
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customSanitizingFunctions sanitize_pc
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customUnslashingSanitizingFunctions false
+// phpcs:set WordPress.Security.NonceVerification customSanitizingFunctions[] sanitize_pc
+// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[]
 
 function foo_7() {
 
@@ -151,8 +151,8 @@ function foo_7() {
 	my_nonce_check( sanitize_twitter( $_POST['tweet'] ) ); // OK.
 }
 
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customNonceVerificationFunctions false
-// @codingStandardsChangeSetting WordPress.Security.NonceVerification customSanitizingFunctions false
+// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[]
+// phpcs:set WordPress.Security.NonceVerification customSanitizingFunctions[]
 
 function foo_8() {
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -131,21 +131,21 @@ function test_this() {
 	
 	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
 
-	// @codingStandardsChangeSetting WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions sanitize_color,sanitize_twitter_handle
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_twitter_handle
 
 	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // OK.
 	$abc = sanitize_facebook_id( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
 	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // Bad x1 - unslash.
 
-	// @codingStandardsChangeSetting WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions sanitize_color,sanitize_facebook_id
-	// @codingStandardsChangeSetting WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions sanitize_twitter_handle
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_facebook_id
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[] sanitize_twitter_handle
 
 	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // OK.
 	$abc = sanitize_facebook_id( wp_unslash( $_POST['abc_field'] ) ); // OK.
 	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // OK.
 
-	// @codingStandardsChangeSetting WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions false
-	// @codingStandardsChangeSetting WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions false
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[]
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[]
 
 	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // Bad x2, sanitize + unslash.
 }

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.1.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.1.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain default
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain default
 // Comment just to trigger the sniff to report the invalid text domain.
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.2.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.2.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain Some_thing
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain Some_thing
 // Comment just to trigger the sniff to report the invalid text domain.
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
@@ -1,6 +1,6 @@
 <?php
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
 
 /*
 Plugin Name: Correct text domain, multi-line comment, minimal headers.
@@ -9,7 +9,7 @@ Text Domain: php-compatibility-checker
 */
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /**
  * Not the plugin header.
@@ -116,4 +116,4 @@ class Debug_Bar {
 //  Version: 2.0.1
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] something-else
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
 
 /*
@@ -8,7 +8,7 @@ Description: Make sure your plugins and themes are compatible with newer PHP ver
 Text Domain: php-compatibility-checker
 */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] bbpress
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /**
@@ -34,7 +34,7 @@ Text Domain: php-compatibility-checker
  * License:     GPLv2 or later (license.txt)
  */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] debug-bar
 
 /*
  Plugin Name: Text domain which should be fixed, multi-line comment, minimal headers.
@@ -60,7 +60,7 @@ class Debug_Bar {
 	const VERSION = '0.9.1-alpha';
 }
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar-constants
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] debug-bar-constants
 
 /**
  * Text domain which should be fixed, docblock format with PHP doc tags and tab aligned.
@@ -86,7 +86,7 @@ class Debug_Bar {
  * Copyright	:	2013-2018 Juliette Reinders Folmer
  */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain a2-optimized
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] a2-optimized
 
 //  Plugin Name: Text domain which should be fixed, multi-line //-style comment.
 //  Plugin URI: https://wordpress.org/plugins/a2-optimized/
@@ -115,5 +115,5 @@ class Debug_Bar {
 //  Plugin URI: https://wordpress.org/plugins/a2-optimized/
 //  Version: 2.0.1
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] something-else
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
 
 /*
@@ -8,7 +8,7 @@ Description: Make sure your plugins and themes are compatible with newer PHP ver
 Text Domain: php-compatibility-checker
 */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] bbpress
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /**
@@ -34,7 +34,7 @@ Text Domain: php-compatibility-checker
  * License:     GPLv2 or later (license.txt)
  */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] debug-bar
 
 /*
  Plugin Name: Text domain which should be fixed, multi-line comment, minimal headers.
@@ -60,7 +60,7 @@ class Debug_Bar {
 	const VERSION = '0.9.1-alpha';
 }
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain debug-bar-constants
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] debug-bar-constants
 
 /**
  * Text domain which should be fixed, docblock format with PHP doc tags and tab aligned.
@@ -86,7 +86,7 @@ class Debug_Bar {
  * Copyright	:	2013-2018 Juliette Reinders Folmer
  */
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain a2-optimized
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] a2-optimized
 
 //  Plugin Name: Text domain which should be fixed, multi-line //-style comment.
 //  Plugin URI: https://wordpress.org/plugins/a2-optimized/
@@ -117,5 +117,5 @@ class Debug_Bar {
 //  Version: 2.0.1
 //  Text Domain: something-else
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.3.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain something-else
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain php-compatibility-checker
 
 /*
 Plugin Name: Correct text domain, multi-line comment, minimal headers.
@@ -9,7 +9,7 @@ Text Domain: php-compatibility-checker
 */
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain bbpress
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /**
  * Not the plugin header.
@@ -118,4 +118,4 @@ class Debug_Bar {
 //  Text Domain: something-else
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -1,6 +1,6 @@
 <?php
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /*
  * The test cases in this file have a variety of whitespace for indentation and around
@@ -204,4 +204,4 @@ __ngettext_noop( $singular, $plural, 'other-text-domain' ); // Error.
 translate_with_context( $text, 'third-text-domain' ); // Error.
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] text-domain,other-text-domain,third-text-domain
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /*
@@ -203,5 +203,5 @@ __ngettext( $singular, $plural, $number ); // Error.
 __ngettext_noop( $singular, $plural, 'other-text-domain' ); // Error.
 translate_with_context( $text, 'third-text-domain' ); // Error.
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -1,5 +1,5 @@
 <?php
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] text-domain,other-text-domain,third-text-domain
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /*
@@ -207,5 +207,5 @@ __ngettext( $singular, $plural, $number, 'something-else' ); // Error.
 __ngettext_noop( $singular, $plural, 'something-else' ); // Error.
 translate_with_context( $text, 'something-else' ); // Error.
 
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain text-domain,other-text-domain,third-text-domain
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
 /*
  * The test cases in this file have a variety of whitespace for indentation and around
@@ -208,4 +208,4 @@ __ngettext_noop( $singular, $plural, 'something-else' ); // Error.
 translate_with_context( $text, 'something-else' ); // Error.
 
 // @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false
-// @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
@@ -1,5 +1,5 @@
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
 
 /*
 Theme Name: Correct text domain.
@@ -15,7 +15,7 @@ Text Domain: twentyten
 */
 
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
 
 /*!
 Theme Name: Text domain which should be fixed and checking that consecutive comments don't get mixed up.
@@ -78,7 +78,7 @@ html {
 	-webkit-text-size-adjust: 100%; /* 2 */
 }
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
 
 /*
 Theme Name: Missing text domain.
@@ -156,4 +156,4 @@ Description: http://thisshouldntbeaurl
  */
 
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css
@@ -1,4 +1,4 @@
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] twentyeleven */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
 
 /*
@@ -14,7 +14,7 @@ Tags: blog, two-columns, custom-header, custom-background, threaded-comments, st
 Text Domain: twentyten
 */
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] _s */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
 
 /*!
@@ -155,5 +155,5 @@ Description: http://thisshouldntbeaurl
  * Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  */
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
@@ -1,5 +1,5 @@
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
 
 /*
 Theme Name: Correct text domain.
@@ -15,7 +15,7 @@ Text Domain: twentyten
 */
 
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
 
 /*!
 Theme Name: Text domain which should be fixed and checking that consecutive comments don't get mixed up.
@@ -78,7 +78,7 @@ html {
 	-webkit-text-size-adjust: 100%; /* 2 */
 }
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyseventeen */
 
 /*
 Theme Name: Missing text domain.
@@ -161,4 +161,4 @@ Text Domain: twentyseventeen
  */
 
 /* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer new_text_domain false */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.css.fixed
@@ -1,4 +1,4 @@
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain twentyeleven */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] twentyeleven */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain twentyten */
 
 /*
@@ -14,7 +14,7 @@ Tags: blog, two-columns, custom-header, custom-background, threaded-comments, st
 Text Domain: twentyten
 */
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain _s */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] _s */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else */
 
 /*!
@@ -160,5 +160,5 @@ Text Domain: twentyseventeen
  * Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  */
 
-/* @codingStandardsChangeSetting WordPress.Utils.I18nTextDomainFixer old_text_domain false */
+/* phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] */
 /* phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false */

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -28,17 +28,17 @@ srand(); // Warning.
 mt_srand(); // Warning.
 wp_rand(); // OK.
 
-// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
+// phpcs:set WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
 parse_url( 'http://example.com/' ); // OK.
-// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
+// phpcs:set WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
 
 strip_tags( $something, '<iframe>' ); // OK.
 
-// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
+// phpcs:set WordPress.WP.AlternativeFunctions minimum_supported_version 4.0
 parse_url($url, PHP_URL_QUERY); // OK.
-// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.7
+// phpcs:set WordPress.WP.AlternativeFunctions minimum_supported_version 4.7
 parse_url($url, PHP_URL_SCHEME); // Warning.
-// @codingStandardsChangeSetting WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
+// phpcs:set WordPress.WP.AlternativeFunctions minimum_supported_version 4.6
 
 file_get_contents( $local_file, true ); // OK.
 file_get_contents( $url, false ); // Warning.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -81,7 +81,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	return $schedules;
 } ); // Warning: time undetermined.
 
-// @codingStandardsChangeSetting WordPress.WP.CronInterval min_interval 600
+// phpcs:set WordPress.WP.CronInterval min_interval 600
 add_filter( 'cron_schedules', function ( $schedules ) {
 	$schedules['every_2_mins'] = array(
 		'interval' => 2 * 60,
@@ -104,7 +104,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	return $schedules;
 } ); // OK: > 10 min.
 
-// @codingStandardsChangeSetting WordPress.WP.CronInterval min_interval 1800
+// phpcs:set WordPress.WP.CronInterval min_interval 1800
 add_filter( 'cron_schedules', function ( $schedules ) {
 	$schedules['every_2_mins'] = array(
 		'interval' => 2 * 60,
@@ -127,7 +127,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	return $schedules;
 } ); // Ok: > 30 min.
 
-// @codingStandardsChangeSetting WordPress.WP.CronInterval min_interval 900
+// phpcs:set WordPress.WP.CronInterval min_interval 900
 
 
 add_filter( 'cron_schedules', function ( $schedules ) {

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -108,7 +108,7 @@ trait My_Class {
 }
 
 // Test adding additional test classes to the whitelist.
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist My_TestClass
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[] My_TestClass
 class Test_Class_D extends My_TestClass {
 
 	public function test_something() {
@@ -116,7 +116,7 @@ class Test_Class_D extends My_TestClass {
 		$tabs = 50; // Ok.
 	}
 }
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist false
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[]
 
 // Test detecting within and skipping over anonymous classes.
 global $year;

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.3.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.3.inc
@@ -6,7 +6,7 @@
  * For this file, none of the variables overrides should throw errors, for the sister-file they all should.
  */
 
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride treat_files_as_scoped true
+// phpcs:set WordPress.WP.GlobalVariablesOverride treat_files_as_scoped true
 
 // Overrides in the global namespace should be detected no matter what. No need for a `global` statement.
 $pagenow = 'abc'; // OK.
@@ -28,4 +28,4 @@ $domain['subkey'] = 'something else'; // OK.
 
 $GLOBALS['domain']['subkey'] = 'something else'; // Still bad.
 
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride treat_files_as_scoped false
+// phpcs:set WordPress.WP.GlobalVariablesOverride treat_files_as_scoped false

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist My\NameSp\TestClass
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[] My\NameSp\TestClass
 
 namespace My \ /* comment */ NameSp;
 
@@ -11,4 +11,4 @@ class Test_Class_D extends TestClass {
 		$tabs = 50; // Ok.
 	}
 }
-// @codingStandardsChangeSetting WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist false
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[]

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -5,7 +5,7 @@
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
 
 __( 'string' ); // Bad - no text domain passed.
 __( 'string', 'something' ); // Bad - text domain mismatch.
@@ -147,20 +147,20 @@ really.
 EOD
 , 'my-slug' ); // OK.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug,default
 __( "String default text domain.", "my-slug" ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
 __( "String default text domain.", 'something' ); // Bad, text domain mismatch.
 __( 'String default text domain.' ); // Warning, use default.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain default
+// phpcs:set WordPress.WP.I18n text_domain[] default
 __( 'String default text domain.', 'my-slug' ); // Bad because text_domain is only 'default'.
 __( 'String default text domain.', 'default' ); // Warning, text domain can be omitted.
 __( 'String default text domain.', /* Explicitly set for reason. */ 'default' ); // Warning, text domain can be omitted (not auto-fixable).
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
 // Issue #1266.
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
 $mo->translate( $string ); // OK, not a function, but a method call.
 Something\esc_html_e( $string ); // OK, not the WP function, but namespaced function call.
 
@@ -177,5 +177,5 @@ $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
+// phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments false
+// phpcs:set WordPress.WP.I18n check_translator_comments false
 
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
@@ -178,4 +178,4 @@ $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change d
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true
+// phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -5,7 +5,7 @@
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
 
 __( 'string' ); // Bad - no text domain passed.
 __( 'string', 'something' ); // Bad - text domain mismatch.
@@ -147,20 +147,20 @@ really.
 EOD
 , 'my-slug' ); // OK.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug,default
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug,default
 __( "String default text domain.", "my-slug" ); // Ok.
 __( "String default text domain.", "default" ); // Ok.
 __( "String default text domain.", 'something' ); // Bad, text domain mismatch.
 __( 'String default text domain.' ); // Warning, use default.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain default
+// phpcs:set WordPress.WP.I18n text_domain[] default
 __( 'String default text domain.', 'my-slug' ); // Bad because text_domain is only 'default'.
 __( 'String default text domain.' ); // Warning, text domain can be omitted.
 __( 'String default text domain.', /* Explicitly set for reason. */ 'default' ); // Warning, text domain can be omitted (not auto-fixable).
 __( 'String default text domain.' ); // Ok because default domain is 'default' and it matches one of the supplied configured text domains.
 
 // Issue #1266.
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
 $mo->translate( $string ); // OK, not a function, but a method call.
 Something\esc_html_e( $string ); // OK, not the WP function, but namespaced function call.
 
@@ -177,5 +177,5 @@ $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
+// phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments false
+// phpcs:set WordPress.WP.I18n check_translator_comments false
 
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
@@ -178,4 +178,4 @@ $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change d
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
 // @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
-// @codingStandardsChangeSetting WordPress.WP.I18n check_translator_comments true
+// phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.2.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.2.inc
@@ -2,7 +2,7 @@
 /*
  * Test sniffing for translator comments.
  */
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain my-slug
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
 
 /* Basic test ****************************************************************/
 __( 'No placeholders here.', 'my-slug' ); // Ok, no placeholders, so no translators comment needed.
@@ -107,4 +107,4 @@ _e(); // Bad.
 // phpcs:ignore Standard.Category.Sniff -- testing that the PHPCS annotations are handled correctly.
 printf( __( 'There are %1$d monkeys in the %2$s', 'my-slug' ), intval( $number ), esc_html( $string ) ); // Bad.
 
-// @codingStandardsChangeSetting WordPress.WP.I18n text_domain false
+// phpcs:set WordPress.WP.I18n text_domain[]

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -17,14 +17,14 @@ $query_args['numberposts'] = '-1'; // OK.
 
 $query_args['my_posts_per_page'] = -1; // OK.
 
-// @codingStandardsChangeSetting WordPress.WP.PostsPerPage posts_per_page 50
+// phpcs:set WordPress.WP.PostsPerPage posts_per_page 50
  $query_args['posts_per_page'] = 50; // OK.
  $query_args['posts_per_page'] = 100; // Bad.
  $query_args['posts_per_page'] = 200; // Bad.
  $query_args['posts_per_page'] = 300; // Bad.
-// @codingStandardsChangeSetting WordPress.WP.PostsPerPage posts_per_page 200
+// phpcs:set WordPress.WP.PostsPerPage posts_per_page 200
  $query_args['posts_per_page'] = 50; // OK.
  $query_args['posts_per_page'] = 100; // OK.
  $query_args['posts_per_page'] = 200; // OK.
  $query_args['posts_per_page'] = 300; // Bad.
-// @codingStandardsChangeSetting WordPress.WP.PostsPerPage posts_per_page 100
+// phpcs:set WordPress.WP.PostsPerPage posts_per_page 100

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
@@ -86,7 +86,7 @@ if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
 
 $directory = ('/' == $file[ strlen($file)-1 ]);
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
 if ((null !== $extra) && ($row->extra !== $extra)) {} // Bad x 4.
 
 if (( null !== $extra ) && ( $row->extra !== $extra )) {}
@@ -114,7 +114,7 @@ if ( $success && ('nothumb' == $target || 'all' == $target) ) {} // Bad x 2.
 
 $directory = ('/' == $file[ strlen($file)-1 ]); // Bad x 2.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
 
 /*
  * Test handling of ignoreNewlines.
@@ -132,7 +132,7 @@ $a = (
 	null !== $extra
 ); // Bad x 2, 1 x line 131, 1 x line 133.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
 if (
 	(
 		null !== $extra
@@ -144,9 +144,9 @@ if (
 $a = (
 	null !== $extra
 ); // Bad x 2, 1 x line 144, 1 x line 146.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
 if (
 	(
 		null !== $extra
@@ -158,4 +158,4 @@ if (
 $a = (
 	null !== $extra
 );
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
@@ -86,7 +86,7 @@ if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
 
 $directory = ('/' == $file[ strlen($file)-1 ]);
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
 if (( null !== $extra ) && ( $row->extra !== $extra )) {} // Bad x 4.
 
 if (( null !== $extra ) && ( $row->extra !== $extra )) {}
@@ -114,7 +114,7 @@ if ( $success && ( 'nothumb' == $target || 'all' == $target ) ) {} // Bad x 2.
 
 $directory = ( '/' == $file[ strlen($file)-1 ] ); // Bad x 2.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
 
 /*
  * Test handling of ignoreNewlines.
@@ -126,15 +126,15 @@ if (
 
 $a = (null !== $extra); // Bad x 2, 1 x line 131, 1 x line 133.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
 if (
 	( null !== $extra ) && ( $row->extra !== $extra )
 ) {} // Bad x 4, 1 x line 137, 2 x line 139, 1 x line 141.
 
 $a = ( null !== $extra ); // Bad x 2, 1 x line 144, 1 x line 146.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
 if (
 	(
 		null !== $extra
@@ -146,4 +146,4 @@ if (
 $a = (
 	null !== $extra
 );
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false
+// phpcs:set WordPress.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
@@ -45,7 +45,7 @@ endif;
 if ( false ) :
 else :
 endif;
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
 $a = function($arg){}; // Bad.
 $a = function ( $arg ) {
 	// Ok.
@@ -74,7 +74,7 @@ function testA()
 
 function &return_by_ref() {} // Ok.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
 
 $a = function() {}; // Ok.
 $a = function( $arg ) {}; // Ok.
@@ -84,7 +84,7 @@ $a = function () {}; // Bad.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
 
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 
@@ -100,7 +100,7 @@ $closureWithArgsAndVars = function ( $arg1, $arg2 )  use ( $var1, $var2 ) {}; //
 // Namespaces.
 use Foo\Admin;
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
 
 $a = function( $arg ) {}; // Ok.
 $a = function ( $arg ) {}; // Ok.
@@ -139,12 +139,12 @@ try{ // Bad.
 }
 
 // Upstream bug PEAR #20248.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 // Bad.
 if ( $one ) {
 
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
 
 // Upstream bug PEAR #20247.
 do {
@@ -152,7 +152,7 @@ do {
 } while ($blah); // Bad.
 
 // Upstream bug GH #782
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 if ( $foo ) {
 
 
@@ -173,7 +173,7 @@ if ( $foo ) {
 
 
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
 
 // Check for too many spaces as long as the next non-blank token is on the same line.
 function test( $blah   ) {} // Bad.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
@@ -43,7 +43,7 @@ endif;
 if ( false ) :
 else :
 endif;
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
 $a = function ( $arg ) {}; // Bad.
 $a = function ( $arg ) {
 	// Ok.
@@ -70,7 +70,7 @@ function testA() {} // Bad.
 
 function &return_by_ref() {} // Ok.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 0
 
 $a = function() {}; // Ok.
 $a = function( $arg ) {}; // Ok.
@@ -80,7 +80,7 @@ $a = function() {}; // Bad.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 $closureWithArgsAndVars = function( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Bad.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren 1
 
 $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // Ok.
 
@@ -96,7 +96,7 @@ $closureWithArgsAndVars = function ( $arg1, $arg2 ) use ( $var1, $var2 ) {}; // 
 // Namespaces.
 use Foo\Admin;
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing spaces_before_closure_open_paren -1
 
 $a = function( $arg ) {}; // Ok.
 $a = function ( $arg ) {}; // Ok.
@@ -135,11 +135,11 @@ try { // Bad.
 }
 
 // Upstream bug PEAR #20248.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 // Bad.
 if ( $one ) {
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
 
 // Upstream bug PEAR #20247.
 do {
@@ -147,7 +147,7 @@ do {
 } while ( $blah ); // Bad.
 
 // Upstream bug GH #782
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 if ( $foo ) {
 
 
@@ -168,7 +168,7 @@ if ( $foo ) {
 
 
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
 
 // Check for too many spaces as long as the next non-blank token is on the same line.
 function test( $blah ) {} // Bad.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.2.inc
@@ -1,7 +1,7 @@
 <?php
 
 // Test correct handling of PHPCS annotations.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 if ( $foo ) {
 	if ( $bar ) {
 
@@ -18,4 +18,4 @@ if ( $foo ) {
 
 
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.2.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.2.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
 // Test correct handling of PHPCS annotations.
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check true
 if ( $foo ) {
 	if ( $bar ) {
 		// phpcs:disable Standard.Category.Sniff -- too much blank space at start of structure.
@@ -12,4 +12,4 @@ if ( $foo ) {
 		// phpcs:enable Standard.Category.Sniff -- too much blank space at end of structure.
 	} // phpcs:ignore Standard.Category.Sniff -- this comment should be skipped over for the "blank line after" check.
 }
-// @codingStandardsChangeSetting WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false
+// phpcs:set WordPress.WhiteSpace.ControlStructureSpacing blank_line_check false

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -1,4 +1,4 @@
-@codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_COMMENT,T_DOC_COMMENT_WHITESPACE,T_INLINE_HTML,T_FUNCTION
+phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[] T_COMMENT,T_DOC_COMMENT_WHITESPACE,T_INLINE_HTML,T_FUNCTION
 
 <?php
 
@@ -41,4 +41,4 @@
 
 <?php
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_NONE
+// phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[]

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
@@ -1,4 +1,4 @@
-@codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_COMMENT,T_FUNCTION
+phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[] T_COMMENT,T_FUNCTION
 
 <?php
 /**

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
@@ -14,4 +14,4 @@
 	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) whitelisted.
 	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) whitelisted.
 
-// @codingStandardsChangeSetting WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens T_NONE
+// phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[]


### PR DESCRIPTION
* Change `@codingStandardsChangeSetting` to `phpcs:set` (PHPCS 3.2.0) for non-array properties.
* Change `@codingStandardsChangeSetting` to `phpcs:set` (PHPCS 3.2.0) for array properties.
* Change properties to use the new array format (PHPCS 3.3.0).

For the `FileName` sniff unit tests:

* Change `@codingStandardsChangeSetting` to `phpcs:set` (PHPCS 3.2.0).
* Change array properties to use the new array format (PHPCS 3.3.0).
* Move the annotations away from line 1.
    If a line just and only contains a PHPCS annotation, no errors will be thrown on it.
    As the `FileName` sniff will always throw errors on line 1, this means that the settings change annotations _cannot_ be on line 1 for the tests to work correctly.