### PR TITLE
Travis: test builds against PHP 7.4 & work around for PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - "7.4snapshot"
     - nightly
 
 env:
@@ -42,6 +43,7 @@ matrix:
 
   allow_failures:
     # Allow failures for unstable builds.
+    - php: "7.4snapshot"
     - php: nightly
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ php:
     - 7.2
     - 7.3
     - "7.4snapshot"
-    - nightly
 
 env:
   # `master` is now 3.x.
@@ -44,7 +43,6 @@ matrix:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - php: nightly
 
 before_install:
     # Speed up build time by disabling Xdebug.
@@ -62,12 +60,20 @@ before_install:
           # The above require already does the install.
           $(pwd)/vendor/bin/phpcs --config-set installed_paths $(pwd)
       fi
+    # Download PHPUnit 7.x for builds on PHP >= 7.2 as the PHPCS
+    # test suite is currently not compatible with PHPUnit 8.x.
+    - if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-7.phar && chmod +x $PHPUNIT_DIR/phpunit-7.phar; fi
 
 script:
     # Lint the PHP files against parse errors.
     - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
-    - phpunit --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    - |
+      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+        php $PHPUNIT_DIR/phpunit-7.phar --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+      else
+        phpunit --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+      fi
     # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
     # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
     # For the first run, the exit code will be 1 (= all fixable errors fixed).


### PR DESCRIPTION
### Travis: test builds against PHP 7.4

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

### Travis: work around PHPUnit 8.x on PHP >= 7.2 images

As of recently, the Travis images for PHP 7.2+ ship with PHPUnit 8.x.
The PHPCS native test framework is not compatible with PHPUnit 8.x and won't be able to be made compatible with it until the minimum PHP version would be raised to PHP 7.1.

So for the unit tests to be able to run on PHP 7.2+, we need to explicitly require PHPUnit 7.x for those builds.
This has been implemented in the same way as a similar requirement was previously implemented fo HHVM.

As for nightly: there is no PHPUnit version which is currently compatible with PHP 8.
As that either means that the builds for `nightly` would always fail or - if the unit tests would be skipped -, the only check executed on `nightly` would be linting the files, I've elected to remove build testing against `nightly` for the time being.

For more details about PHPUnit vs PHPCS vs PHP 8, see https://github.com/squizlabs/PHP_CodeSniffer/pull/2416

---

Note: I've set this PR to `prio:high` as builds will currently fail without this fix, so this is a blocker for any new PR and for merging existing PRs (until this PR has been merged).