### PR TITLE
Sniff::is_sanitized(): allow for map_deep() to sanitize arrays

### DIFF
--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -267,3 +267,12 @@ function test_ignoring_is_type_function_calls() {
 	if ( array_key_exists( 'null', $_GET ) && ! is_null( $_GET['null'] ) ) {} // OK.
 	if ( array_key_exists( 'null', $_POST ) && $_POST['null'] !== null ) {} // OK.
 }
+
+function test_additional_array_walking_functions() {
+	if ( ! isset( $_GET['test'] ) ) {
+		return;
+	}
+
+	$sane = map_deep( wp_unslash( $_GET['test'] ), 'sanitize_text_field' ); // Ok.
+	$sane = map_deep( wp_unslash( $_GET['test'] ), 'foo' ); // Bad.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -66,6 +66,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			251 => 1,
 			257 => 1,
 			266 => 1,
+			277 => 1,
 		);
 	}
 


### PR DESCRIPTION
Array sanitization via `array_map()` was already recognized. This PR adds recognition of array sanization using `map_deep()`.

**Important note:**
Functions which alter the array by reference, such as the PHP native `array_walk()` and `array_walk_recursive()` are not listed in the new `$arrayWalkingFunctions` property on purpose.

* These cannot easily be used for sanitization as they can't be combined with unslashing, so could only be used in combination with the `$unslashingSanitizingFunctions`.
    Additionally as they alter the array by reference, at this moment, accessing the array after the sanitization through one of these function would _still_ trigger errors.
    If at some point in the future, the above combination would be accounted for, preventing these additional errors would also need to be addressed.
* Similarly, they cannot be used for late escaping as the return value is a boolean, not the altered array.

Also see my comment in the original issue where I go into more detail: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1660#issuecomment-478254403

Includes unit test.

Fixes #1660
Fixes #1618

Once this has been merged, the [Sanitizing array input data](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Sanitizing-array-input-data) wiki page should probably be updated (or an issue be opened saying that it should be with a link to this PR and the tickets).