### PR TITLE
Update default minimum_supported_version to WP 4.8

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -82,7 +82,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '4.7';
+	public $minimum_supported_version = '4.8';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -579,6 +579,11 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => 'wp_die()',
 			'version' => '3.0.0',
 		),
+		// Verified version & alternative.
+		'install_blog_defaults' => array(
+			'alt'     => 'wp_install_defaults',
+			'version' => '3.0.0',
+		),
 		'is_main_blog' => array(
 			'alt'     => 'is_main_site()',
 			'version' => '3.0.0',
@@ -1329,6 +1334,16 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'wp_ajax_press_this_save_post' => array(
 			'alt'     => '',
 			'version' => '4.9.0',
+		),
+
+		// WP 5.1.0.
+		'insert_blog' => array(
+			'alt'     => 'wp_insert_site()',
+			'version' => '5.1.0',
+		),
+		'install_blog' => array(
+			'alt'     => '',
+			'version' => '5.1.0',
 		),
 	);
 

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -143,6 +143,7 @@ get_user_details();
 get_usermeta();
 get_usernumposts();
 graceful_fail();
+install_blog_defaults();
 is_main_blog();
 is_site_admin();
 is_taxonomy();
@@ -319,10 +320,6 @@ use function popuplinks as something_else; // Related to issue #1306.
 post_form_autocomplete_off();
 wp_embed_handler_googlevideo();
 wp_get_sites();
-
-/*
- * Warning.
- */
 /* ============ WP 4.7 ============ */
 _sort_nav_menu_items();
 _usort_terms_by_ID();
@@ -330,6 +327,10 @@ _usort_terms_by_name();
 get_paged_template();
 wp_get_network();
 wp_kses_js_entities();
+
+/*
+ * Warning.
+ */
 /* ============ WP 4.8 ============ */
 wp_dashboard_plugins_output();
 /* ============ WP 4.9 ============ */
@@ -337,3 +338,6 @@ get_shortcut_link();
 is_user_option_local();
 wp_ajax_press_this_add_category();
 wp_ajax_press_this_save_post();
+/* ============ WP 5.1 ============ */
+insert_blog();
+install_blog();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 
-		$errors = array_fill( 8, 314, 1 );
+		$errors = array_fill( 8, 322, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
@@ -45,22 +45,23 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[80],
 			$errors[118],
 			$errors[125],
-			$errors[161],
-			$errors[174],
-			$errors[178],
-			$errors[210],
-			$errors[233],
-			$errors[251],
-			$errors[255],
-			$errors[262],
-			$errors[274],
-			$errors[281],
-			$errors[285],
-			$errors[290],
-			$errors[295],
-			$errors[303],
-			$errors[310],
-			$errors[318]
+			$errors[162],
+			$errors[175],
+			$errors[179],
+			$errors[211],
+			$errors[234],
+			$errors[252],
+			$errors[256],
+			$errors[263],
+			$errors[275],
+			$errors[282],
+			$errors[286],
+			$errors[291],
+			$errors[296],
+			$errors[304],
+			$errors[311],
+			$errors[319],
+			$errors[323]
 		);
 
 		return $errors;
@@ -73,10 +74,10 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 326, 14, 1 );
+		$warnings = array_fill( 335, 9, 1 );
 
 		// Unset the lines related to version comments.
-		unset( $warnings[326], $warnings[333], $warnings[335] );
+		unset( $warnings[336], $warnings[341] );
 
 		return $warnings;
 	}

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -48,6 +48,7 @@ the_author( 'deprecated', 'deprecated' );
 the_author_posts_link( 'deprecated' );
 trackback_rdf( 'deprecated' );
 trackback_url( 'deprecated' );
+unregister_setting( '', '', '', 'deprecated' );
 update_blog_option( '', '', '', 'deprecated' );
 update_user_status( '', '', '', 'deprecated' );
 wp_get_http_headers( '', 'deprecated' );
@@ -60,7 +61,6 @@ wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 4.7.
+// All will give an WARNING as they have been deprecated after WP 4.8.
 
 get_category_parents( '', '', '', '', array( 'deprecated') );
-unregister_setting( '', '', '', 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -27,7 +27,7 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		$errors = array_fill( 28, 34, 1 );
+		$errors = array_fill( 28, 35, 1 );
 
 		$errors[22] = 1;
 		$errors[23] = 1;
@@ -47,7 +47,6 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			65 => 1,
 			66 => 1,
 		);
 	}

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -70,7 +70,7 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="4.8"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 5.1 being out, it should now be 4.8.

Includes updating the list of deprecated functions. Input for this based on @JDGrimes's WP deprecated code scanner.