### PR TITLE
ValidatedSanitizedInput: allow for validation using key_exists()

### DIFF
--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -225,3 +225,8 @@ function test_more_safe_functions() {
 	$float = doubleval( $_GET['test'] ); // OK.
 	$count = count( $_GET['test'] ); // Issue #1659; OK.
 }
+
+function test_allow_array_key_exists_alias() {
+	if ( key_exists( 'my_field1', $_POST ) ) {
+	$id = (int) $_POST['my_field1']; // OK.
+}


### PR DESCRIPTION
This builds onto the previous enhancement made in #1635 which started recognizing `array_key_exists()` as a way to validate a variable.

`key_exists()` is an alias for `array_key_exists()` and while alias functions shouldn't be used,  for the purposes of the ValidatedSanitizedInput sniff, both functions should be recognized.

Includes unit test.

Notes:
* Removes the `array_key_exists()` method from the list of `$sanitizingFunctions` as it doesn't belong there and is now handled differently anyway (this should have been removed in #1635).
* Updates the version numbers for the change in the method documentation. We never released version 2.0.1, so both this change as well as the one from #1635 will now be released in 2.1.0.