### PR TITLE
ValidatedSanitizedInput: treat array-value comparison functions same as other comparisons

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -155,6 +155,11 @@ class ValidatedSanitizedInputSniff extends Sniff {
 			return;
 		}
 
+		// If this is a comparison using the array comparison functions, sanitization isn't needed.
+		if ( $this->is_in_array_comparison( $stackPtr ) ) {
+			return;
+		}
+
 		$this->mergeFunctionLists();
 
 		// Now look for sanitizing functions.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -276,3 +276,16 @@ function test_additional_array_walking_functions() {
 	$sane = map_deep( wp_unslash( $_GET['test'] ), 'sanitize_text_field' ); // Ok.
 	$sane = map_deep( wp_unslash( $_GET['test'] ), 'foo' ); // Bad.
 }
+
+function test_recognize_array_comparison_functions_as_such() {
+	if ( ! isset( $_POST['form_fields'] ) ) {
+		return;
+	}
+
+	if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], array( 'install', 'update', 'activate' ), true ) ) {} // OK.
+	if ( isset( $_REQUEST['plugin_state'] ) && in_array( $_REQUEST['plugin_state'], $states, true ) ) {} // OK.
+	if ( in_array( 'my_form_hidden_field_value', $_POST['form_fields'], true ) ) {} // OK.
+	if ( array_search( $_POST['form_fields'], 'my_form_hidden_field_value' ) ) {} // OK.
+	if ( array_keys( $_POST['form_fields'], 'my_form_hidden_field_value', true ) ) {} // OK.
+	if ( array_keys( $_POST['form_fields'] ) ) {} // Bad x2.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -67,6 +67,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			257 => 1,
 			266 => 1,
 			277 => 1,
+			290 => 2,
 		);
 	}
 


### PR DESCRIPTION
Whether a comparison is made via a comparison operator or via one of the array-value comparison functions shouldn't make a difference for this sniff. Both ways of making a comparison should be treated the same.

This was, so far, not the case. While `in_array()` was listed in the `$sanitizingFunctions` list, the other array-value comparison functions were not. And for `in_array()` a "missing unslash" error would still be thrown, while this doesn't happen when using straight comparisons.
At the same time, `in_array()` by itself does not_sanitize_ the value.

This PR fixes that and adds a new `is_in_array_comparison()` utility function to the `Sniff` class.

Includes unit tests via the sniff.