### PR TITLE
Sniff::is_sanitized(): make the method more code style independent

### DIFF
--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -209,3 +209,5 @@ if ( $obj->array_key_exists( 'my_field4', $_POST ) ) {
 if ( ClassName::array_key_exists( 'my_field5', $_POST ) ) {
 	$id = (int) $_POST['my_field5']; // Bad.
 }
+
+echo sanitize_text_field (wp_unslash ($_GET['test'])); // OK.


### PR DESCRIPTION
Whether people comply with the WP style rules regarding whitespace and such, is irrelevant for determining whether or not a value is sanitized/unslashed.

This fixed a false positive where superglobals which were correctly unslashed/sanitized were not being recognized as such.

Includes unit test in the `ValidatedSanitizedInput` sniff.

Related to #763