### PR TITLE
Extra: Defer to upstream `Generic.Files.OneObjectStructurePerFile` sniff (PHPCS 3.1.0)

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -63,22 +63,9 @@
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
 
 	<!-- Encourage having only one class/interface/trait per file. -->
-	<!-- Once the minimum WPCS PHPCS requirement has gone up to PHPCS 3.1.0, these three sniffs can be
-	     replaced by the more comprehensive Generic.Files.OneObjectStructurePerFile sniff. -->
-	<rule ref="Generic.Files.OneClassPerFile"/>
-	<rule ref="Generic.Files.OneClassPerFile.MultipleFound">
+	<rule ref="Generic.Files.OneObjectStructurePerFile">
 		<type>warning</type>
-		<message>Best practice suggestion: Declare only one class in a file.</message>
-	</rule>
-	<rule ref="Generic.Files.OneInterfacePerFile"/>
-	<rule ref="Generic.Files.OneInterfacePerFile.MultipleFound">
-		<type>warning</type>
-		<message>Best practice suggestion: Declare only one interface in a file.</message>
-	</rule>
-	<rule ref="Generic.Files.OneTraitPerFile"/>
-	<rule ref="Generic.Files.OneTraitPerFile.MultipleFound">
-		<type>warning</type>
-		<message>Best practice suggestion: Declare only one trait in a file.</message>
+		<message>Best practice suggestion: Declare only one class/interface/trait in a file.</message>
 	</rule>
 
 	<!-- Verify modifier keywords for declared methods and properties in classes.


### PR DESCRIPTION
PHPCS 3.1.0 includes a new `Generic.Files.OneObjectStructurePerFile` sniff.

We previously included the `Generic.Files.OneClassPerFile`, `Generic.Files.OneInterfacePerFile` and the `Generic.Files.OneTraitPerFile` sniffs.

Each of those would only throw an error is a second object structure of the same kind was found in a file, i.e. two classes in one file, but would allow files which contained more than one object structure, but of different types, through without any errors being thrown, i.e. an interface and a class in the same file.

The new `Generic.Files.OneObjectStructurePerFile` sniff fixes this and can effectively replace the previously included sniffs.

Note: this is a BC-break for anyone using a custom ruleset or PHPCS annotations referencing the previously included sniffs.

Refs:
* squizlabs/PHP_CodeSniffer#1627
* squizlabs/PHP_CodeSniffer#1630