### PR TITLE
Security: allow for type testing superglobals

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -145,6 +145,11 @@ class ValidatedSanitizedInputSniff extends Sniff {
 			return;
 		}
 
+		// If this variable is being tested with one of the `is_..()` functions, sanitization isn't needed.
+		if ( $this->is_in_type_test( $stackPtr ) ) {
+			return;
+		}
+
 		// If this is a comparison ('a' == $_POST['foo']), sanitization isn't needed.
 		if ( $this->is_comparison( $stackPtr ) ) {
 			return;

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -17,7 +17,7 @@ function ajax_process() {
 }
 add_action( 'wp_ajax_process', 'ajax_process' );
 
-// It's also OK to check with isset() before the the nonce check.
+// It's also OK to check with isset() before the nonce check.
 function foo() {
 	if ( ! isset( $_POST['test'] ) || ! wp_verify_nonce( 'some_action' ) ) {
 		exit;
@@ -159,4 +159,22 @@ function foo_8() {
 	do_something( $_POST['foo'] ); // Bad.
 	sanitize_pc( $_POST['bar'] ); // Bad.
 	my_nonce_check( sanitize_twitter( $_POST['tweet'] ) ); // Bad.
+}
+
+/*
+ * Using a superglobal in a is_...() function is OK as long as a nonce check is done
+ * before the variable is *really* used.
+ */
+function test_whitelisting_use_in_type_test_functions() {
+	if ( ! is_numeric ( $_POST['foo'] ) ) { // OK.
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}
+
+function test_incorrect_use_in_type_test_functions() {
+	if ( ! is_numeric ( $_POST['foo'] ) ) { // Bad.
+		return;
+	}
 }

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -46,6 +46,7 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			159 => 1,
 			160 => 1,
 			161 => 1,
+			177 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -257,3 +257,13 @@ function test_invalid_array_key_exists_call() {
 		$id = (int) $_POST['bar']; // Bad x 1 - validate.
 	}
 }
+
+function test_ignoring_is_type_function_calls() {
+	// Usage within variable type tests does not need unslashing or sanitization.
+	if ( isset( $_POST[ $key ] ) && is_numeric( $_POST[ $key ] ) ) {} // OK.
+	if ( isset($_POST['plugin']) && is_string( $_POST['plugin'] ) ) {} // OK.
+
+	if ( ! is_null( $_GET['not_set'] ) ) {} // Bad x1 - missing validation.
+	if ( array_key_exists( 'null', $_GET ) && ! is_null( $_GET['null'] ) ) {} // OK.
+	if ( array_key_exists( 'null', $_POST ) && $_POST['null'] !== null ) {} // OK.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -65,6 +65,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			245 => 1,
 			251 => 1,
 			257 => 1,
+			266 => 1,
 		);
 	}
 


### PR DESCRIPTION
When a superglobal variable is being tested with, for instance, `is_numeric()`, unslashing or sanitization are not needed and it's ok for the nonce check to be done after it. This is completely safe.
Ref: https://php.net/manual/en/ref.var.php

Using these type testing functions should however not be regarded as a way of sanitizing/unslashing the variable and the variable does still need to be validated before being passed to one of these functions.

To test whether a variable is used in one of these functions, a new `is_in_type_test()` method has been added to the `WordPressCS\Sniff` class, along with a `$typeTestFunctions` property containing the names of the functions this applies to.

Notes:
* The `is_array()` function which was previously, incorrectly, listed in the `$unslashingSanitizingFunctions` list has been moved to the new property.
    `is_array()` does not unslash or sanitize the contents of a variable, it only checks the variable type.
* Implemented the use of the new `Sniff::is_in_type_test()` method  in both the `ValidatedSanitizedInput` sniff, as well as in the `Sniff:has_nonce_check()` method for the `NonceVerification` sniff.

Includes unit tests via the sniffs.