### PR TITLE
WPCS native PHPCS ruleset: minor tweaks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -7,18 +7,18 @@
 
 	<arg value="sp"/>
 	<arg name="extensions" value="php"/>
+	<arg name="basepath" value="."/>
+	<arg name="parallel" value="8"/>
 
 	<exclude-pattern>/bin/class-ruleset-test.php</exclude-pattern>
 	<!-- Exclude Composer vendor directory. -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<rule ref="WordPress-Extra">
+	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 	</rule>
-
-	<rule ref="WordPress-Docs"/>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>


### PR DESCRIPTION
The `basepath` and `parallel` options were introduced in PHPCS 3.0 and can now be enabled for the WPCS native PHPCS checking.

And as WPCS 2.0.0 drops the `VIP` ruleset, we can now include the `WordPress` ruleset instead of including the `WordPress-Extra` + `WordPress-Docs` rulesets separately.