### PR TITLE
Sniff::merge_custom_array(): Remove support for incorrectly set custom array properties

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -943,10 +943,8 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Merge a pre-set array with a ruleset provided array or inline provided string.
+	 * Merge a pre-set array with a ruleset provided array.
 	 *
-	 * - Will correctly handle custom array properties which were set without
-	 *   the `type="array"` indicator.
 	 * - By default flips custom lists to allow for using `isset()` instead
 	 *   of `in_array()`.
 	 * - When `$flip` is true:
@@ -961,14 +959,14 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * which extends an upstream sniff can also use it.}}
 	 *
 	 * @since 0.11.0
+	 * @since 2.0.0  No longer supports custom array properties which were incorrectly
+	 *               passed as a string.
 	 *
-	 * @param array|string $custom Custom list as provided via a ruleset.
-	 *                             Can be either a comma-delimited string or
-	 *                             an array of values.
-	 * @param array        $base   Optional. Base list. Defaults to an empty array.
-	 *                             Expects `value => true` format when `$flip` is true.
-	 * @param bool         $flip   Optional. Whether or not to flip the custom list.
-	 *                             Defaults to true.
+	 * @param array $custom Custom list as provided via a ruleset.
+	 * @param array $base   Optional. Base list. Defaults to an empty array.
+	 *                      Expects `value => true` format when `$flip` is true.
+	 * @param bool  $flip   Optional. Whether or not to flip the custom list.
+	 *                      Defaults to true.
 	 * @return array
 	 */
 	public static function merge_custom_array( $custom, $base = array(), $flip = true ) {
@@ -976,17 +974,9 @@ abstract class Sniff implements PHPCS_Sniff {
 			$base = array_filter( $base );
 		}
 
-		if ( empty( $custom ) || ( ! \is_array( $custom ) && ! \is_string( $custom ) ) ) {
+		if ( empty( $custom ) || ! \is_array( $custom ) ) {
 			return $base;
 		}
-
-		// Allow for a comma delimited list.
-		if ( \is_string( $custom ) ) {
-			$custom = explode( ',', $custom );
-		}
-
-		// Always trim whitespace from the values.
-		$custom = array_filter( array_map( 'trim', $custom ) );
 
 		if ( true === $flip ) {
 			$custom = array_fill_keys( $custom, false );

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -240,7 +240,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		// Allow overruling the prefixes set in a ruleset via the command line.
 		$cl_prefixes = trim( PHPCSHelper::get_config_data( 'prefixes' ) );
 		if ( ! empty( $cl_prefixes ) ) {
-			$this->prefixes = $cl_prefixes;
+			$this->prefixes = array_filter( array_map( 'trim', explode( ',', $cl_prefixes ) ) );
 		}
 
 		$this->prefixes = $this->merge_custom_array( $this->prefixes, array(), false );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -192,7 +192,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		// Allow overruling the text_domain set in a ruleset via the command line.
 		$cl_text_domain = trim( PHPCSHelper::get_config_data( 'text_domain' ) );
 		if ( ! empty( $cl_text_domain ) ) {
-			$this->text_domain = $cl_text_domain;
+			$this->text_domain = array_filter( array_map( 'trim', explode( ',', $cl_text_domain ) ) );
 		}
 
 		$this->text_domain = $this->merge_custom_array( $this->text_domain, array(), false );


### PR DESCRIPTION
Array properties passed in from a custom ruleset need to have a `type="array"` attribute.

Until now WPCS was lenient when this attribute was missing and would convert an array passed as a comma delimited string to an array.

This functionality was deprecated for the only property which still "officially" allowed for a comma-delimited string list in WPCS 1.0.0 and will now be removed.

The only exception are the two array properties which can also be set via the command-line, i.e. the `prefixes` property for the `WordPress.NamingConventions.PrefixAllGlobals` sniff and the `text_domain` property for the `WordPress.WP.I18n` sniff.
If - and only if - these properties are set from the command-line, the sniffs will still convert the received string to an array.

Refs:
* #1390

This PR also removes the leniency for spaces surrounding array values.

PHPCS 3.2.0 includes a similar fix as was previously made in WPCS via PR #1185, which means that properties passed as arrays will already be trimmed, so no need to do it again.

Refs:
* #1185
* squizlabs/PHP_CodeSniffer#1689