### PR TITLE
Sniff::has_nonce_check(): ignore nonce checks in nested closed scopes

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1468,6 +1468,16 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Loop through the tokens looking for nonce verification functions.
 		for ( $i = $start; $i < $end; $i++ ) {
+			// Skip over nested closed scope constructs.
+			if ( \T_FUNCTION === $tokens[ $i ]['code']
+				|| \T_CLOSURE === $tokens[ $i ]['code']
+				|| isset( Tokens::$ooScopeTokens[ $tokens[ $i ]['code'] ] )
+			) {
+				if ( isset( $tokens[ $i ]['scope_closer'] ) ) {
+					$i = $tokens[ $i ]['scope_closer'];
+				}
+				continue;
+			}
 
 			// If this isn't a function name, skip it.
 			if ( \T_STRING !== $tokens[ $i ]['code'] ) {

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -189,3 +189,23 @@ function fix_false_negatives_namespaced_function_same_name() {
 	WP_Faker\SecurityBypass\wp_verify_nonce( 'something' );
 	do_something( $_POST['abc'] ); // Bad.
 }
+
+function skip_over_nested_constructs_1() {
+	$b = function () {
+		check_ajax_referer( 'something' ); // Nonce check is not in the same function scope.
+	};
+
+	do_something( $_POST['abc'] ); // Bad.
+}
+
+function skip_over_nested_constructs_2() {
+	if ( $_POST['abc'] === 'test' ) { // Bad.
+		return;
+	}
+
+	$b = new class() {
+		public function named() {
+			check_ajax_referer( 'something' ); // Nonce check is not in the same function scope.
+		}
+	};
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -49,6 +49,8 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			177 => 1,
 			185 => 1,
 			190 => 1,
+			198 => 1,
+			202 => 1,
 		);
 	}
 


### PR DESCRIPTION
A function, closure, anonymous class and other OO constructs are all "closed" scopes.

If any of these are nested, they open a nested closed scope and anything within that scope should be disregarded for the purpose of verifying whether or not a nonce check has been executed.

This small change implements that.

This fixes some potential false negatives.

Includes unit tests.

Related to #764