### PR TITLE
PrefixAllGlobals: improve error message clarity

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -367,7 +367,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 						return;
 					}
 
-					$error_text = 'Functions declared';
+					$error_text = 'Functions declared in the global namespace';
 					$error_code = 'NonPrefixedFunctionFound';
 					break;
 
@@ -555,7 +555,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$stackPtr,
 			'NonPrefixedVariableFound',
 			array(
-				'Variables defined',
+				'Global variables defined',
 				$variable_name,
 			)
 		);
@@ -705,7 +705,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$is_error,
 			'NonPrefixedVariableFound',
 			array(
-				'Variables defined',
+				'Global variables defined',
 				'$' . $variable_name,
 			)
 		);


### PR DESCRIPTION
When people run the sniffs without the `-s` option, the messages for some of the errors in this sniff were not specific enough as the "Prefix**AllGlobals**" part would not be seen.

I considered adjusting the error message template `ERROR_MSG`, however, this would cause more confusion as, for instance, namespace declarations will **always** be in the global namespace.

So, I've opted to adjust select error messages instead.

Issue identified by @justintadlock in https://github.com/WPTRT/WPThemeReview/issues/200#issuecomment-464789010