### PR TITLE
Sniff::$unslashingSanitizingFunctions: add doubleval() and count()

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -309,10 +309,13 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected $unslashingSanitizingFunctions = array(
 		'absint'       => true,
 		'boolval'      => true,
+		'count'        => true,
+		'doubleval'    => true,
 		'floatval'     => true,
 		'intval'       => true,
 		'is_array'     => true,
 		'sanitize_key' => true,
+		'sizeof'       => true,
 	);
 
 	/**

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -216,3 +216,12 @@ if ( isset( $_GET['unslash_check'] ) ) {
 	$clean = sanitize_text_field( WP_Faker::wp_unslash( $_GET['unslash_check'] ) ); // Bad x1 - unslash.
 	$clean = WP_Faker\sanitize_text_field( wp_unslash( $_GET['unslash_check'] ) ); // Bad x1 - sanitize.
 }
+
+function test_more_safe_functions() {
+	if ( ! isset( $_GET['test'] ) ) {
+		return;
+	}
+
+	$float = doubleval( $_GET['test'] ); // OK.
+	$count = count( $_GET['test'] ); // Issue #1659; OK.
+}


### PR DESCRIPTION
While `doubleval()` is an alias of `floatval()` and shouldn't be used, for the purposes of the `ValidatedSanitizedInput` sniff, both functions should be recognized.

And as `count()` doesn't actually access the data in the variable, but only counts the number of elements, it is also safe to use without unslashing/sanitizing the variable beforehand.
Same goes for the `sizeof()` alias of `count()`.

Includes unit tests.

Fixes #1659