### PR TITLE
ValidatedSanitizedInput: only recognize a variable as validated if the correct variable is examined

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1772,6 +1772,10 @@ abstract class Sniff implements PHPCS_Sniff {
 					continue;
 				}
 
+				if ( $this->tokens[ $stackPtr ]['content'] !== $this->tokens[ $i ]['content'] ) {
+					continue;
+				}
+
 				// If we're checking for a specific array key (ex: 'hello' in
 				// $_POST['hello']), that must match too. Quote-style, however, doesn't matter.
 				if ( isset( $array_key )

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -85,7 +85,7 @@ echo array_map( array( $obj, 'sanitize_text_field' ), wp_unslash( $_GET['test'] 
 $foo = (int) $_POST['foo6']; // Bad.
 
 // Non-assignment checks are OK.
-if ( 'bar' === $_POST['foo'] ) {} // Ok.
+if ( isset( $_POST['foo'] ) && 'bar' === $_POST['foo'] ) {} // Ok.
 if ( $_GET['test'] != 'a' ) {} // Ok.
 if ( 'bar' === do_something( wp_unslash( $_POST['foo'] ) ) ) {} // Bad.
 
@@ -182,4 +182,9 @@ function barfoo() {
 // Issue #1467.
 if ( isset( $_POST[ 'currentid' ] ) ){
             $id = (int) $_POST[ "currentid" ]; // OK.
+}
+
+// Only recognize validation if the correct superglobal is examined.
+if ( isset ( $_POST['thisisnotget'] ) ) {
+	$get = (int) $_GET['thisisnotget']; // Bad.
 }

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -54,6 +54,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			138 => 1,
 			150 => 2,
 			160 => 2,
+			189 => 1,
 		);
 	}
 


### PR DESCRIPTION
The `Sniff::is_validated()` method did not check whether the variable being validated was in actual fact the same variable as the one for which validation was needed.

This could cause false negatives for the `InputNotValidated` error if an array key in, for instance, `$_GET` was validated, but that same array key was later requested - without validation - from `$_POST`.