### PR TITLE
Sniff::is_test_class(): recognize `TestCase`

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -861,6 +861,8 @@ abstract class Sniff implements PHPCS_Sniff {
 		'WP_XMLRPC_UnitTestCase'                     => true,
 		'PHPUnit_Framework_TestCase'                 => true,
 		'PHPUnit\Framework\TestCase'                 => true,
+		// PHPUnit native TestCase class when imported via use statement.
+		'TestCase'                                   => true,
 	);
 
 	/**

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
@@ -2,5 +2,5 @@
 phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
 <?php
 
-class TestCase extends TestSample {}
+class MyUnitTest extends TestSample {}
 /* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.5.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.5.inc
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Test_Class_D extends TestCase {
+
+	public function test_something() {
+		global $tabs;
+		$tabs = 50; // Ok.
+	}
+}


### PR DESCRIPTION
What with WP dropping support for PHP 5.2, I expect that more and more projects will start to use `use` statements in their code.

When the PHPUnit native `PHPUnit\Framework\TestCase` is imported via a `use` statement and then `extend`ed, the WPCS sniffs would not recognize the extending class as a test class.

Adding `TestCase` to the default test class whitelist fixes this.

While this means that any class extending the quite genericly named `TestCase` will now be recognized as a test class, even when the `TestCase` in question is not the PHPUnit native one, I think it's safe to assume that even when it's not the PHPUnit native one, it _will_ be a test base class and for WPCS purposes the extending class can be marked as a test class.

Includes unit test via the `GlobalVariablesOverride` sniff.

Includes adjusting an existing unit test for the `FileName` sniff to still test what it was testing before.