### PR TITLE
GlobalVariablesOverride: implement the Sniff::is_foreach_as() method

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -321,17 +321,8 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			}
 
 			// Check if this is a variable assignment within a `foreach()` declaration.
-			if ( isset( $this->tokens[ $ptr ]['nested_parenthesis'] ) ) {
-				$nested_parenthesis = $this->tokens[ $ptr ]['nested_parenthesis'];
-				$close_parenthesis  = end( $nested_parenthesis );
-				if ( isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] )
-					&& \T_FOREACH === $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
-					&& ( false !== $previous
-						&& ( \T_DOUBLE_ARROW === $this->tokens[ $previous ]['code']
-						|| \T_AS === $this->tokens[ $previous ]['code'] ) )
-				) {
-					$this->maybe_add_error( $ptr );
-				}
+			if ( $this->is_foreach_as( $ptr ) === true ) {
+				$this->maybe_add_error( $ptr );
 			}
 		}
 	}


### PR DESCRIPTION
Removing some code duplication.