### PR TITLE
Sniff::$test_class_whitelist: add newly added base test class to the list

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -770,6 +770,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @var string[]
 	 */
 	protected $test_class_whitelist = array(
+		'WP_UnitTestCase_Base'                       => true,
 		'WP_UnitTestCase'                            => true,
 		'WP_Ajax_UnitTestCase'                       => true,
 		'WP_Canonical_UnitTestCase'                  => true,


### PR DESCRIPTION
See: https://core.trac.wordpress.org/changeset/44701