### PR TITLE
ValidatedSanitizedInput/Sniff::is_validated(): allow for multi-level array key check

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -123,16 +123,16 @@ class ValidatedSanitizedInputSniff extends Sniff {
 			return;
 		}
 
-		$array_key = $this->get_array_access_key( $stackPtr );
+		$array_keys = $this->get_array_access_keys( $stackPtr );
 
-		if ( empty( $array_key ) ) {
+		if ( empty( $array_keys ) ) {
 			return;
 		}
 
 		$error_data = array( $this->tokens[ $stackPtr ]['content'] );
 
 		// Check for validation first.
-		if ( ! $this->is_validated( $stackPtr, $array_key, $this->check_validation_in_scope_only ) ) {
+		if ( ! $this->is_validated( $stackPtr, $array_keys, $this->check_validation_in_scope_only ) ) {
 			$this->phpcsFile->addError(
 				'Detected usage of a non-validated input variable: %s',
 				$stackPtr,

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -230,3 +230,30 @@ function test_allow_array_key_exists_alias() {
 	if ( key_exists( 'my_field1', $_POST ) ) {
 	$id = (int) $_POST['my_field1']; // OK.
 }
+
+function test_correct_multi_level_array_validation() {
+	if ( isset( $_POST['toplevel']['sublevel'] ) ) {
+		$id = (int) $_POST['toplevel']; // OK, if a subkey exists, the top level key *must* also exist.
+		$id = (int) $_POST['toplevel']['sublevel']; // OK.
+		$id = (int) $_POST['toplevel']['sublevel']['subsub']; // Bad x1 - validate, this sub has not been validated.
+	}
+
+	if ( array_key_exists( 'bar', $_POST['foo'] ) ) {
+		$id = (int) $_POST['bar']; // Bad x 1 - validate.
+		$id = (int) $_POST['foo']; // OK.
+		$id = (int) $_POST['foo']['bar']; // OK.
+		$id = (int) $_POST['foo']['bar']['baz']; // Bad x 1 - validate.
+	}
+}
+
+function test_correct_multi_level_array_validation_key_order() {
+	if ( isset( $_POST['toplevel']['sublevel'] ) ) {
+		$id = (int) $_POST['sublevel']['toplevel']; // Bad x 1 - validate - key order is wrong.
+	}
+}
+
+function test_invalid_array_key_exists_call() {
+	if ( array_key_exists( 'bar' ) ) {
+		$id = (int) $_POST['bar']; // Bad x 1 - validate.
+	}
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -60,6 +60,11 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			210 => 1,
 			216 => 1,
 			217 => 1,
+			238 => 1,
+			242 => 1,
+			245 => 1,
+			251 => 1,
+			257 => 1,
 		);
 	}
 


### PR DESCRIPTION
This PR builds onto earlier improvements to this sniff via PR #1634 and #1635

It adds a new `Sniff::get_array_access_keys()` utility method to retrieve _all_ array keys for a multi-level array access.
The original `Sniff::get_array_access_key()` method defers to the new method under the hood, however, the behaviour of that method has not changed.

It then implements the use of the new `get_array_access_keys()` method in the `WordPress.Security.ValidatedSanitizedInput` sniff and the `Sniff::is_validated()` method.

This allow for more precise checking of whether the correct variable has been validated properly before use.

This should prevent some false positives as well as false negatives.

Includes unit tests.