### PR TITLE
Remove paginate_comments_links from escaped functions list

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -202,7 +202,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		'get_the_ID'                => true,
 		'get_the_post_thumbnail'    => true,
 		'get_the_term_list'         => true,
-		'paginate_comments_links'   => true,
 		'post_type_archive_title'   => true,
 		'readonly'                  => true,
 		'selected'                  => true,


### PR DESCRIPTION
Remove `paginate_comments_links` from escaped functions list as it uses `paginate_links` on echo and return which is not a safe function.