### PR TITLE
Extra: Use the new `Generic.WhiteSpace.LanguageConstructSpacing` sniff (PHPCS 3.3.0)

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -56,7 +56,7 @@
 	<!-- Check correct spacing of language constructs. This also ensures that the
 	     above rule for not using brackets with require is fixed correctly.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1153 -->
-	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 
 	<!-- Hook callbacks may not use all params -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->


### PR DESCRIPTION
The `Squiz.WhiteSpace.LanguageConstructSpacing` sniff has been deprecated in PHPCS 3.3.0 and will be removed in PHPCS 4, in favour of the newly introduced `Generic.WhiteSpace.LanguageConstructSpacing` sniff.

Ref:
* #1328
* squizlabs/PHP_CodeSniffer#1337