### PR TITLE
Sniff::has_nonce_check(): allow for comparing a variable before nonce check

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1440,6 +1440,8 @@ abstract class Sniff implements PHPCS_Sniff {
 		$allow_nonce_after = false;
 		if ( $this->is_in_isset_or_empty( $stackPtr )
 			|| $this->is_in_type_test( $stackPtr )
+			|| $this->is_comparison( $stackPtr )
+			|| $this->is_in_array_comparison( $stackPtr )
 		) {
 			$allow_nonce_after = true;
 		}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -209,3 +209,40 @@ function skip_over_nested_constructs_2() {
 		}
 	};
 }
+
+// Issue #1506
+function allow_for_compare_before_noncecheck() {
+	if (
+		'newsletter_sign_up' === $_POST['action'] && // OK.
+		wp_verify_nonce( $_POST['newsletter_nonce'] )
+	) {}
+}
+
+// Issue #1114
+function allow_for_nonce_check_within_switch() {
+	if ( ! isset( $_REQUEST['action'] ) ) {
+		return;
+	}
+
+	switch ( $_REQUEST['action'] ) { // OK.
+		case 'foo':
+			check_admin_referer( 'foo' );
+			break;
+		case 'bar':
+			check_admin_referer( 'bar' );
+			break;
+	}
+}
+
+function allow_for_array_compare_before_noncecheck() {
+	if ( array_search( array( 'subscribe', 'unsubscribe', $_POST['action'], true ) // OK.
+		&& wp_verify_nonce( $_POST['newsletter_nonce'] )
+	) {}
+}
+
+function allow_for_array_comparison_in_condition() {
+	if ( in_array( $_GET['action'], $valid_actions, true ) ) { // OK.
+		check_admin_referer( 'foo' );
+		foo();
+	}
+}


### PR DESCRIPTION
This builds onto the similar changes made for the `ValidatedSanitizedInput` sniff in #1682.

This fixes false positives as reported in #1114 and #1506.

Note: it is not currently checked that the nonce check is done within the same conditional scope as the comparison. Just that it is done within the same _function_ scope.

Includes unit tests.

Fixes #1114
Fixes #1506