### PR TITLE
Core: warn against the use of loose comparisons

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -392,6 +392,11 @@
 	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
+	<!-- Rule: Unless absolutely necessary, loose comparisons should not be used,
+		 as their behaviour can be misleading. -->
+	<rule ref="WordPress.PHP.StrictComparisons"/>
+	<rule ref="WordPress.PHP.StrictInArray"/>
+
 	<!-- Rule: Assignments must not be placed in placed in conditionals.
 		 Note: sniff is a duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
 		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -103,18 +103,9 @@
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/26 -->
 	<rule ref="WordPress.WP.GlobalVariablesOverride"/>
 
-	<!-- Encourage the use of strict ( === and !== ) comparisons.
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/242 -->
-	<rule ref="WordPress.PHP.StrictComparisons"/>
-
 	<!-- Detect incorrect or risky use of the `ini_set()` function.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1447 -->
 	<rule ref="WordPress.PHP.IniSet"/>
-
-	<!-- Check that in_array() and array_search() use strict comparisons.
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/399
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/503 -->
-	<rule ref="WordPress.PHP.StrictInArray"/>
 
 	<!-- Check enqueue and register styles and scripts to have version and in_footer parameters explicitly set.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1146 -->


### PR DESCRIPTION
As per the proposal in #1624, this moves the sniffs which `warn` against the use of loose comparisons from `Extra` to the `Core` ruleset.

Open actions:
* [x] Adjust Core PHP handbook to mention this rule in the `Clever code` section (or wherever else it should go).

/cc @pento 