### PR TITLE
ValidatedSanitizedInput: make the error messages more informative

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -129,12 +129,12 @@ class ValidatedSanitizedInputSniff extends Sniff {
 			return;
 		}
 
-		$error_data = array( $this->tokens[ $stackPtr ]['content'] );
+		$error_data = array( $this->tokens[ $stackPtr ]['content'] . '[' . implode( '][', $array_keys ) . ']' );
 
 		// Check for validation first.
 		if ( ! $this->is_validated( $stackPtr, $array_keys, $this->check_validation_in_scope_only ) ) {
 			$this->phpcsFile->addError(
-				'Detected usage of a non-validated input variable: %s',
+				'Detected usage of a possibly undefined superglobal array index: %s. Use isset() or empty() to check the index exists before using it',
 				$stackPtr,
 				'InputNotValidated',
 				$error_data


### PR DESCRIPTION
This changes two things:
1. For both the `InputNotValidated` as well as the `InputNotSanitized` error, it will now display the array keys for the variable triggering the error.
    Previously, the message would just say `$_POST`, now it will say `$_POST['foo']['bar']`.
2. For the `InputNotValidated`, the error message text has been expanded to make it more obvious how to fix this issue.

Fixes #1541