### PR TITLE
PHPCS 3.2+: Remove work-arounds for old style PHPCS ChangeSettings annotations

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -947,8 +947,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * - Will correctly handle custom array properties which were set without
 	 *   the `type="array"` indicator.
-	 *   This also allows for making these custom array properties testable using
-	 *   a `@codingStandardsChangeSetting` comment in the unit tests.
 	 * - By default flips custom lists to allow for using `isset()` instead
 	 *   of `in_array()`.
 	 * - When `$flip` is true:
@@ -1094,8 +1092,7 @@ abstract class Sniff implements PHPCS_Sniff {
 				$lastPtr = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $end_of_statement - 1 ), null, true );
 			}
 
-			if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
-					&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
+			if ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 					|| ( isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] )
 					&& \T_PHPCS_SET !== $this->tokens[ $lastPtr ]['code'] ) )
 				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
@@ -1110,8 +1107,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$end_of_line = $this->get_last_ptr_on_line( $stackPtr );
 		$lastPtr     = $this->phpcsFile->findPrevious( \T_WHITESPACE, $end_of_line, null, true );
 
-		if ( ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
-				&& strpos( $this->tokens[ $lastPtr ]['content'], '@codingStandardsChangeSetting' ) === false )
+		if ( ( \T_COMMENT === $this->tokens[ $lastPtr ]['code']
 				|| ( isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] )
 				&& \T_PHPCS_SET !== $this->tokens[ $lastPtr ]['code'] ) )
 			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -163,8 +163,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 * Prepare the punctuation regular expression.
 	 *
 	 * Merges the existing regular expression with potentially provided extra word delimiters to allow.
-	 * This is done 'late' and for each found token as otherwise inline `@codingStandardsChangeSetting`
-	 * directives would be ignored.
+	 * This is done 'late' and for each found token as otherwise inline `phpcs:set` directives
+	 * would be ignored.
 	 *
 	 * @return string
 	 */

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -272,12 +272,6 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *                  normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
-		if ( \T_COMMENT === $this->tokens[ $stackPtr ]['code']
-			&& strpos( $this->tokens[ $stackPtr ]['content'], '@codingStandardsChangeSetting' ) !== false
-		) {
-			return;
-		}
-
 		// Check if the old/new properties are correctly set. If not, bow out.
 		if ( ! is_string( $this->new_text_domain )
 			|| '' === $this->new_text_domain


### PR DESCRIPTION
Those are generally only used for unit testing sniffs and as all WPCS native unit tests have been adjusted, the work-arounds for the _old style_ annotations are no longer needed.

Included removing a, now redundant, comment in the `Sniff` class. The comment was relevant before the new-style array annotation for `phpcs:set` comments was introduced. However, now those are used, this is no longer an issue.