### PR TITLE
EscapeOutput: allow for map_deep() to output escape arrays

### DIFF
--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -289,3 +289,6 @@ echo esc_html( $something ),
 echo get_the_title(); // Bad.
 echo wp_kses_post( get_the_title() ); // Ok.
 echo esc_html( get_the_title() ); // Ok.
+
+echo implode( '<br>', map_deep( $items, 'esc_html' ) ); // Ok.
+echo implode( '<br>', map_deep( $items, 'foo' ) ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -79,6 +79,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			264 => 1,
 			266 => 1,
 			289 => 1,
+			294 => 1,
 		);
 	}
 


### PR DESCRIPTION
Similar to #1679. 

Includes unit test.