### PR TITLE
Extra: Replace `Squiz.Scope.MemberVarScope` with `PSR2.Classes.PropertyDeclaration`

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -73,7 +73,7 @@
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1101 -->
 	<rule ref="Squiz.Scope.MethodScope"/>
-	<rule ref="Squiz.Scope.MemberVarScope"/>
+	<rule ref="PSR2.Classes.PropertyDeclaration"/>
 	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
 	<rule ref="PSR2.Methods.MethodDeclaration"/>
 	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">


### PR DESCRIPTION
PR #1103 added the `Squiz.Scope.MemberVarScope` sniff to the `WordPress-Extra` ruleset which checks that all class properties have their visibility declared.

The upstream `PSR2.Classes.PropertyDeclaration` sniff also does this, however it contains more extensive checks.
In addition to checking for the visibility of properties being declared, this sniff also checks:
* That property names are not prefixed with an underscore `_` to indicate visibility.
    _For methods, we already check this in the `Extra` ruleset via the `PSR2.Methods.MethodDeclaration` sniff._
* That the `var` keyword is not used for property declarations.
    This could be considered a duplicate check with the "use visibility" check.
* That each property declaration statement only declares one property, i.e. it forbids the use of code like this:
    ```php
    public $prop1 = true,
        $prop2 = '',
        $prop3 = 123;
    ```
    ~~As there is no precedent or reference to this type of property declarations in the handbook or elsewhere in the various rulesets, I'm not sure that we're ready to take a stand on this type of coding, so I've **excluded** this particular error code for now.~~
    _Even though there is no precedent or reference to this type of property declarations in the handbook or elsewhere in the various rulesets, WP Core itself does not appear to use multi-property assignments, so we may as well check leave the check in for now._
    _People can always still exclude it in their own custom rulesets and if we'd get a lot of push-back, we can reconsider._
* As of PHPCS 3.4.0: that the order of the property keywords is `visibility static`, not `static visibility` (includes fixer).
    _For methods, we already check this in the `Extra` ruleset via the `PSR2.Methods.MethodDeclaration` sniff._

All in all, using the `PSR2` sniff is more in line with the checks we already have in place for methods, so IMO, this seemed like a good change to make.