### PR TITLE
Core: Defer to upstream `PSR12.Keywords.ShortFormTypeKeywords` sniff (PHPCS 3.3.0)

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -241,11 +241,14 @@
 
 	<!-- Rule: Perform logical comparisons, like so: if ( ! $foo ) { -->
 
-	<!-- Covers rule: When type casting, do it like so: $foo = (boolean) $bar; -->
+	<!-- Covers rule: Type casts must be lowercase. Always prefer the short form
+		 of type casts, (int) instead of (integer) and (bool) rather than (boolean).
+		 For float casts use (float). -->
 	<rule ref="Generic.Formatting.SpaceAfterCast"/>
 	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
 	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
 	<rule ref="WordPress.PHP.TypeCasts"/>
+	<rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
 	<!-- N.B.: This sniff also checks the case of (parameter/return) type declarations, not just type casts. -->
 	<rule ref="Generic.PHP.LowerCaseType"/>
 

--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -16,8 +16,6 @@ use PHP_CodeSniffer\Util\Tokens;
  * Verifies the correct usage of type cast keywords.
  *
  * Type casts should be:
- * - lowercase;
- * - short form, i.e. (bool) not (boolean);
  * - normalized, i.e. (float) not (real).
  *
  * Additionally, the use of the (unset) and (binary) casts is discouraged.
@@ -27,6 +25,8 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.2.0
+ * @since   2.0.0 No longer checks that type casts are lowercase or short form.
+ *                Relevant PHPCS native sniffs have been included in the rulesets instead.
  */
 class TypeCastsSniff extends Sniff {
 
@@ -36,10 +36,12 @@ class TypeCastsSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		$targets = Tokens::$castTokens;
-		unset( $targets[ \T_ARRAY_CAST ], $targets[ \T_OBJECT_CAST ] );
-
-		return $targets;
+		return array(
+			\T_DOUBLE_CAST,
+			\T_UNSET_CAST,
+			\T_STRING_CAST,
+			\T_BINARY_CAST,
+		);
 	}
 
 	/**
@@ -55,39 +57,7 @@ class TypeCastsSniff extends Sniff {
 		$typecast    = str_replace( ' ', '', $this->tokens[ $stackPtr ]['content'] );
 		$typecast_lc = strtolower( $typecast );
 
-		$this->phpcsFile->recordMetric( $stackPtr, 'Typecast encountered', $typecast );
-
 		switch ( $token_code ) {
-			case \T_BOOL_CAST:
-				if ( '(bool)' !== $typecast_lc ) {
-					$fix = $this->phpcsFile->addFixableError(
-						'Short form type keywords must be used; expected "(bool)" but found "%s"',
-						$stackPtr,
-						'LongBoolFound',
-						array( $typecast )
-					);
-
-					if ( true === $fix ) {
-						$this->phpcsFile->fixer->replaceToken( $stackPtr, '(bool)' );
-					}
-				}
-				break;
-
-			case \T_INT_CAST:
-				if ( '(int)' !== $typecast_lc ) {
-					$fix = $this->phpcsFile->addFixableError(
-						'Short form type keywords must be used; expected "(int)" but found "%s"',
-						$stackPtr,
-						'LongIntFound',
-						array( $typecast )
-					);
-
-					if ( true === $fix ) {
-						$this->phpcsFile->fixer->replaceToken( $stackPtr, '(int)' );
-					}
-				}
-				break;
-
 			case \T_DOUBLE_CAST:
 				if ( '(float)' !== $typecast_lc ) {
 					$fix = $this->phpcsFile->addFixableError(

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc
@@ -1,16 +1,12 @@
 <?php
 
 // OK.
-$a = (bool) $b;
-$a = (int) $b;
 $a = (float) $b;
 $a = (string) $b;
 $a = (array) $b;
 $a = (object) $b;
 
 // Error: Wrong form.
-$a = (boolean) $b;
-$a = (integer) $b;
 $a = (double) $b;
 $a = (real) $b;
 
@@ -22,15 +18,11 @@ $a = b"binary $string"; // Warning.
 
 // Test recognition with whitespace within the cast.
 // OK.
-$a = (  bool  ) $b;
-$a = ( int ) $b;
 $a = ( float) $b;
 $a = (string ) $b;
 $a = (          array) $b;
 $a = (object      ) $b;
 
-$a = (     boolean          ) $b; // Error.
-$a = (  integer) $b; // Error.
 $a = (double ) $b; // Error.
 $a = ( real ) $b; // Error.
 $a = (  unset ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
@@ -1,16 +1,12 @@
 <?php
 
 // OK.
-$a = (bool) $b;
-$a = (int) $b;
 $a = (float) $b;
 $a = (string) $b;
 $a = (array) $b;
 $a = (object) $b;
 
 // Error: Wrong form.
-$a = (bool) $b;
-$a = (int) $b;
 $a = (float) $b;
 $a = (float) $b;
 
@@ -22,15 +18,11 @@ $a = b"binary $string"; // Warning.
 
 // Test recognition with whitespace within the cast.
 // OK.
-$a = (  bool  ) $b;
-$a = ( int ) $b;
 $a = ( float) $b;
 $a = (string ) $b;
 $a = (          array) $b;
 $a = (object      ) $b;
 
-$a = (bool) $b; // Error.
-$a = (int) $b; // Error.
 $a = (float) $b; // Error.
 $a = (float) $b; // Error.
 $a = (  unset ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -28,14 +28,10 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			12 => 1,
-			13 => 1,
-			14 => 1,
-			15 => 1,
-			32 => 1,
-			33 => 1,
-			34 => 1,
-			35 => 1,
+			10 => 1,
+			11 => 1,
+			26 => 1,
+			27 => 1,
 		);
 	}
 
@@ -46,12 +42,12 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			18 => 1,
-			19 => 1,
-			20 => ( version_compare( PHPCSHelper::get_version(), '3.4.0', '<' ) === true ? 0 : 1 ),
-			21 => 1,
-			36 => 1,
-			37 => 1,
+			14 => 1,
+			15 => 1,
+			16 => ( version_compare( PHPCSHelper::get_version(), '3.4.0', '<' ) === true ? 0 : 1 ),
+			17 => 1,
+			28 => 1,
+			29 => 1,
 		);
 	}
 }


### PR DESCRIPTION
The WPCS native `WordPress.PHP.TypeCasts` sniff used to check that:
* Type casts are in lowercase;
* Boolean and integer casts are short form;
* The `(double)` cast is not used;
* Discourages the use of the `(unset)` and `(binary)` casts.

The lowercase checks has been removed in WPCS 2.0.0 in favour of the upstream `Generic.PHP.LowerCaseType` sniff via #1582.

Asides from that sniff, PHPCS 3.3.0 also introduces the `PSR12.Keywords.ShortFormTypeKeywords` sniff which checks that boolean and integer casts are in short form.

This PR removes that check from the `WordPress.PHP.TypeCasts` sniff in favour of using the upstream sniff.

There is currently one known bug in the upstream sniff - a false positive when a type cast contains whitespace, see squizlabs/PHP_CodeSniffer#2331 -, however, as WPCS also includes the `Squiz.WhiteSpace.CastSpacing` sniff which forbids whitespace within type casts anyway, this is not a reason to delay.

Includes updating the ruleset inline documentation to be in line with the current text in the handbook.
Includes updating the sniff class documentation to be in line with the current checks contained in the sniff.
Includes removing unit tests which are no longer relevant.