### PR TITLE
Core: Remove `encoding` (PHPCS 3.0.0)

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -5,9 +5,6 @@
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>
 
-	<!-- Treat all files as UTF-8. -->
-	<config name="encoding" value="utf-8"/>
-
 	<!-- Default tab width for indentation fixes and such. -->
 	<arg name="tab-width" value="4"/>
 


### PR DESCRIPTION
The default encoding as of PHPCS 3.0.0 is `utf-8`, so there is no need to set this anymore in the ruleset.