### PR TITLE
Sniff::has_nonce_check(): allow for unslashing a variable before nonce check

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1455,6 +1455,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			|| $this->is_in_type_test( $stackPtr )
 			|| $this->is_comparison( $stackPtr )
 			|| $this->is_in_array_comparison( $stackPtr )
+			|| $this->is_in_function_call( $stackPtr, $this->unslashingFunctions ) !== false
 		) {
 			$allow_nonce_after = true;
 		}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -246,3 +246,21 @@ function allow_for_array_comparison_in_condition() {
 		foo();
 	}
 }
+
+# Issue #572.
+function allow_for_unslash_before_noncecheck_but_demand_noncecheck() {
+	$var = wp_unslash( $_POST['foo'] ); // Bad.
+	echo $var;
+}
+
+function allow_for_unslash_before_noncecheck() {
+	$var = stripslashes_from_strings_only( $_POST['foo'] ); // OK.
+	wp_verify_nonce( $var );
+	echo $var;
+}
+
+function allow_for_unslash_in_sanitization() {
+	$var = sanitize_text_field( wp_unslash( $_POST['foo'] ) ); // OK.
+	wp_verify_nonce( $var );
+	echo $var;
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -51,6 +51,7 @@ class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			190 => 1,
 			198 => 1,
 			202 => 1,
+			252 => 1,
 		);
 	}
 


### PR DESCRIPTION
This also gets rid of a bug were sanitization was not recognized as such if the call to `wp_unslash()` was nested inside it.

Includes unit tests.

Fixes #572