### PR TITLE
Extra: remove superfluous directive

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -76,9 +76,6 @@
 	<rule ref="Squiz.Scope.MemberVarScope"/>
 	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
 	<rule ref="PSR2.Methods.MethodDeclaration"/>
-	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-		<type>warning</type>
-	</rule>
 
 	<!-- Warn against using fully-qualified class names instead of the self keyword. -->
 	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">


### PR DESCRIPTION
The sniff already throws a warning for that error code, so we don't need to change the `type`.