### PR TITLE
ValidVariableName: adjust error messages and codes

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -943,6 +943,25 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
+	 * Transform the name of a PHP construct (function, variable etc) to one in snake_case.
+	 *
+	 * @since 2.0.0 Moved from the `WordPress.NamingConventions.ValidFunctionName` sniff
+	 *              to this class, renamed from `get_name_suggestion` and made static
+	 *              so it can also be used by classes which don't extend this class.
+	 *
+	 * @param string $name The construct name.
+	 *
+	 * @return string
+	 */
+	public static function get_snake_case_name_suggestion( $name ) {
+		$suggested = preg_replace( '`([A-Z])`', '_$1', $name );
+		$suggested = strtolower( $suggested );
+		$suggested = str_replace( '__', '_', $suggested );
+		$suggested = trim( $suggested, '_' );
+		return $suggested;
+	}
+
+	/**
 	 * Merge a pre-set array with a ruleset provided array.
 	 *
 	 * - By default flips custom lists to allow for using `isset()` instead

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff as PHPCS_PEAR_ValidFunctionNameSniff;
 use PHP_CodeSniffer\Files\File;
+use WordPressCS\WordPress\Sniff;
 
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
@@ -21,6 +22,8 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since   0.1.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   2.0.0  The `get_name_suggestion()` method has been moved to the
+ *                 WordPress native `Sniff` base class as `get_snake_case_name_suggestion()`.
  *
  * Last synced with parent class December 2018 up to commit ee167761d7756273b8ad0ad68bf3db1f2c211bb8.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -71,7 +74,7 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			$error     = 'Function name "%s" is not in snake case format, try "%s"';
 			$errorData = array(
 				$functionName,
-				$this->get_name_suggestion( $functionName ),
+				Sniff::get_snake_case_name_suggestion( $functionName ),
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid', $errorData );
 		}
@@ -155,24 +158,10 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			$errorData = array(
 				$methodName,
 				$className,
-				$this->get_name_suggestion( $methodName ),
+				Sniff::get_snake_case_name_suggestion( $methodName ),
 			);
 			$phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}
-	}
-
-	/**
-	 * Transform the existing function/method name to one which complies with the naming conventions.
-	 *
-	 * @param string $name The function/method name.
-	 * @return string
-	 */
-	protected function get_name_suggestion( $name ) {
-		$suggested = preg_replace( '/([A-Z])/', '_$1', $name );
-		$suggested = strtolower( $suggested );
-		$suggested = str_replace( '__', '_', $suggested );
-		$suggested = trim( $suggested, '_' );
-		return $suggested;
 	}
 
 }

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -28,8 +28,8 @@ use WordPressCS\WordPress\Sniff;
  *
  * Last synced with base class June 2018 at commit 78ddbae97cac078f09928bf89e3ab9e53ad2ace0.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
- * One change from upstream deferred till later (PHPCS 3.3.0+):
- * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1048#issuecomment-364282100
+ *
+ * @uses PHP_CodeSniffer\Sniffs\AbstractVariableSniff::$phpReservedVars
  */
 class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
@@ -92,7 +92,6 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 */
 	protected $addedCustomProperties = array(
 		'properties' => null,
-		'variables'  => null,
 	);
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -23,7 +23,8 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   2.0.0  Defers to the upstream `$phpReservedVars` property.
+ * @since   2.0.0  - Defers to the upstream `$phpReservedVars` property.
+ *                 - Now offers name suggestions for variables in violation.
  *
  * Last synced with base class June 2018 at commit 78ddbae97cac078f09928bf89e3ab9e53ad2ace0.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -139,9 +140,12 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 					}
 
 					if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $obj_var_name ] ) && self::isSnakeCase( $obj_var_name ) === false ) {
-						$error = 'Object property "%s" is not in valid snake_case format';
-						$data  = array( $original_var_name );
-						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
+						$error = 'Object property "$%s" is not in valid snake_case format, try "$%s"';
+						$data  = array(
+							$original_var_name,
+							Sniff::get_snake_case_name_suggestion( $original_var_name ),
+						);
+						$phpcs_file->addError( $error, $var, 'UsedPropertyNotSnakeCase', $data );
 					}
 				}
 			}
@@ -165,15 +169,18 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 		if ( self::isSnakeCase( $var_name ) === false ) {
 			if ( $in_class && ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) ) {
-				$error      = 'Object property "%s" is not in valid snake_case format';
-				$error_name = 'NotSnakeCaseMemberVar';
+				$error      = 'Object property "$%s" is not in valid snake_case format, try "$%s"';
+				$error_name = 'UsedPropertyNotSnakeCase';
 			} elseif ( ! $in_class ) {
-				$error      = 'Variable "%s" is not in valid snake_case format';
-				$error_name = 'NotSnakeCase';
+				$error      = 'Variable "$%s" is not in valid snake_case format, try "$%s"';
+				$error_name = 'VariableNotSnakeCase';
 			}
 
 			if ( isset( $error, $error_name ) ) {
-				$data = array( $original_var_name );
+				$data = array(
+					$original_var_name,
+					Sniff::get_snake_case_name_suggestion( $original_var_name ),
+				);
 				$phpcs_file->addError( $error, $stack_ptr, $error_name, $data );
 			}
 		}
@@ -205,10 +212,13 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		// Merge any custom variables with the defaults.
 		$this->mergeWhiteList();
 
-		$error_data = array( $var_name );
 		if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
-			$error = 'Member variable "%s" is not in valid snake_case format.';
-			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
+			$error = 'Member variable "$%s" is not in valid snake_case format, try "$%s"';
+			$data  = array(
+				$var_name,
+				Sniff::get_snake_case_name_suggestion( $var_name ),
+			);
+			$phpcs_file->addError( $error, $stack_ptr, 'PropertyNotSnakeCase', $data );
 		}
 	}
 
@@ -242,9 +252,12 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 				}
 
 				if ( false === self::isSnakeCase( $var_name ) ) {
-					$error = 'Variable "%s" is not in valid snake_case format';
-					$data  = array( $var_name );
-					$phpcs_file->addError( $error, $stack_ptr, 'StringNotSnakeCase', $data );
+					$error = 'Variable "$%s" is not in valid snake_case format, try "$%s"';
+					$data  = array(
+						$var_name,
+						Sniff::get_snake_case_name_suggestion( $var_name ),
+					);
+					$phpcs_file->addError( $error, $stack_ptr, 'InterpolatedVariableNotSnakeCase', $data );
 				}
 			}
 		}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -167,3 +167,22 @@ echo ClassName
 		$var_name2
 			// More sillyness.
 			['test'];
+
+class MultiVarDeclarations {
+	public $multiVar1, $multiVar2, // Bad x 2.
+		$multiVar3, // Bad.
+		// Some comment.
+		$multiVar4, // Bad.
+		$multiVar5 = false, // Bad.
+		$multiVar6 = 123, // Bad.
+		$multi_var7 = 'string'; // Ok.
+		
+	public function testMultiGlobalAndStatic() {
+		global $multiGlobal1, $multi_global2, // Bad x 1.
+			$multiGlobal3; // Bad.
+
+		static $multiStatic1, $multi_static2 = false, // Bad x 1.
+			// Comment.
+			$multiStatic3 = ''; // Bad.
+	}
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -73,6 +73,15 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			138 => 1,
 			145 => 1,
 			160 => 1,
+			172 => 2,
+			173 => 1,
+			175 => 1,
+			176 => 1,
+			177 => 1,
+			181 => 1,
+			182 => 1,
+			184 => 1,
+			186 => 1,
 		);
 	}
 


### PR DESCRIPTION
### ValidFunctionName: move `get_name_suggestion()` to the Sniff base class

... rename it to `get_snake_case_name_suggestion()` and make it a static method so it's also available to sniffs extending upstream sniffs.

### ValidVariableName: adjust error messages and codes

* Adjusts the error messages to include an alternative name suggestion in snake_case.
* Adds back the previously stripped `$` to the variable name for the error message.
* Adjusts the error messages the sniff throws to be more consistent.

Fixes #1280

### ValidVariableName: minor tweaks

Minor changes missed in PR #1586.

* Update the class documentation.
* Remove a, now unused, property array key.

### ValidVariableName: add some additional unit tests

... to confirm that the sniff handles multi-variable/property declarations correctly.

(some of these would have failed prior to PHPCS 3.3.0)