### PR TITLE
Sniff::has_nonce_check(): add `is_class_object_call()` and `is_token_namespaced()` checks

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1457,6 +1457,17 @@ abstract class Sniff implements PHPCS_Sniff {
 
 			// If this is one of the nonce verification functions, we can bail out.
 			if ( isset( $this->nonceVerificationFunctions[ $tokens[ $i ]['content'] ] ) ) {
+				/*
+				 * Now, make sure it is a call to a global function.
+				 */
+				if ( $this->is_class_object_call( $i ) === true ) {
+					continue;
+				}
+
+				if ( $this->is_token_namespaced( $i ) === true ) {
+					continue;
+				}
+
 				$last['nonce_check'] = $i;
 				return true;
 			}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -178,3 +178,14 @@ function test_incorrect_use_in_type_test_functions() {
 		return;
 	}
 }
+
+function fix_false_negatives_userland_method_same_name() {
+	WP_Faker::check_ajax_referer( 'something' );
+	$faker->check_admin_referer( 'something' );
+	do_something( $_POST['abc'] ); // Bad.
+}
+
+function fix_false_negatives_namespaced_function_same_name() {
+	WP_Faker\SecurityBypass\wp_verify_nonce( 'something' );
+	do_something( $_POST['abc'] ); // Bad.
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -47,6 +47,8 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			160 => 1,
 			161 => 1,
 			177 => 1,
+			185 => 1,
+			190 => 1,
 		);
 	}
 


### PR DESCRIPTION
This fixes potential false negatives when a method/namespaced function mirroring the name of the WP nonce verification functions would be used.

Includes unit tests.