### PR TITLE
PrefixAllGlobals: prevent false negatives for autoloaded user-defined global functions

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -174,6 +174,18 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
+	 * List of all PHP native functions.
+	 *
+	 * Using this list rather than a call to `function_exists()` prevents
+	 * false negatives from user-defined functions when those would be
+	 * autoloaded via a Composer autoload files directives.
+	 *
+	 * @var array
+	 */
+	private $built_in_functions;
+
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @since 0.12.0
@@ -181,6 +193,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @return array
 	 */
 	public function register() {
+		// Get a list of all PHP native functions.
+		$all_functions            = get_defined_functions();
+		$this->built_in_functions = array_flip( $all_functions['internal'] );
+
+		// Set the sniff targets.
 		$targets  = array(
 			\T_NAMESPACE => \T_NAMESPACE,
 			\T_FUNCTION  => \T_FUNCTION,
@@ -345,7 +362,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					}
 
 					$item_name = $this->phpcsFile->getDeclarationName( $stackPtr );
-					if ( function_exists( '\\' . $item_name ) ) {
+					if ( isset( $this->built_in_functions[ $item_name ] ) ) {
 						// Backfill for PHP native function.
 						return;
 					}


### PR DESCRIPTION
The `PrefixAllGlobals` sniff verifies that functions declared in the global namespace are prefixed with one of the whitelisted prefixes as passed to the sniff in the `prefixes` property in a custom ruleset.

The sniff prevents false positives for polyfills for PHP native functions - which should be named exactly as named in PHP without prefix for them to be usable as a polyfill - by checking that the function doesn't exist.

Generally speaking this works fine in 98% of all cases as PHPCS is normally run stand-alone and doesn't contain any functions defined in the global namespace.

Similarly, when PHPCS is installed via Composer, this would normally work fine as the commonly used `autoload` options are `PSR-0`, `PSR-4` and `classmap` which are all based on code being in classes.

However, if the Composer `autoload` `files` option is used to load, for instance, a functions file declaring functions in the global namespace, this "polyfill false positive prevention" would incorrectly cause errors _not_ to be thrown for functions declared in the global namespace which were now autoloaded via Composer.

I have now fixed this by, instead of using `function_exists()`, using a check against a functions list retrieved via `get_defined_functions()`.

This change does not have unit tests as:
* Preventing false positives for polyfills is already unit tested.
* Checking that autoloaded user defined functions are not recognized as PHP native functions is not something which can be unit tested as such. This would need an integration test including a composer setup to be tested.

Based on the test case provided in the issue which originally reported this, I have confirmed that this PR fixes the issue though.

Fixes #1632