### PR TITLE
ValidatedSanitizedInput: allow for more unslashing functions

### DIFF
--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -322,3 +322,12 @@ function test_null_coalesce_equals_validation() {
 	$key            = sanitize_text_field( wp_unslash( $_POST['key'] ) ); // OK, validated via null coalesce equals.
 	$another_key    = sanitize_text_field( wp_unslash( $_POST['another_key'] ) ); // Bad, not validated, different key.
 }
+
+function test_using_different_unslashing_functions() {
+	if ( ! isset( $_GET['test'] ) ) {
+		return;
+	}
+
+	$sane = sanitize_text_field(stripslashes_deep($_GET['test'])); // Ok.
+	$sane = sanitize_text_field( stripslashes_from_strings_only( $_GET['test'] ) ); // OK.
+}


### PR DESCRIPTION
As correctly pointed out by @sybrew in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/869#issuecomment-478329921 and confirmed via a trace-back of the functions used by `wp_unslash()`, WP contains two additional unslashing functions which are perfectly valid to use for unslashing received data.

Refs:
* https://developer.wordpress.org/reference/functions/wp_unslash/
* https://developer.wordpress.org/reference/functions/stripslashes_deep/
* https://developer.wordpress.org/reference/functions/stripslashes_from_strings_only/

This commit adds allowance for using these. It also updates the error message to reflect this.

Includes unit tests.