### PR TITLE
GlobalVariablesOverride: minor error code adjustment

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -373,7 +373,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		$this->phpcsFile->addError(
 			'Overriding WordPress globals is prohibited. Found assignment to %s',
 			$stackPtr,
-			'OverrideProhibited',
+			'Prohibited',
 			$data
 		);
 	}


### PR DESCRIPTION
This is more a cosmetic change than anything else.

The sniff name for this sniff got changed in WPCS 1.0.0 from `GlobalVariables` to `GlobalVariablesOverride`, however, the error code also contains `override` which is now redundant.

This is a BC-break and as the change is cosmetic, is a bit disputable to make this change.

However, as the sniff only contains one error code, excluding the whole sniff had the same effect as excluding the single error code, so with a bit of luck, not that many people will have excluded this based on the error code.