### PR TITLE
ValidateSanitizedInput: allow for validation using array_key_exists()

### DIFF
--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -188,3 +188,24 @@ if ( isset( $_POST[ 'currentid' ] ) ){
 if ( isset ( $_POST['thisisnotget'] ) ) {
 	$get = (int) $_GET['thisisnotget']; // Bad.
 }
+
+// Recognize PHP native array_key_exists() as validation function.
+if ( array_key_exists( 'my_field1', $_POST ) ) {
+	$id = (int) $_POST['my_field1']; // OK.
+}
+
+if ( \array_key_exists( 'my_field2', $_POST ) ) {
+	$id = (int) $_POST['my_field2']; // OK.
+}
+
+if ( \Some\ClassName\array_key_exists( 'my_field3', $_POST ) ) {
+	$id = (int) $_POST['my_field3']; // Bad.
+}
+
+if ( $obj->array_key_exists( 'my_field4', $_POST ) ) {
+	$id = (int) $_POST['my_field4']; // Bad.
+}
+
+if ( ClassName::array_key_exists( 'my_field5', $_POST ) ) {
+	$id = (int) $_POST['my_field5']; // Bad.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -55,6 +55,9 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			150 => 2,
 			160 => 2,
 			189 => 1,
+			202 => 1,
+			206 => 1,
+			210 => 1,
 		);
 	}
 


### PR DESCRIPTION
Just like, `isset()` and `empty()`, `array_key_exists()` is a way to validate a variable exists and should therefore be recognized by this function.

Note the difference between the functions:
* `isset( $foo['bar'] )` - checks whether the key `bar` exists in the array `$foo` _and has a value assigned to it_.
* `! empty( $foo['bar'] )` - checks whether the key `bar` exists in the array `$foo` _and has a _non-falsy_ value assigned to it_.
* `array_key_exists( 'bar', $foo )` - checks whether the key `bar` exists in the array `$foo`. I.e. when using `array_key_exists()` a `null` value is acceptable.

Which validation method is used, should be left up to the judgement of a developer.

All three will prevent _Undefined variable_ notices, so in my opinion, `array_key_exists()` should be regarded as a valid way of validating a variable.

Includes unit tests covering the change in `Sniff::is_validated()`.

The change in `Sniff::is_in_isset_or_empty()` is currently not (sufficiently) unit tested as the only sniff which uses the method, `ValidatedSanitizedInput`, requires for a superglobal to have an array key set and therefor doesn't throw an error for the use of `$_POST` in a call to `array_key_exists()`.