### PR TITLE
PreparedSQL: use unique errorcode for messages

### DIFF
--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -151,7 +151,7 @@ class PreparedSQLSniff extends Sniff {
 					$this->phpcsFile->addError(
 						'Use placeholders and $wpdb->prepare(); found interpolated variable $%s at %s',
 						$this->i,
-						'NotPrepared',
+						'InterpolatedNotPrepared',
 						array(
 							$bad_variable,
 							$this->tokens[ $this->i ]['content'],


### PR DESCRIPTION
The `WordPress.DB.PreparedSQL` sniff contains two different error messages, but didn't use unique error codes for these.

This is a breaking change as <exclude>s for the old errorcode currently in custom rulesets will now no longer exclude all errors and inline annotations using the error code may be invalidated by it.

