### PR TITLE
Deprecate use of the WPCS native whitelist comments

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,40 +37,9 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 > **Important**:
 > PHPCS 3.2.0 introduced new selective ignore annotations, which can be considered an improved version of the whitelist mechanism which WPCS contains.
 >
-> There is a [tentative intention to drop support for the WPCS native whitelist comments](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1048#issuecomment-340698249) in WPCS 2.0.0.
-> 
-> Considering that, the introduction of new whitelist comments is discouraged.
+> Support for the WPCS native whitelist comments has been deprecated in WPCS 2.0.0 and will be removed in WPCS 3.0.0.
 >
-> The below information remains as guidance for exceptional cases and to aid in understanding the previous implementation.
-
-Sometimes, a sniff will flag code which upon further inspection by a human turns out to be OK.
-
-If the sniff you are writing is susceptible to this, please consider adding the ability to [whitelist lines of code](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors).
-
-To this end, the `WordPress\Sniff::has_whitelist_comment()` method was introduced.
-
-Example usage:
-```php
-namespace WordPressCS\WordPress\Sniffs\Security;
-
-use WordPressCS\WordPress\Sniff;
-
-class NonceVerificationSniff extends Sniff {
-
-	public function process_token( $stackPtr ) {
-
-		// Check something.
-		
-		if ( $this->has_whitelist_comment( 'CSRF', $stackPtr ) ) {
-			return;
-		}
-		
-		$this->phpcsFile->addError( ... );
-	}
-}
-```
-
-When you introduce a new whitelist comment, please don't forget to update the [whitelisting code wiki page](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) with the relevant details once your PR has been merged into the `develop` branch.
+> With that in mind, (new) sniffs should not introduce new WPCS native whitelist comments.
 
 
 # Unit Testing

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -46,4 +46,10 @@
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
 	</rule>
 
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.DeprecatedWhitelistCommentFound">
+		<!-- False positive for whitelist comment recognition, but no use fixing this now
+			 as the WPCS native whitelist comments are deprecated anyhow. -->
+		<exclude-pattern>/WordPress/AbstractClassRestrictionsSniff\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1066,6 +1066,8 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @since 0.4.0
 	 * @since 0.14.0 Whitelist comments at the end of the statement are now also accepted.
 	 *
+	 * @deprecated 2.0.0 Use the PHPCS native `phpcs:ignore` annotations instead.
+	 *
 	 * @param string  $comment  Comment to find.
 	 * @param integer $stackPtr The position of the current token in the stack passed
 	 *                          in $tokens.
@@ -1078,6 +1080,12 @@ abstract class Sniff implements PHPCS_Sniff {
 		if ( true === PHPCSHelper::ignore_annotations( $this->phpcsFile ) ) {
 			return false;
 		}
+
+		static $thrown_notices = array();
+
+		$deprecation_notice = 'Using the WPCS native whitelist comments is deprecated. Please use the PHPCS native "phpcs:ignore Standard.Category.SniffName.ErrorCode" annotations instead. Found: %s';
+		$deprecation_code   = 'DeprecatedWhitelistCommentFound';
+		$filename           = $this->phpcsFile->getFileName();
 
 		$regex = '#\b' . preg_quote( $comment, '#' ) . '\b#i';
 
@@ -1101,6 +1109,19 @@ abstract class Sniff implements PHPCS_Sniff {
 				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
 				&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 			) {
+				if ( isset( $thrown_notices[ $filename ][ $lastPtr ] ) === false
+					&& isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] ) === false
+				) {
+					$this->phpcsFile->addWarning(
+						$deprecation_notice,
+						$lastPtr,
+						$deprecation_code,
+						array( $this->tokens[ $lastPtr ]['content'] )
+					);
+
+					$thrown_notices[ $filename ][ $lastPtr ] = true;
+				}
+
 				return true;
 			}
 		}
@@ -1117,6 +1138,19 @@ abstract class Sniff implements PHPCS_Sniff {
 			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']
 			&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
 		) {
+			if ( isset( $thrown_notices[ $filename ][ $lastPtr ] ) === false
+				&& isset( Tokens::$phpcsCommentTokens[ $this->tokens[ $lastPtr ]['code'] ] ) === false
+			) {
+				$this->phpcsFile->addWarning(
+					$deprecation_notice,
+					$lastPtr,
+					$deprecation_code,
+					array( $this->tokens[ $lastPtr ]['content'] )
+				);
+
+				$thrown_notices[ $filename ][ $lastPtr ] = true;
+			}
+
 			return true;
 		}
 

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -61,21 +61,7 @@ class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 		if ( $this->has_whitelist_comment( 'slow query', $stackPtr ) ) {
 			return;
-		}
-
-		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
-			/*
-			 * Only throw the warning about a deprecated comment when the sniff would otherwise
-			 * have been triggered on the array key.
-			 */
-			if ( \in_array( $this->tokens[ $stackPtr ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
-				$this->phpcsFile->addWarning(
-					'The "tax_query" whitelist comment is deprecated in favor of the "slow query" whitelist comment.',
-					$stackPtr,
-					'DeprecatedWhitelistFlagFound'
-				);
-			}
-
+		} elseif ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -85,7 +85,9 @@ class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			57  => 1,
 			58  => 1,
 			61  => 1,
+			62  => 1, // Whitelist comment deprecation warning.
 			66  => 1,
+			68  => 1, // Whitelist comment deprecation warning.
 			126 => 1,
 			139 => 1,
 			160 => 2,

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -57,7 +57,12 @@ class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			11 => 1, // Whitelist comment deprecation warning.
+			12 => 1, // Whitelist comment deprecation warning.
+			97 => 1, // Whitelist comment deprecation warning.
+			99 => 1, // Whitelist comment deprecation warning.
+		);
 	}
 
 }

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -44,7 +44,7 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			19 => 2,
 			30 => 1,
-			32 => 1, // Warning about deprecated whitelist comment.
+			32 => 1, // Whitelist comment deprecation warning.
 		);
 	}
 

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -44,7 +44,9 @@ class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			19 => 2,
 			30 => 1,
+			31 => 1, // Whitelist comment deprecation warning.
 			32 => 1, // Whitelist comment deprecation warning.
+			35 => 1, // Whitelist comment deprecation warning.
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -99,6 +99,11 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
 					1   => 3, // 3 x warning for potentially incorrect prefix passed.
+					201 => 1, // Whitelist comment deprecation warning.
+					208 => 1, // Whitelist comment deprecation warning.
+					212 => 1, // Whitelist comment deprecation warning.
+					215 => 1, // Whitelist comment deprecation warning.
+					216 => 1, // Whitelist comment deprecation warning.
 					249 => 1,
 					250 => 1,
 					253 => 1,

--- a/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
+++ b/WordPress/Tests/PHP/StrictComparisonsUnitTest.php
@@ -40,6 +40,7 @@ class StrictComparisonsUnitTest extends AbstractSniffUnitTest {
 			3  => 1,
 			10 => 1,
 			12 => 1,
+			19 => 1, // Whitelist comment deprecation warning.
 			24 => 1,
 			29 => 1,
 		);

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -88,7 +88,14 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			126 => 1, // Whitelist comment deprecation warning.
+			127 => 1, // Whitelist comment deprecation warning.
+			128 => 1, // Whitelist comment deprecation warning.
+			241 => 1, // Whitelist comment deprecation warning.
+			243 => 1, // Whitelist comment deprecation warning.
+			250 => 1, // Whitelist comment deprecation warning.
+		);
 	}
 
 }

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -55,7 +55,9 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			88 => 1, // Whitelist comment deprecation warning.
+		);
 	}
 
 }

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -63,7 +63,9 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			76 => 1, // Whitelist comment deprecation warning.
+		);
 	}
 
 }

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -59,6 +59,7 @@ class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 			101 => 1,
 			139 => 1,
 			146 => 0, // False negative.
+			167 => 1, // Whitelist comment deprecation warning.
 			173 => 1,
 			181 => 1,
 		);

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -85,10 +85,20 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array <int line number> => <int number of warnings>
 	 */
-	public function getWarningList() {
-		return array();
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'GlobalVariablesOverrideUnitTest.1.inc':
+				return array(
+					11 => 1, // Whitelist comment deprecation warning.
+				);
+
+			default:
+				return array();
+		}
 	}
 
 }

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -69,6 +69,7 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 					30 => 1,
 					31 => 1,
 					32 => 1,
+					34 => 1, // Whitelist comment deprecation warning.
 					39 => 1,
 					65 => 1,
 				);


### PR DESCRIPTION
### Sniff::has_whitelist_comment(): Deprecate use of the WPCS native whitelist comments (PHPCS 3.2.0)

The WPCS native whitelist comments were introduced for lack of the ability to selectively ignore one or more sniffs for a piece of code.

PHPCS 3.2.0 introduced native PHPCS annotations which allow for selective ignoring/disabling of sniffs and while those were originally a bit buggy, all known bugs have been fixed since, making the WPCS native whitelist comments redundant.

This commit deprecates the method within WPCS which is used to check for the WPCS native whitelist comments.

It also introduces a warning which will be thrown whenever a WPCS native whitelist comment is encountered to alert people to this change and encourage them to switch over to the PHPCS native annotations.

Notes:
* No deprecation notice will be thrown when a WPCS whitelist comment is combined with a PHPCS native annotation, i.e. `// phpcs:ignore WP.Security.EscapeOutput -- WPCS: XSS ok.`
* As a sniff may be triggered several times for different tokens, a light weight (static) cache variable has been introduced to prevent the deprecation notice being thrown more than once for each WPCS whitelist comment encountered.

The `Sniff::has_whitelist_comment()` method and all calls to it should be removed in WPCS 3.0.0.

- [ ] References to the WPCS native whitelist comments need to be removed from the wiki and/or replaced with an upgrade guide.
- [ ] Open an issue about removing the `Sniff::has_whitelist_comment()` method and calls to it in WPCS 3.0.0.
    Note: all unit tests testing that the WPCS native whitelist comments are being respected should also be removed at that time. Or alternatively, they can remain and it should be verified that the WPCS native whitelist comment makes no difference anymore.

Refs:
* squizlabs/PHP_CodeSniffer#604

### WPCS native PHPCS ruleset: ignore a whitelist deprecation notice

The deprecation notice in this case is actually a false positive, however as the WPCS native whitelisting is now deprecated, fixing that false positive is a moot point.

### SlowDBQuery: remove the warning about the deprecated `tax_query` whitelist comment

As the whole WPCS whitelist comment system is now deprecated, a notice will be thrown about that comment already. No need to also throw one about the comment using an old whitelist comment.

### Unit tests: account for the new WPCS whitelist comment deprecation notices

A number of unit test case files contain WPCS whitelist comments to test that those are correctly being respected.
As of now, a deprecation warning for use of the WPCS whitelist comments will be thrown on those lines, so we need to make sure that PHPCS expects those warnings.