### PR TITLE
ValidatedSanitizedInput: handle null coalesce (equal) correctly

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2229,12 +2229,24 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * Also recognizes `switch ( $var )`.
 	 *
 	 * @since 0.5.0
+	 * @since 2.1.0 Added the $include_coalesce parameter.
 	 *
-	 * @param int $stackPtr The index of this token in the stack.
+	 * @param int  $stackPtr         The index of this token in the stack.
+	 * @param bool $include_coalesce Optional. Whether or not to regard the null
+	 *                               coalesce operator - ?? - as a comparison operator.
+	 *                               Defaults to true.
+	 *                               Null coalesce is a special comparison operator in this
+	 *                               sense as it doesn't compare a variable to whatever is
+	 *                               on the other side of the comparison operator.
 	 *
 	 * @return bool Whether this is a comparison.
 	 */
-	protected function is_comparison( $stackPtr ) {
+	protected function is_comparison( $stackPtr, $include_coalesce = true ) {
+
+		$comparisonTokens = Tokens::$comparisonTokens;
+		if ( false === $include_coalesce ) {
+			unset( $comparisonTokens[ \T_COALESCE ] );
+		}
 
 		// We first check if this is a switch statement (switch ( $var )).
 		if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
@@ -2258,7 +2270,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			true
 		);
 
-		if ( isset( Tokens::$comparisonTokens[ $this->tokens[ $previous_token ]['code'] ] ) ) {
+		if ( isset( $comparisonTokens[ $this->tokens[ $previous_token ]['code'] ] ) ) {
 			return true;
 		}
 
@@ -2281,7 +2293,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			);
 		}
 
-		if ( false !== $next_token && isset( Tokens::$comparisonTokens[ $this->tokens[ $next_token ]['code'] ] ) ) {
+		if ( false !== $next_token && isset( $comparisonTokens[ $this->tokens[ $next_token ]['code'] ] ) ) {
 			return true;
 		}
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -151,7 +151,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// If this is a comparison ('a' == $_POST['foo']), sanitization isn't needed.
-		if ( $this->is_comparison( $stackPtr ) ) {
+		if ( $this->is_comparison( $stackPtr, false ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -161,7 +161,7 @@ some string {$_POST[some_var]} {$_GET['evil']}
 EOD
 ); // Bad x2.
 
-if ( ( $_POST['foo'] ?? 'post' ) === 'post' ) {} // OK.
+if ( ( $_POST['foo'] ?? 'post' ) === 'post' ) {} // Bad x2 - unslash, sanitize - more complex compares are not handled.
 if ( ( $_POST['foo'] <=> 'post' ) === 0 ) {} // OK.
 
 // Test whitespace independent isset/empty detection.
@@ -288,4 +288,37 @@ function test_recognize_array_comparison_functions_as_such() {
 	if ( array_search( $_POST['form_fields'], 'my_form_hidden_field_value' ) ) {} // OK.
 	if ( array_keys( $_POST['form_fields'], 'my_form_hidden_field_value', true ) ) {} // OK.
 	if ( array_keys( $_POST['form_fields'] ) ) {} // Bad x2.
+}
+
+/*
+ * Test recognition of validation via null coalesce, while still checking the var for sanitization.
+ */
+function test_null_coalesce_1() {
+	$var = sanitize_text_field( wp_unslash( $_POST['foo'] ?? '' ) ); // OK.
+	$var = sanitize_text_field( wp_unslash( $_POST['fool'] ?? $_POST['secondary'] ?? '' ) ); // OK.
+	$var = sanitize_text_field( wp_unslash( $_POST['bar']['sub'] ?? '' ) ); // OK.
+	$var = sanitize_text_field( $_POST['foobar'] ?? '' ); // Bad x1 - unslash.
+}
+
+// The below two sets should give the same errors.
+function test_null_coalesce_2() {
+	$var = $_POST['foo'] ?? ''; // Bad x2 - sanitize + unslash.
+	$var = $_POST['bar']['sub'] ?? ''; // Bad x2 - sanitize + unslash.
+	$var = ( $_POST['foobar']['sub'] ?? '' ); // Bad x2 - sanitize + unslash.
+
+	$var = isset( $_POST['_foo'] ) ? $_POST['_foo'] : ''; // Bad x2 - sanitize + unslash.
+	$var = isset( $_POST['_bar']['_sub'] ) ? $_POST['_bar']['_sub'] : ''; // Bad x2 - sanitize + unslash.
+	$var = ( isset( $_POST['_foobar']['_sub'] ) ? $_POST['_foobar']['_sub'] : '' ); // Bad x2 - sanitize + unslash.
+}
+
+function test_null_coalesce_validation() {
+	$_POST['key'] = $_POST['key'] ?? 'default'; // OK, assignment & Bad x2 - unslash, sanitize.
+	$key            = sanitize_text_field( wp_unslash( $_POST['key'] ) ); // OK, validated via null coalesce.
+	$another_key    = sanitize_text_field( wp_unslash( $_POST['another_key'] ) ); // Bad, not validated, different key.
+}
+
+function test_null_coalesce_equals_validation() {
+	$_POST['key'] ??= 'default'; // OK, assignment.
+	$key            = sanitize_text_field( wp_unslash( $_POST['key'] ) ); // OK, validated via null coalesce equals.
+	$another_key    = sanitize_text_field( wp_unslash( $_POST['another_key'] ) ); // Bad, not validated, different key.
 }

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -54,6 +54,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			138 => 1,
 			150 => 2,
 			160 => 2,
+			164 => 2,
 			189 => 1,
 			202 => 1,
 			206 => 1,
@@ -68,6 +69,16 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			266 => 1,
 			277 => 1,
 			290 => 2,
+			300 => 1,
+			305 => 2,
+			306 => 2,
+			307 => 2,
+			309 => 2,
+			310 => 2,
+			311 => 2,
+			315 => 2,
+			317 => 1,
+			323 => 1,
 		);
 	}
 


### PR DESCRIPTION
PHP 7.0 introduced the null coalesce operator, while PHP 7.4 will introduce the null coalesce equal operator.

These operators should be accounted for in the `ValidatedSanitizedInput` sniff as valid ways to validate a variable, but should still allow for the sniff to *also* check for sanitization.

Refs:
* https://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.coalesce
* https://wiki.php.net/rfc/isset_ternary
* https://wiki.php.net/rfc/null_coalesce_equal_operator

Related to #764

Includes unit tests.

Fixes #837
Closes #840 which is superseded by this PR

---

As part of this PR, two methods in the `Sniff` class received changes:

### Sniff::is_comparison(): allow to disregard null coalesce

The null coalesce operator `??` is a special comparison operator, in the sense that it doesn't compare a variable to whatever is on the other side of the comparison operator.

For this reason, it should be possible to disregard it.

### Sniff::is_validated(): recognize null coalesce (equal) operator as a way to validate a variable

This adds recognition of the coalesce operator `??` (PHP 7.0) and the coalesce equals operator `??=`, as will be added in PHP 7.4, to the `Sniff::is_validated()` method.

This prevents false positives where variables would be seen as "not validated", when the variable has in fact been validated via a coalesce equals assignment in a previous statement.

Related to #764, #840
