### PR TITLE
CS: minor code clean up

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -302,8 +302,6 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 			$this->string_to_errorcode( $group_name . '_' . $matched_content ),
 			array( $matched_content )
 		);
-
-		return;
 	}
 
 	/**

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -102,7 +102,7 @@ class PreparedSQLSniff extends Sniff {
 	 */
 	public function register() {
 
-		$this->ignored_tokens = $this->ignored_tokens + Tokens::$emptyTokens;
+		$this->ignored_tokens += Tokens::$emptyTokens;
 
 		return array(
 			\T_VARIABLE,

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -114,7 +114,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList( $phpcs_file );
+		$this->mergeWhiteList();
 
 		// Likewise if it is a mixed-case var used by WordPress core.
 		if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
@@ -203,7 +203,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList( $phpcs_file );
+		$this->mergeWhiteList();
 
 		$error_data = array( $var_name );
 		if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
@@ -228,7 +228,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) > 0 ) {
 
 			// Merge any custom variables with the defaults.
-			$this->mergeWhiteList( $phpcs_file );
+			$this->mergeWhiteList();
 
 			foreach ( $matches[1] as $var_name ) {
 				// If it's a php reserved var, then its ok.
@@ -265,12 +265,11 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * if we haven't already.
 	 *
 	 * @since 0.10.0
-	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @since 2.0.0  Removed unused $phpcs_file parameter.
 	 *
 	 * @return void
 	 */
-	protected function mergeWhiteList( File $phpcs_file ) {
+	protected function mergeWhiteList() {
 		if ( $this->customPropertiesWhitelist !== $this->addedCustomProperties['properties'] ) {
 			// Fix property potentially passed as comma-delimited string.
 			$customProperties = Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );

--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -10,7 +10,6 @@
 namespace WordPressCS\WordPress\Sniffs\PHP;
 
 use WordPressCS\WordPress\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verifies the correct usage of type cast keywords.

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -169,15 +169,13 @@ class EscapeOutputSniff extends Sniff {
 	 */
 	public function register() {
 
-		$tokens = array(
+		return array(
 			\T_ECHO,
 			\T_PRINT,
 			\T_EXIT,
 			\T_STRING,
 			\T_OPEN_TAG_WITH_ECHO,
 		);
-
-		return $tokens;
 	}
 
 	/**

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -27,7 +27,7 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		$errors = array(
+		return array(
 			2   => 1,
 			5   => 1,
 			8   => 1,
@@ -74,8 +74,6 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			145 => 1,
 			160 => 1,
 		);
-
-		return $errors;
 	}
 
 	/**

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -84,7 +84,7 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 				);
 
 			case 'PrecisionAlignmentUnitTest.5.inc':
-				$warnings = array(
+				return array(
 					9  => 1,
 					14 => 1,
 					19 => 1,
@@ -97,8 +97,6 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 					56 => 1,
 					58 => 1,
 				);
-
-				return $warnings;
 
 			case 'PrecisionAlignmentUnitTest.6.inc':
 				return array(


### PR DESCRIPTION
Removing:
* Unused `use` statement (no longer used after code removal).
* Some unnecessary interim variables (no longer needed as code which added to the variables has been removed).
* Unnecessary `return` statement.
* Simplify an (re-)assignment to the same variable.
* Remove an unused function parameter (no longer used after previous refactor of the function code).