### PR TITLE
WP/AlternativeFunctions: allow for more input streams with file related functions

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -26,6 +26,47 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
+	 * Local input streams which should not be flagged for the file system function checks.
+	 *
+	 * @link http://php.net/manual/en/wrappers.php.php
+	 *
+	 * @var array
+	 */
+	protected $allowed_local_streams = array(
+		'php://input'  => true,
+		'php://output' => true,
+		'php://stdin'  => true,
+		'php://stdout' => true,
+		'php://stderr' => true,
+	);
+
+	/**
+	 * Local input streams which should not be flagged for the file system function checks if
+	 * the $filename starts with them.
+	 *
+	 * @link http://php.net/manual/en/wrappers.php.php
+	 *
+	 * @var array
+	 */
+	protected $allowed_local_stream_partials = array(
+		'php://temp/',
+		'php://fd/',
+	);
+
+	/**
+	 * Local input stream constants which should not be flagged for the file system function checks.
+	 *
+	 * @link http://php.net/manual/en/wrappers.php.php
+	 *
+	 * @var array
+	 */
+	protected $allowed_local_stream_constants = array(
+		'STDIN'  => true,
+		'STDOUT' => true,
+		'STDERR' => true,
+	);
+
+	/**
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
@@ -83,13 +124,13 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'since'     => '2.5.0',
 				'functions' => array(
 					'readfile',
-					'fopen',
-					'fsockopen',
-					'pfsockopen',
 					'fclose',
+					'fopen',
 					'fread',
 					'fwrite',
 					'file_put_contents',
+					'fsockopen',
+					'pfsockopen',
 				),
 			),
 
@@ -202,13 +243,34 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					return;
 				}
 
-				$raw_stripped = $this->strip_quotes( $params[1]['raw'] );
-				if ( 'php://input' === $raw_stripped ) {
-					// This is not a file, but the read-only raw data stream from the request body.
+				if ( $this->is_local_data_stream( $params[1]['raw'] ) === true ) {
+					// Local data stream.
 					return;
 				}
 
-				unset( $params, $raw_stripped );
+				unset( $params );
+
+				break;
+
+			case 'readfile':
+			case 'fopen':
+			case 'file_put_contents':
+				/*
+				 * Allow for handling raw data streams from the request body.
+				 */
+				$first_param = $this->get_function_call_parameter( $stackPtr, 1 );
+
+				if ( false === $first_param ) {
+					// If the file to work with is not set, local data streams don't come into play.
+					break;
+				}
+
+				if ( $this->is_local_data_stream( $first_param['raw'] ) === true ) {
+					// Local data stream.
+					return;
+				}
+
+				unset( $first_param );
 
 				break;
 		}
@@ -223,4 +285,29 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		}
 	}
 
+	/**
+	 * Determine based on the "raw" parameter value, whether a file parameter points to
+	 * a local data stream.
+	 *
+	 * @param string $raw_param_value Raw parameter value.
+	 *
+	 * @return bool True if this is a local data stream. False otherwise.
+	 */
+	protected function is_local_data_stream( $raw_param_value ) {
+
+		$raw_stripped = $this->strip_quotes( $raw_param_value );
+		if ( isset( $this->allowed_local_streams[ $raw_stripped ] )
+			|| isset( $this->allowed_local_stream_constants[ $raw_param_value ] )
+		) {
+			return true;
+		}
+
+		foreach ( $this->allowed_local_stream_partials as $partial ) {
+			if ( strpos( $raw_stripped, $partial ) === 0 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -51,3 +51,18 @@ file_get_contents( MUPLUGINDIR . 'some-file.xml' ); // OK.
 file_get_contents( plugin_dir_path( __FILE__ ) . 'subfolder/*.conf' ); // OK.
 file_get_contents(WP_Upload_Dir()['path'] . 'subdir/file.inc'); // OK.
 file_get_contents( 'php://input' ); // OK.
+
+// Loosely related to issue 295.
+file_get_contents( 'php://stdin' ); // OK.
+$input_stream = fopen( 'php://stdin', 'w' ); // OK.
+$csv_ar = fopen(STDIN); // OK.
+
+$output_stream = fopen( 'php://output', 'w' ); // OK.
+$output_stream = fopen( 'php://stdout', 'w' ); // OK.
+$output_stream = fopen( 'php://stderr', 'w' ); // OK.
+$output_stream = fopen( STDOUT, 'w' ); // OK.
+$output_stream = fopen( STDERR, 'w' ); // OK.
+$output_stream = fopen( 'php://fd/3', 'w' ); // OK.
+$fp = fopen("php://temp/maxmemory:$fiveMBs", 'r+'); // OK.
+readfile( 'php://filter/resource=http://www.example.com' ); // Warning.
+file_put_contents("php://filter/write=string.rot13/resource=example.txt","Hello World"); // Warning.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -40,13 +40,9 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			5  => 1,
 			6  => 1,
 			7  => 1,
-
 			10 => 1,
-
 			12 => 1,
-
 			14 => 1,
-
 			16 => 1,
 			17 => 1,
 			18 => 1,
@@ -60,13 +56,13 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			26 => 1,
 			27 => 1,
 			28 => 1,
-
 			40 => 1,
-
 			44 => 1,
 			46 => 1,
 			47 => 1,
 			49 => 1,
+			67 => 1,
+			68 => 1,
 		);
 	}
 


### PR DESCRIPTION
Similar to #1649 which allowed for using `php://input` with `file_get_contents()` and surprisingly inspired by the closing of issue #295.

This PR expands on the earlier work done in relation to the PHP native input streams by:
* recognizing more PHP native input streams;
* recognizing the PHP input stream constants;
* allowing for these in a number of the `file_system_read` group functions as well as for the `file_get_contents` function.

Refs:
* http://php.net/manual/en/wrappers.php.php
* http://php.net/manual/en/features.commandline.io-streams.php

Includes unit tests.

Related #1649
Related #295

Notes:
* I have not checked the WP FileSystem to see if it even could handle these input streams. If it can, we may need to discuss what is the preferred option in that case.
    Personally, this to me seems like something for which the WP FileSystem would be overkill/superfluous.
* At a later point in time, the new method + properties could be a candidate for moving to `Sniff` or a separate utility class.
    As no other sniffs currently need them though, this is not necessary at this moment and could possible be combined with/actioned when #1465 comes into play.