### PR TITLE
Core: forbid assignments in conditions

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -392,6 +392,13 @@
 	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
+	<!-- Rule: Assignments must not be placed in placed in conditionals.
+		 Note: sniff is a duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594
+		 Update: the "assignment in ternary" part of the sniff is currently not yet covered in
+		 the upstream version. This needs to be pulled first before we can defer to upstream. -->
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
+
 	<!-- Rule: In a switch statement... If a case contains a block, then falls through
 		 to the next block, this must be explicitly commented. -->
 	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -24,12 +24,6 @@
 		</properties>
 	</rule>
 
-	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
-		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594
-		 Note: the "assignment in ternary" part of the sniff is currently not yet covered in
-		 the upstream version. This needs to be pulled first before we can defer to upstream. -->
-	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
-
 	<!-- More generic PHP best practices.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
 	<rule ref="Squiz.PHP.NonExecutableCode"/>


### PR DESCRIPTION
Move the `WordPress.CodeAnalysis.AssignmentInCondition` from the `Extra` ruleset to the `Core` ruleset.

As per the proposal in https://make.wordpress.org/core/2019/03/26/coding-standards-updates-for-php-5-6/

Open actions:
* [x] Adjust Core PHP handbook to mention this rule in the `Clever code` section

/cc @pento 