### PR TITLE
WP.EnqueuedResources: bug fix

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -44,7 +44,7 @@ class EnqueuedResourcesSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 		$token = $this->tokens[ $stackPtr ];
 
-		if ( preg_match( '#rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
+		if ( preg_match( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
 			$this->phpcsFile->addError(
 				'Stylesheets must be registered/enqueued via wp_enqueue_style',
 				$stackPtr,

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
@@ -30,3 +30,9 @@ $head = <<<'EOD'
 <link rel="stylesheet" href="http://someurl/somefile.css">
 <script src="http://someurl/somefile.js"></script>
 EOD;
+
+?>
+
+jQuery( document ).ready( function() {
+	$('link[rel="stylesheet"]:not([data-inprogress])').forEach(StyleFix.link);
+});


### PR DESCRIPTION
Identified by @joyously in the ThemeReviewCS repo: WPTRT/WPThemeReview#202

When inline jQuery is used to reference a stylesheet link tag, the sniff misidentifies this as a stylesheet which needs to be enqueued.

This very simple fix should prevent that, at least for the reported cases.

Includes unit test.