### PR TITLE
CapitalPDangit: ignore misspellings in constant declarations

### DIFF
--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -188,6 +188,24 @@ class CapitalPDangitSniff extends Sniff {
 			}
 		}
 
+		// Ignore constant declarations via define().
+		if ( $this->is_in_function_call( $stackPtr, array( 'define' => true ), true, true ) ) {
+			return;
+		}
+
+		// Ignore constant declarations using the const keyword.
+		$stop_points = array(
+			\T_CONST,
+			\T_SEMICOLON,
+			\T_OPEN_TAG,
+			\T_CLOSE_TAG,
+			\T_OPEN_CURLY_BRACKET,
+		);
+		$maybe_const = $this->phpcsFile->findPrevious( $stop_points, ( $stackPtr - 1 ) );
+		if ( false !== $maybe_const && \T_CONST === $this->tokens[ $maybe_const ]['code'] ) {
+			return;
+		}
+
 		$content = $this->tokens[ $stackPtr ]['content'];
 
 		if ( preg_match_all( self::WP_REGEX, $content, $matches, ( \PREG_PATTERN_ORDER | \PREG_OFFSET_CAPTURE ) ) > 0 ) {

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
@@ -180,3 +180,11 @@ wordpress.pot
 $text = <<<'EOD'
 This is an explanation about word-press.
 EOD;
+
+// Issue 1698 - ignore constant declarations.
+define( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
+class TestMe {
+	public const MY_CONST = 123,
+		ANOTHER => array( 'a' => 'b' ),
+		WORDPRESS_SOMETHING = 'wordpress'; // OK (complex declaration to make sure start of statement is detected correctly).
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
@@ -180,3 +180,11 @@ wordpress.pot
 $text = <<<'EOD'
 This is an explanation about WordPress.
 EOD;
+
+// Issue 1698 - ignore constant declarations.
+define( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
+class TestMe {
+	public const MY_CONST = 123,
+		ANOTHER => array( 'a' => 'b' ),
+		WORDPRESS_SOMETHING = 'wordpress'; // OK (complex declaration to make sure start of statement is detected correctly).
+}


### PR DESCRIPTION
Just like in array declarations, when `wordpress` is spelled incorrectly in constant declarations, this will be a false positive in 90% of the cases, so just ignore it.

Fixes #1698