### PR TITLE
Add missing WP global variable `$current_blog`

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -638,6 +638,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'compress_css'                     => true,
 		'compress_scripts'                 => true,
 		'concatenate_scripts'              => true,
+		'current_blog'                     => true,
 		'current_screen'                   => true,
 		'current_site'                     => true,
 		'current_user'                     => true,


### PR DESCRIPTION
I encountered a missing global variable called `$current_blog`.

It is used for Multisite installations and referes to the current site, just as `$current_site` (which is included in the list) refers to the current network.