### PR TITLE
New utility method Sniff::is_in_function_call() + implement use of it

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1539,6 +1539,14 @@ abstract class Sniff implements PHPCS_Sniff {
 	/**
 	 * Check if a token is (part of) a parameter for a function call to a select list of functions.
 	 *
+	 * This is useful, for instance, when trying to determine the context a variable is used in.
+	 *
+	 * For example: this function could be used to determine if the variable `$foo` is used
+	 * in a global function call to the function `is_foo()`.
+	 * In that case, a call to this function would return the stackPtr to the T_STRING `is_foo`
+	 * for code like: `is_foo( $foo, 'some_other_param' )`, while it would return `false` for
+	 * the following code `is_bar( $foo, 'some_other_param' )`.
+	 *
 	 * @since 2.1.0
 	 *
 	 * @param int   $stackPtr        The index of the token in the stack.
@@ -1546,8 +1554,10 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *                               Note: The keys to this array should be the function names
 	 *                               in lowercase. Values are irrelevant.
 	 * @param bool  $global          Optional. Whether to make sure that the function call is
-	 *                               to a global function. If `false`, methods and namespaced
-	 *                               function calls will also be allowed.
+	 *                               to a global function. If `false`, calls to methods, be it static
+	 *                               `Class::method()` or via an object `$obj->method()`, and
+	 *                               namespaced function calls, like `MyNS\function_name()` will
+	 *                               also be accepted.
 	 *                               Defaults to `true`.
 	 * @param bool  $allow_nested    Optional. Whether to allow for nested function calls within the
 	 *                               call to this function.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1460,16 +1460,9 @@ abstract class Sniff implements PHPCS_Sniff {
 			return true;
 		}
 
-		if ( \T_STRING === $previous_code && 'array_key_exists' === $this->tokens[ $previous_non_empty ]['content'] ) {
-			if ( $this->is_class_object_call( $previous_non_empty ) === true ) {
-				return false;
-			}
-
-			if ( $this->is_token_namespaced( $previous_non_empty ) === true ) {
-				return false;
-			}
-
-			$second_param = $this->get_function_call_parameter( $previous_non_empty, 2 );
+		$functionPtr = $this->is_in_function_call( $stackPtr, array( 'array_key_exists' => true ) );
+		if ( false !== $functionPtr ) {
+			$second_param = $this->get_function_call_parameter( $functionPtr, 2 );
 			if ( $stackPtr >= $second_param['start'] && $stackPtr <= $second_param['end'] ) {
 				return true;
 			}

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -56,6 +56,15 @@ class CronIntervalSniff extends Sniff {
 	);
 
 	/**
+	 * Function within which the hook should be found.
+	 *
+	 * @var array
+	 */
+	protected $valid_functions = array(
+		'add_filter' => true,
+	);
+
+	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array
@@ -82,13 +91,18 @@ class CronIntervalSniff extends Sniff {
 		}
 
 		// If within add_filter.
-		$functionPtr = $this->phpcsFile->findPrevious( \T_STRING, key( $token['nested_parenthesis'] ) );
-		if ( false === $functionPtr || 'add_filter' !== $this->tokens[ $functionPtr ]['content'] ) {
+		$functionPtr = $this->is_in_function_call( $stackPtr, $this->valid_functions );
+		if ( false === $functionPtr ) {
 			return;
 		}
 
 		$callback = $this->get_function_call_parameter( $functionPtr, 2 );
 		if ( false === $callback ) {
+			return;
+		}
+
+		if ( $stackPtr >= $callback['start'] ) {
+			// "cron_schedules" found in the second parameter, not the first.
 			return;
 		}
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -211,3 +211,8 @@ if ( ClassName::array_key_exists( 'my_field5', $_POST ) ) {
 }
 
 echo sanitize_text_field (wp_unslash ($_GET['test'])); // OK.
+
+if ( isset( $_GET['unslash_check'] ) ) {
+	$clean = sanitize_text_field( WP_Faker::wp_unslash( $_GET['unslash_check'] ) ); // Bad x1 - unslash.
+	$clean = WP_Faker\sanitize_text_field( wp_unslash( $_GET['unslash_check'] ) ); // Bad x1 - sanitize.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -58,6 +58,8 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			202 => 1,
 			206 => 1,
 			210 => 1,
+			216 => 1,
+			217 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -52,7 +52,7 @@ add_filter( 'cron_schedules' ); // Ignore, no callback parameter.
 
 add_filter( 'cron_schedules', [ 'Foo', 'my_add_quicklier' ] ); // Error: 5 min.
 
-// Ignore, not our function. Currently gives false positive, will be fixed later when function call detection utility functions are added.
+// Ignore, not our function.
 My_Custom::add_filter( 'cron_schedules', [ 'Foo', 'my_add_quicklier' ] );
 
 // Deal correctly with the WP time constants.
@@ -139,3 +139,8 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	);
 	return $schedules;
 } ); // Error: 9 min.
+
+Custom::add_filter( 'cron_schedules', array( $class, $method ) ); // OK, not the WP function.
+add_filter( 'some_hook', array( $place, 'cron_schedules' ) ); // OK, not the hook we're looking for.
+add_filter( function() { return get_hook_name('cron_schedules'); }(), array( $class, $method ) ); // OK, nested in another function call.
+

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -45,7 +45,6 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			41  => 1,
 			43  => 1,
 			53  => 1,
-			56  => 1, // False positive.
 			67  => 1,
 			76  => 1,
 			85  => 1,


### PR DESCRIPTION
## New utility method `Sniff::is_in_function_call()`

Allows for checking whether a token is (part of) a parameter passed to a specific (set of) function(s).

Optionally checks whether the function call is to a global function.
Optionally only checks the "deepest" function call.

Returns the stack pointer to the `T_STRING` token for the function call or `false`.

Note: most of the time, it is more efficient to sniff from an outward structure-in, however, for some checks going from inside a structure-out works better.

This utility method is specifically for those situations.

### Sniff::is_in_isset_or_empty(): implement new `is_in_function_call()` method

This fixes potential false negatives when a method/namespaced function mirroring the name of the PHP array_key_exists() function would be used.

### Sniff::is_sanitized(): implement new `is_in_function_call()` method

This fixes potential false negatives when a method/namespaced function mirroring the name of the WP unslashing/sanitization functions would be used.

Includes unit test.

### CronInterval: implement new `Sniff::is_in_function_call()` method

This fixes some potential false positives.

Includes unit tests.