### PR TITLE
Documentation: Touch up the class and method documentation

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -19,8 +19,8 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.3.0
  * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
  *                 Moved the file and renamed the class from
- *                 `WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff` to
- *                 `WordPress_AbstractArrayAssignmentRestrictionsSniff`.
+ *                 `\WordPressCS\WordPress\Sniffs\Arrays\ArrayAssignmentRestrictionsSniff` to
+ *                 `\WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff`.
  */
 abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -79,7 +79,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * {@internal Unlike in the `WordPress_AbstractFunctionRestrictionsSniff`,
+	 * {@internal Unlike in the `AbstractFunctionRestrictionsSniff`,
 	 *            we can't do a preliminary check on classes as at this point
 	 *            we don't know the class name yet.}}
 	 *

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -20,9 +20,9 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.3.0
  * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
  *                 Moved the file and renamed the class from
- *                 `WordPress_Sniffs_Functions_FunctionRestrictionsSniff` to
- *                 `WordPress_AbstractFunctionRestrictionsSniff`.
- * @since   0.11.0 Extends the WordPress_Sniff class.
+ *                 `\WordPressCS\WordPress\Sniffs\Functions\FunctionRestrictionsSniff` to
+ *                 `\WordPressCS\WordPress\AbstractFunctionRestrictionsSniff`.
+ * @since   0.11.0 Extends the WordPressCS native `Sniff` class.
  */
 abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -500,7 +500,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @since 0.3.0
 	 * @since 0.11.0 Changed visibility from public to protected.
 	 * @since 0.12.0 Renamed from `$globals` to `$wp_globals` to be more descriptive.
-	 * @since 0.12.0 Moved from WordPress_Sniffs_Variables_GlobalVariablesSniff to WordPress_Sniff
+	 * @since 0.12.0 Moved here from the WordPress.Variables.GlobalVariables sniff.
 	 *
 	 * @var array
 	 */
@@ -955,7 +955,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *     before merging/returning to allow for resetting to the base array.
 	 *
 	 * {@internal Function is static as it doesn't use any of the properties or others
-	 * methods anyway and this way the `WordPress_Sniffs_NamingConventions_ValidVariableNameSniff`
+	 * methods anyway and this way the `WordPress.NamingConventions.ValidVariableName` sniff
 	 * which extends an upstream sniff can also use it.}}
 	 *
 	 * @since 0.11.0
@@ -2196,7 +2196,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Determine the namespace name an arbitrary token lives in.
 	 *
 	 * @since 0.10.0
-	 * @since 0.12.0 Moved from the WordPress_AbstractClassRestrictionsSniff to this sniff.
+	 * @since 0.12.0 Moved from the `AbstractClassRestrictionsSniff` to this class.
 	 *
 	 * @param int $stackPtr The token position for which to determine the namespace.
 	 *
@@ -2262,7 +2262,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * i.e. MyProject\Sub\Level which will be returned together as one string.
 	 *
 	 * @since 0.12.0 A lesser variant of this method previously existed in the
-	 *               WordPress_AbstractClassRestrictionsSniff.
+	 *               `AbstractClassRestrictionsSniff` class.
 	 *
 	 * @param int|bool $stackPtr The position of a T_NAMESPACE token.
 	 *

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -27,14 +27,13 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.11.0 - The WordPress specific additional checks have now been split off
- *                 from the WordPress_Sniffs_Arrays_ArrayDeclaration sniff into
- *                 this sniff.
+ *                   from the `WordPress.Arrays.ArrayDeclaration` sniff into this sniff.
  *                 - Added sniffing & fixing for associative arrays.
  * @since   0.12.0 Decoupled this sniff from the upstream sniff completely.
- *                 This sniff now extends the `WordPress_Sniff` instead.
- * @since   0.13.0 Added the last remaining checks from the `ArrayDeclaration` sniff
- *                 which were not covered elsewhere. The `ArrayDeclaration` sniff has
- *                 now been deprecated.
+ *                 This sniff now extends the WordPressCS native `Sniff` class instead.
+ * @since   0.13.0 Added the last remaining checks from the `WordPress.Arrays.ArrayDeclaration`
+ *                 sniff which were not covered elsewhere.
+ *                 The `WordPress.Arrays.ArrayDeclaration` sniff has now been deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 Single item associative arrays are now by default exempt from the
  *                 "must be multi-line" rule. This behaviour can be changed using the

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -20,7 +20,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since   0.3.0
  * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
- * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class ArrayKeySpacingRestrictionsSniff extends Sniff {

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   0.3.0
  * @since   0.6.0  Removed the add_unique_message() function as it is no longer needed.
- * @since   0.11.0 This class now extends WordPress_Sniff.
+ * @since   0.11.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -25,10 +25,10 @@ use WordPressCS\WordPress\Sniff;
  *                   template tags end in `-template`. Based on @subpackage file DocBlock tag.
  *                 - This sniff will now allow for underscores in file names for certain theme
  *                   specific exceptions if the `$is_theme` property is set to `true`.
- * @since   0.12.0 Now extends the `WordPress_Sniff` class.
+ * @since   0.12.0 Now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
  */
 class FileNameSniff extends Sniff {
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.2.0  Now also checks whether namespaces are prefixed.
  *
- * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
  */
 class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -24,7 +24,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.10.0
- * @since   0.11.0 Extends the WordPress_AbstractFunctionParameterSniff class.
+ * @since   0.11.0 Extends the WordPressCS native `AbstractFunctionParameterSniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class ValidHookNameSniff extends AbstractFunctionParameterSniff {

--- a/WordPress/Sniffs/PHP/DontExtractSniff.php
+++ b/WordPress/Sniffs/PHP/DontExtractSniff.php
@@ -18,7 +18,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @package WPCS\WordPressCodingStandards
  *
- * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff.
+ * @since   0.10.0 Previously this check was contained within the
+ *                 `WordPress.VIP.RestrictedFunctions` sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -20,8 +20,9 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @package WPCS\WordPressCodingStandards
  *
- * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff
- *                 and the WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff.
+ * @since   0.10.0 Previously this check was contained within the
+ *                 `WordPress.VIP.RestrictedFunctions` and the
+ *                 `WordPress.PHP.DiscouragedPHPFunctions` sniffs.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -19,10 +19,11 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.9.0
- * @since   0.10.0 This sniff not only checks for `in_array()`, but also `array_search()` and `array_keys()`.
- *                 The sniff no longer needlessly extends the WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
- *                 which it didn't use.
- * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.10.0 - This sniff not only checks for `in_array()`, but also `array_search()`
+ *                   and `array_keys()`.
+ *                 - The sniff no longer needlessly extends the `ArrayAssignmentRestrictionsSniff`
+ *                   class which it didn't use.
+ * @since   0.11.0 Refactored to extend the new WordPressCS native `AbstractFunctionParameterSniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class StrictInArraySniff extends AbstractFunctionParameterSniff {

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class YodaConditionsSniff extends Sniff {

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -20,9 +20,9 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   2013-06-11
- * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
  * @since   0.5.0  The various function list properties which used to be contained in this class
- *                 have been moved to the WordPress_Sniff parent class.
+ *                 have been moved to the WordPressCS native `Sniff` parent class.
  * @since   0.12.0 This sniff will now also check for output escaping when using shorthand
  *                 echo tags `<?=`.
  * @since   0.13.0 Class name changed: this class is now namespaced.

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -19,7 +19,8 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.11.0 Refactored to extend the new WordPressCS native
+ *                 `AbstractFunctionParameterSniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -19,8 +19,8 @@ use WordPressCS\WordPress\Sniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.4.0  This class now extends WordPress_Sniff.
- * @since   0.5.0  Method getArrayIndexKey() has been moved to WordPress_Sniff.
+ * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
+ * @since   0.5.0  Method getArrayIndexKey() has been moved to the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -21,7 +21,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   1.0.0  - Takes the minimum supported WP version into account.
  *                 - Takes exceptions based on passed parameters into account.
  *
- * @uses    \WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
  */
 class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.11.0 - Extends the WordPress_Sniff class.
+ * @since   0.11.0 - Extends the WordPressCS native `Sniff` class.
  *                 - Now deals correctly with WP time constants.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 The minimum cron interval tested against is now configurable.

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -28,7 +28,7 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -28,7 +28,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since   1.0.0
  *
- * @uses    \WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -28,7 +28,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
  */
 class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class EnqueuedResourcesSniff extends Sniff {

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -18,14 +18,14 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.4.0  This class now extends WordPress_Sniff.
- * @since   0.12.0 The $wp_globals property has been moved to the WordPress_Sniff.
+ * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
+ * @since   0.12.0 The $wp_globals property has been moved to the `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  * @since   1.1.0  The sniff now also detects variables being overriden in the global namespace.
  *
- * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
  */
 class GlobalVariablesOverrideSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -27,7 +27,8 @@ use PHP_CodeSniffer\Util\Tokens;
  *                   as a comma-delimited list.
  *                   `phpcs --runtime-set text_domain my-slug,default`
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This class now extends the AbstractFunctionRestrictionSniff.
+ * @since   1.0.0  This class now extends the WordPressCS native
+ *                 `AbstractFunctionRestrictionSniff` class.
  *                 The parent `exclude` property is, however, disabled as it
  *                 would disable the whole sniff.
  */

--- a/WordPress/Sniffs/WP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/WP/TimezoneChangeSniff.php
@@ -19,8 +19,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
- *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.11.0 Extends the WordPressCS native `AbstractFunctionRestrictionsSniff`
+ *                 class instead of the upstream `Generic.PHP.ForbiddenFunctions` sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.3.0
  * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
  * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
- * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
 class CastStructureSpacingSniff extends Sniff {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.1.0
  * @since   2013-06-11 This sniff no longer supports JS.
  * @since   0.3.0      This sniff now has the ability to fix most errors it flags.
- * @since   0.7.0      This class now extends WordPress_Sniff.
+ * @since   0.7.0      This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0     Class name changed: this class is now namespaced.
  *
  * Last synced with base class 2017-01-15 at commit b024ad84656c37ef5733c6998ebc1e60957b2277.


### PR DESCRIPTION
What with classes originally having underscore delimited names, then becoming namespaced and now the namespaces being changed, documentation still referencing old, outdated class names can be confusing for new contributors.

With that in mind, I've fixed up most of the documentation to either reference the sniff _code_ or the current sniff class name.