### PR TITLE
Update PrefixAllGlobalsSniff with new core hook

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -119,6 +119,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	protected $whitelisted_core_hooks = array(
 		'widget_title'   => true,
 		'add_meta_boxes' => true,
+		'the_content'    => true,
 	);
 
 	/**

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -425,3 +425,6 @@ define(
 );
 
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]
+
+// OK: Additional core whitlisted prefixes
+$text = apply_filters( 'the_content', $text );


### PR DESCRIPTION
Added `the_content` to the list of whitelisted core hooks.

Related: https://github.com/WPTRT/theme-sniffer/issues/104

EDIT: We should also wait a bit, because there are extra hooks that we are missing (I'm still waiting on the issue report from people using the Theme Sniffer)