### PR TITLE
AlternativeFunctions: allow for php://input used with file_get_contents()

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -202,7 +202,13 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					return;
 				}
 
-				unset( $params );
+				$raw_stripped = $this->strip_quotes( $params[1]['raw'] );
+				if ( 'php://input' === $raw_stripped ) {
+					// This is not a file, but the read-only raw data stream from the request body.
+					return;
+				}
+
+				unset( $params, $raw_stripped );
 
 				break;
 		}

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -50,3 +50,4 @@ file_get_contents(MYABSPATH . 'plugin-file.json'); // Warning.
 file_get_contents( MUPLUGINDIR . 'some-file.xml' ); // OK.
 file_get_contents( plugin_dir_path( __FILE__ ) . 'subfolder/*.conf' ); // OK.
 file_get_contents(WP_Upload_Dir()['path'] . 'subdir/file.inc'); // OK.
+file_get_contents( 'php://input' ); // OK.


### PR DESCRIPTION
Reported by @remcotolsma in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/commit/49e7700073b7486077c95b37afe55d129b3e4881#commitcomment-32391794

While a little esoteric in a WP context, using the WP File Wrapper functions is not a suitable alternative when `php://input` is being read.

Includes unit test.

Note: an issue should probably be opened to check if any other sniffs should be adjusted to account for `php://input`. I have not verified this at this time, but the input validation sniff comes to mind.