### PR TITLE
WP/AlternativeFunctions: allow calling `curl_version()`

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -273,6 +273,10 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				unset( $first_param );
 
 				break;
+
+			case 'curl_version':
+				// Curl version doesn't actually create a connection.
+				return;
 		}
 
 		if ( ! isset( $this->groups[ $group_name ]['since'] ) ) {

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -66,3 +66,5 @@ $output_stream = fopen( 'php://fd/3', 'w' ); // OK.
 $fp = fopen("php://temp/maxmemory:$fiveMBs", 'r+'); // OK.
 readfile( 'php://filter/resource=http://www.example.com' ); // Warning.
 file_put_contents("php://filter/write=string.rot13/resource=example.txt","Hello World"); // Warning.
+
+curl_version(); // OK.


### PR DESCRIPTION
`curl_version()` doesn't create or need a cURL resource, so is perfectly fine to use.

Ref: http://php.net/manual/en/function.curl-version.php