### PR TITLE
Simplify Composer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,8 @@ before_install:
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     - export XMLLINT_INDENT="	"
     - export PHPUNIT_DIR=/tmp/phpunit
+    - composer install
     - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --update-no-dev --no-suggest --no-scripts
-    - |
-      if [[ "$SNIFF" == "1" ]]; then
-          composer install --dev --no-suggest
-          # The `dev` required DealerDirect Composer plugin takes care of the installed_paths.
-      else
-          # The above require already does the install.
-          $(pwd)/vendor/bin/phpcs --config-set installed_paths $(pwd)
-      fi
 
 script:
     # Lint the PHP files against parse errors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
 
 script:
     # Lint the PHP files against parse errors.
-    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+    - if [[ "$LINT" == "1" ]]; composer lint-php fi
     # Run the unit tests.
     - composer run-test
     # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
     # Lint the PHP files against parse errors.
     - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
-    - phpunit --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    - composer run-test
     # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
     # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
     # For the first run, the exit code will be 1 (= all fixable errors fixed).

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
     - export XMLLINT_INDENT="	"
     - export PHPUNIT_DIR=/tmp/phpunit
     - composer install
-    - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --update-no-dev --no-suggest --no-scripts
+    - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-suggest --no-scripts
 
 script:
     # Lint the PHP files against parse errors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
 
 script:
     # Lint the PHP files against parse errors.
-    - if [[ "$LINT" == "1" ]]; composer lint-php fi
+    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
     - composer run-test
     # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,6 @@
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
-		"install-codestandards": [
-			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-		],
 		"run-tests": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
 		"fix-cs": [
 			"@php vendor/bin/phpcbf"
 		],
+		"install-codestandards": [
+			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+		],
 		"run-tests": [
 			"@php vendor/bin/phpunit --filter WordPress vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]

--- a/composer.json
+++ b/composer.json
@@ -29,16 +29,16 @@
 	"minimum-stability": "RC",
 	"scripts": {
 		"check-cs": [
-			"@php vendor/bin/phpcs"
+			"@php ./vendor/bin/phpcs"
 		],
 		"fix-cs": [
-			"@php vendor/bin/phpcbf"
+			"@php ./vendor/bin/phpcbf"
 		],
 		"install-codestandards": [
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
 		],
 		"run-tests": [
-			"@php vendor/bin/phpunit --filter WordPress vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/bin/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]
 	},
 	"support": {

--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,13 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"overtrue/phplint": "^1.1"
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"minimum-stability": "RC",
 	"scripts": {
-		"lint-php": [
-			"@php vendor/bin/phplint --exclude=vendor --no-cache ."
-		],
 		"check-cs": [
 			"@php vendor/bin/phpcs"
 		],

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
 		],
 		"run-tests": [
-			"@php ./vendor/bin/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/bin/phpunit --filter WordPress --bootstrap ./vendor/squizlabs/php_codesniffer/tests/bootstrap.php ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]
 	},
 	"support": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,17 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"overtrue/phplint": "^1.1"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"minimum-stability": "RC",
 	"scripts": {
+		"lint-php": [
+			"@php vendor/bin/phplint --exclude=vendor --no-cache ."
+		],
 		"check-cs": [
 			"@php vendor/bin/phpcs"
 		],

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"run-tests": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]
 	},
 	"support": {

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
 	"minimum-stability": "RC",
 	"scripts": {
 		"check-cs": [
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+			"@php vendor/bin/phpcs"
 		],
 		"fix-cs": [
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+			"@php vendor/bin/phpcbf"
 		],
 		"run-tests": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php vendor/bin/phpunit --filter WordPress vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		]
 	},
 	"support": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,9 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
-	colors="true">
+	colors="true"
+	bootstrap="vendor/squizlabs/php_codesniffer/tests/bootstrap.php"
+	>
 
 	<testsuites>
 		<testsuite name="WordPress">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,9 +4,7 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
-	colors="true"
-	bootstrap="vendor/squizlabs/php_codesniffer/tests/bootstrap.php"
-	>
+	colors="true">
 
 	<testsuites>
 		<testsuite name="WordPress">


### PR DESCRIPTION
- Use Composer package binaries linked under `/vendor/bin` to account for binaries being moved in the source repositories. Also shorter to read.

- Define the phpunit bootstrap in `phpunit.xml.dist` just like we do with `backupGlobals` and `colors`.

- Remove the current directory prefix from all file paths since we already specify the PHP script handler `@php` before each script.

- Introduce a cross-platform PHP linter [overtrue/phplint](https://packagist.org/packages/overtrue/phplint) instead of relying on bash commands to define and check PHP files for syntax errors.