### PR TITLE
Improve global function call detection

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -213,7 +213,15 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	public function is_targetted_token( $stackPtr ) {
 
 		// Exclude function definitions, class methods, and namespaced calls.
-		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
+		if ( \T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( $this->is_class_object_call( $stackPtr ) === true ) {
+				return false;
+			}
+
+			if ( $this->is_token_namespaced( $stackPtr ) === true ) {
+				return false;
+			}
+
 			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 			if ( false !== $prev ) {
@@ -222,20 +230,10 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 					\T_FUNCTION        => \T_FUNCTION,
 					\T_CLASS           => \T_CLASS,
 					\T_AS              => \T_AS, // Use declaration alias.
-					\T_DOUBLE_COLON    => \T_DOUBLE_COLON,
-					\T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
 				);
 
 				if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
 					return false;
-				}
-
-				// Skip namespaced functions, ie: \foo\bar() not \bar().
-				if ( \T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
-					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
-					if ( false !== $pprev && \T_STRING === $this->tokens[ $pprev ]['code'] ) {
-						return false;
-					}
 				}
 			}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1461,23 +1461,12 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		if ( \T_STRING === $previous_code && 'array_key_exists' === $this->tokens[ $previous_non_empty ]['content'] ) {
-			$before_function = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $previous_non_empty - 1 ), null, true, null, true );
+			if ( $this->is_class_object_call( $previous_non_empty ) === true ) {
+				return false;
+			}
 
-			if ( false !== $before_function ) {
-				if ( \T_OBJECT_OPERATOR === $this->tokens[ $before_function ]['code']
-					|| \T_DOUBLE_COLON === $this->tokens[ $before_function ]['code']
-				) {
-					// Method call.
-					return false;
-				}
-
-				if ( \T_NS_SEPARATOR === $this->tokens[ $before_function ]['code'] ) {
-					$before_before = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $before_function - 1 ), null, true, null, true );
-					if ( false !== $before_before && \T_STRING === $this->tokens[ $before_before ]['code'] ) {
-						// Namespaced function call.
-						return false;
-					}
-				}
+			if ( $this->is_token_namespaced( $previous_non_empty ) === true ) {
+				return false;
 			}
 
 			$second_param = $this->get_function_call_parameter( $previous_non_empty, 2 );

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2726,10 +2726,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		if ( false !== $prev
-			&& \T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
-			&& \T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
-		) {
+		if ( $this->is_token_namespaced( $stackPtr ) === true ) {
 			// Namespaced constant of the same name.
 			return false;
 		}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1907,22 +1907,14 @@ abstract class Sniff implements PHPCS_Sniff {
 						continue 2;
 					}
 
-					$previous_non_empty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $i - 1 ), null, true, null, true );
-					if ( false !== $previous_non_empty ) {
-						if ( \T_OBJECT_OPERATOR === $this->tokens[ $previous_non_empty ]['code']
-							|| \T_DOUBLE_COLON === $this->tokens[ $previous_non_empty ]['code']
-						) {
-							// Method call.
-							continue 2;
-						}
+					if ( $this->is_class_object_call( $i ) === true ) {
+						// Method call.
+						continue 2;
+					}
 
-						if ( \T_NS_SEPARATOR === $this->tokens[ $previous_non_empty ]['code'] ) {
-							$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $previous_non_empty - 1 ), null, true, null, true );
-							if ( false !== $pprev && \T_STRING === $this->tokens[ $pprev ]['code'] ) {
-								// Namespaced function call.
-								continue 2;
-							}
-						}
+					if ( $this->is_token_namespaced( $i ) === true ) {
+						// Namespaced function call.
+						continue 2;
 					}
 
 					$params = $this->get_function_call_parameters( $i );

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -124,10 +124,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( false !== $prev
-			&& \T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
-			&& \T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
-		) {
+		if ( $this->is_token_namespaced( $stackPtr ) === true ) {
 			// Namespaced constant of the same name.
 			return;
 		}

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -310,8 +310,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			}
 
 			// Don't throw false positives for static class properties.
-			$previous = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
-			if ( false !== $previous && \T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {
+			if ( $this->is_class_object_call( $ptr ) === true ) {
 				continue;
 			}
 

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.inc
@@ -32,3 +32,8 @@ phpinfo(); // Ok - within excluded group.
 // phpcs:set WordPress.PHP.DevelopmentFunctions exclude[]
 trigger_error(); // Error.
 phpinfo(); // Error.
+
+Wrapper_Class::var_dump(); // OK, not the native PHP function.
+$wrapper ->var_dump(); // OK, not the native PHP function.
+namespace\var_dump(); // OK as long as the file is namespaced.
+MyNamespace\var_dump(); // OK, namespaced function.

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -42,7 +42,7 @@ define( 'My\STYLESHEETPATH', 'something' );
 if ( defined( 'STYLESHEETPATH' ) ) { // Ok.
 	// Do something unrelated.
 }
-
+echo namespace\STYLESHEETPATH; // "Magic" namespace operator.
 
 /*
  * These are all bad.


### PR DESCRIPTION
### `Sniff`: add two new utility methods `is_class_object_call()` and `is_token_namespaced()`

These should help make the checking of whether or not a function call is a global function, method call or a namespaced function call more consistent.

This also implements allowing for the [`namespace` keyword being used as an operator](https://www.php.net/manual/en/language.namespaces.nsconstants.php#example-258), though this may yield false negatives when the [operator is used in a non-namespaced file](https://www.php.net/manual/en/language.namespaces.nsconstants.php#example-259), but I rate the chances of that happening as small.

These functions will be unit tested by the implementations in various other places and the fact that the existing unit tests still pass after that.

Loosely related to #764

### Implement the new methods

In:
* `Sniff::is_in_isset_or_empty()`
* `Sniff::is_validated()`
* `Sniff::is_use_of_global_constant()`
* `AbstractFunctionRestrictionsSniff`
* `WordPress.WP.GlobalVariablesOverride`
* `WordPress.WP.DiscouragedConstants`