### PR TITLE
Docs: make the inclusion of the Generic sniff slightly more specific

### DIFF
--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -86,7 +86,7 @@
 		<exclude name="Squiz.Commenting.VariableComment.VarOrder"/>
 	</rule>
 
-	<rule ref="Generic.Commenting">
+	<rule ref="Generic.Commenting.DocComment">
 		<!-- WP has different alignment of tag values -->
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
 		<!-- WP has a different prefered order of tags -->
@@ -103,8 +103,5 @@
 		<exclude name="Generic.Commenting.DocComment.SpacingBeforeShort"/>
 		<!-- Exclude to allow duplicate hooks to be documented -->
 		<exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
-
-		<!-- WP allows @todo's in comments -->
-		<exclude name="Generic.Commenting.Todo"/>
 	</rule>
 </ruleset>


### PR DESCRIPTION
The `Generic.Commenting` category has three sniffs:
* `DocComment`
* `Todo`
* `Fixme`

As WP allows to do's and has no opinion on `FIXME` comments, we may as well just include the one sniff we actually need.