### PR TITLE
DiscouragedConstants: make the error codes more modular

### DIFF
--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -173,7 +173,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		$this->phpcsFile->addWarning(
 			'Found usage of constant "%s". Use %s instead.',
 			$stackPtr,
-			'UsageFound',
+			$this->string_to_errorcode( $content . 'UsageFound' ),
 			array(
 				$content,
 				$this->discouraged_constants[ $content ],
@@ -208,7 +208,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 			$this->phpcsFile->addWarning(
 				'Found declaration of constant "%s". Use %s instead.',
 				$stackPtr,
-				'DeclarationFound',
+				$this->string_to_errorcode( $raw_content . 'DeclarationFound' ),
 				array(
 					$raw_content,
 					$this->discouraged_constants[ $raw_content ],


### PR DESCRIPTION
This sniff is based on an array of constants the sniff looks for.
Previously, the sniff had two distinct error codes for the different use-cases in which the constant could be found (use of vs declaration).

This change makes the error codes unique to the constant found, making it easier to silence the error message(s) for just one particular constant.

This is a breaking change as `<exclude>`s for the old errorcodes currently in custom rulesets will be invalidated by it, as well as inline annotations using the error codes.