### PR TITLE
Revert "Extra: Use the new `Generic.WhiteSpace.LanguageConstructSpacing` sniff (PHPCS 3.3.0)"

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -56,7 +56,7 @@
 	<!-- Check correct spacing of language constructs. This also ensures that the
 	     above rule for not using brackets with require is fixed correctly.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1153 -->
-	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
+	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
 
 	<!-- Hook callbacks may not use all params -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->


### PR DESCRIPTION
This effectively reverts PR #1585 as the PEAR installation of PHPCS will not work with WPCS 2.0.0 if we leave this in.

Once upstream PR squizlabs/PHP_CodeSniffer#2340 has been merged, a new PHPCS version tagged & released and WPCS is ready & willing to upgrade to that version, this change should be made anew as the new sniff is definitely better than the old version, but until that time, it is not important enough to allow WPCS to be broken for anyone using a PEAR install of PHPCS.

Fixes #1614