### PR TITLE
Accept tag_ID as variable name

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -741,6 +741,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'table_prefix'                     => true,
 		'tabs'                             => true,
 		'tag'                              => true,
+		'tag_ID'                           => true,
 		'targets'                          => true,
 		'tax'                              => true,
 		'taxnow'                           => true,

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -51,6 +51,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		'PHP_SELF'          => true,
 		'post_ID'           => true,
 		'user_ID'           => true,
+		'tag_ID'            => true,
 	);
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -50,8 +50,8 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		'is_winIE'          => true,
 		'PHP_SELF'          => true,
 		'post_ID'           => true,
-		'user_ID'           => true,
 		'tag_ID'            => true,
+		'user_ID'           => true,
 	);
 
 	/**


### PR DESCRIPTION
WordPress has a global variable `$tag_ID`, used for example in `wp-admin/edit-tags.php` or `wp-admin/term.php`. It should be accepted as an exception for the valid variable name sniff.