### PR TITLE
ValidFunctionName: sync in fixes from upstream

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -31,29 +31,6 @@ use PHP_CodeSniffer\Files\File;
 class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 
 	/**
-	 * Additional double underscore prefixed methods specific to certain PHP native extensions.
-	 *
-	 * Currently only handles the SoapClient Extension.
-	 *
-	 * @link http://php.net/manual/en/class.soapclient.php
-	 *
-	 * @var array <string method name> => <string class name>
-	 */
-	private $methodsDoubleUnderscore = array(
-		'doRequest'              => 'SoapClient',
-		'getFunctions'           => 'SoapClient',
-		'getLastRequest'         => 'SoapClient',
-		'getLastRequestHeaders'  => 'SoapClient',
-		'getLastResponse'        => 'SoapClient',
-		'getLastResponseHeaders' => 'SoapClient',
-		'getTypes'               => 'SoapClient',
-		'setCookie'              => 'SoapClient',
-		'setLocation'            => 'SoapClient',
-		'setSoapHeaders'         => 'SoapClient',
-		'soapCall'               => 'SoapClient',
-	);
-
-	/**
 	 * Processes the tokens outside the scope.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
@@ -163,7 +140,7 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 		// Is this a magic method ? I.e. is it prefixed with "__" ?
 		if ( 0 === strpos( $methodName, '__' ) ) {
 			$magicPart = substr( $methodNameLc, 2 );
-			if ( isset( $this->magicMethods[ $magicPart ] ) || isset( $this->methodsDoubleUnderscore[ $magicPart ] ) ) {
+			if ( isset( $this->magicMethods[ $magicPart ] ) ) {
 				return;
 			}
 

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -109,3 +109,17 @@ function __MyTemplateTags() {} // Bad x 2.
 interface MyInterface extends InterfaceA, InterfaceB {
 	function __MyTemplateTags(); // OK.
 }
+
+class Nested {
+    public function get_anonymous_class() {
+        return new class() {
+            public function nestedFunction() {}
+            protected function __something() {}
+        };
+    }
+}
+
+abstract class My_Class {
+    public function my_Class() {}
+    public function _MY_CLASS() {}
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -44,6 +44,8 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			88  => 2,
 			89  => 2,
 			106 => 2,
+			116 => 1,
+			117 => 1,
 		);
 	}
 


### PR DESCRIPTION
_When I started looking at #1280, I realized this sniff hadn't been synced with upstream for over two years, so here goes._

### ValidFunctionName: sync in fixes from upstream

This adds similar fixes which were made to the upstream `PEAR` sniff to the WPCS native version of the sniff in as far applicable.

* The `WordPress.NamingConventions.ValidFunctionName` sniff would throw the same error twice for functions in nested classes.
    The reasoning and solution used is the same as applied upstream.
    > Turns out the `processTokensWithinScope()` method gets called for each whitelisted scope a `T_FUNCTION` token exists in.
    >
    > In effect, this means that the first time it gets called for the `nestedFunction()` method, it is because it is within the scope of the `Nested` class, the second time the function gets called, it is for the method being in the scope of the anonymous class.
    >
    > The fix I've now applied checks that the scope for which the method is called is actually the deepest scope first and bows out if it's not.

    This fixes the error messages being thrown twice.
* For methods in anonymous classes, the error message would read `Method name "nestedFunction" in class  is not ....` (take note of the missing class name) which could be considered confusing.
    I've changed this to now read: `Method name "nestedFunction" in class [Anonymous class] is not ....`
* Class and method names in PHP are case _in_sensitive. While the sniff took that into account for the magic methods, it did not when checking for PHP4 style constructors/destructors.
     This has now been fixed by lowercasing both the class name as well as the function name before comparing them.

Includes unit tests.

### ValidFunctionName: remove redundant code

As the "method name" check exits out if it finds an extended class or implemented interface anyway, checking the name of underscore magic methods which are only used in extended classes is redundant.