### PR TITLE
NonceVerification: improve handling of nested functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1441,13 +1441,15 @@ abstract class Sniff implements PHPCS_Sniff {
 		$tokens = $this->phpcsFile->getTokens();
 
 		// If we're in a function, only look inside of it.
-		$f = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
-		if ( false !== $f ) {
-			$start = $tokens[ $f ]['scope_opener'];
-		} else {
-			$f = $this->phpcsFile->getCondition( $stackPtr, \T_CLOSURE );
-			if ( false !== $f ) {
-				$start = $tokens[ $f ]['scope_opener'];
+		// Once PHPCS 3.5.0 comes out this should be changed to the new Conditions::GetLastCondition() method.
+		if ( isset( $tokens[ $stackPtr ]['conditions'] ) === true ) {
+			$conditions = $tokens[ $stackPtr ]['conditions'];
+			$conditions = array_reverse( $conditions, true );
+			foreach ( $conditions as $tokenPtr => $condition ) {
+				if ( \T_FUNCTION === $condition || \T_CLOSURE === $condition ) {
+					$start = $tokens[ $tokenPtr ]['scope_opener'];
+					break;
+				}
 			}
 		}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -247,7 +247,7 @@ function allow_for_array_comparison_in_condition() {
 	}
 }
 
-# Issue #572.
+// Issue #572.
 function allow_for_unslash_before_noncecheck_but_demand_noncecheck() {
 	$var = wp_unslash( $_POST['foo'] ); // Bad.
 	echo $var;
@@ -275,3 +275,29 @@ function dont_allow_bypass_nonce_via_sanitization() {
 	wp_verify_nonce( $var );
 	echo $var;
 }
+
+// Issue #1694
+function function_containing_nested_class() {
+	if ( !class_exists( 'Nested_Class' ) ) {
+		class Nested_Class extends Something {
+			public function method_in_nested_class() {
+				if ( isset( $_POST['my_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce'] ) ), 'the_nonce' ) ) {
+					if ( isset( $_POST['hello'] ) ) {
+						echo 'world';
+					}
+				}
+			}
+		}
+	}
+}
+
+function function_containing_nested_closure() {
+	$closure = function() {
+		if ( isset( $_POST['my_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce'] ) ), 'the_nonce' ) ) {
+			if ( isset( $_POST['hello'] ) ) {
+				echo 'world';
+			}
+		}
+	};
+}
+


### PR DESCRIPTION
The `Sniff::has_nonce_verification()` method would determine the scope within which to look for a nonce verification function based on the first function condition of the `$stackPtr` being examined.

This breaks when closures/functions are nested within other functions, as the code within those nested constructs will be ignored, while instead, that should be the code which should be examined.

By changing the start point of the scope within which the method looks for nonce verification functions to the deepest nested function, this use-case is handled correctly.

Note that PHPCS 3.5.0 is expected to contain a utility function which can largely replace the code which was now added. Once PHPCS 3.5.0 has been released and WPCS ups it's minimum version requirement, this change should be made.

Fixes #1694