### PR TITLE
OperatorSpacing: check spacing around `instanceof` operator

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -54,6 +54,7 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 	public function register() {
 		$tokens                   = parent::register();
 		$tokens[ \T_BOOLEAN_NOT ] = \T_BOOLEAN_NOT;
+		$tokens[ \T_INSTANCEOF ]  = \T_INSTANCEOF;
 		$logical_operators        = Tokens::$booleanOperators;
 
 		// Using array union to auto-dedup.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -64,3 +64,7 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
+
+// Instanceof
+if ( MyClass    instanceof    SomeOtherClass ) {}
+if ( MyClass instanceof SomeOtherClass ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -64,3 +64,7 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
+
+// Instanceof
+if ( MyClass instanceof SomeOtherClass ) {}
+if ( MyClass instanceof SomeOtherClass ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -42,6 +42,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 			49 => 2,
 			50 => 2,
 			51 => 2,
+			69 => 2,
 		);
 	}
 


### PR DESCRIPTION
PHPCS 3.3.0 introduces a `PSR12.Operators.OperatorSpacing` sniff.

I've investigated whether that sniff would be a better sniff to extend for the `WordPress.WhiteSpace.OperatorSpacing` sniff than the `Squiz.WhiteSpace.OperatorSpacing` sniff which is currently being extended and have concluded that it is not for the following reason:
* The PSR12 sniff demands _at least_ one space instead of _exactly_ one space (both allow for new lines with the correct properties).

All the same, the `PSR12` sniff did include an additional token - `T_INSTANCEOF` - which makes sense to add to the WPCS sniff.

Includes unit tests.