### PR TITLE
Composer: some tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
     - |
       if [[ "$SNIFF" == "1" ]]; then
           composer install --dev --no-suggest
-          # The post-install-cmd script takes care of the installed_paths.
+          # The `dev` required DealerDirect Composer plugin takes care of the installed_paths.
       else
           # The above require already does the install.
           $(pwd)/vendor/bin/phpcs --config-set installed_paths $(pwd)

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"squizlabs/php_codesniffer": "^3.3.1"
 	},
 	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},
@@ -27,12 +28,18 @@
 	},
 	"minimum-stability": "RC",
 	"scripts": {
-		"post-install-cmd": "@install-codestandards",
-		"post-update-cmd": "@install-codestandards",
-		"check-cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-		"fix-cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-		"install-codestandards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../phpcompatibility/php-compatibility",
-		"run-tests": "@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"install-codestandards": [
+			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+		],
+		"run-tests": [
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+		]
 	},
 	"support": {
 		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",


### PR DESCRIPTION
* Make the `scripts` section more readable by setting each script up as an array.
* `require-dev` the DealerDirect Composer plugin to make life easier on WPCS devs using Composer for their dev environment.
    Includes:
    - Adjusting the `install-codestandards` script to use the plugin.
        This script should be considered _deprecated_, but is left in place for devs who are used to having it available in their workflow.
    - Removing the `post-install-cmd` and `post-update-cmd` scripts which shouldn't be needed anymore as the plugin automatically takes care of installing the standards.
* Includes updating the inline documentation in the Travis script to be inline with these changes.