### PR TITLE
PHPCS native ruleset: don't require exact array double arrow alignment

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -26,6 +26,7 @@
 	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
 		<properties>
 			<property name="alignMultilineItems" value="!=100"/>
+			<property name="exact" value="false" phpcs-only="true"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
When the item with the _longest_ array key is removed, WPCS requires the double arrows in the whole array to be re-aligned.
Setting the [`exact` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment) to `false` removes this requirement and allows for cleaner diffs when this happens.

As PR #1547 removed a large number of items from the `Sniff::$autoEscapedFunctions` array, PHPCS was currently throwing warnings about the WPCS codebase.

This small tweaks gets rid of those.