### PR TITLE
Update default minimum_supported_version to WP 4.9

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -82,7 +82,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '4.8';
+	public $minimum_supported_version = '4.9';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -327,12 +327,12 @@ _usort_terms_by_name();
 get_paged_template();
 wp_get_network();
 wp_kses_js_entities();
+/* ============ WP 4.8 ============ */
+wp_dashboard_plugins_output();
 
 /*
  * Warning.
  */
-/* ============ WP 4.8 ============ */
-wp_dashboard_plugins_output();
 /* ============ WP 4.9 ============ */
 get_shortcut_link();
 is_user_option_local();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 
-		$errors = array_fill( 8, 322, 1 );
+		$errors = array_fill( 8, 324, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
@@ -61,7 +61,8 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[304],
 			$errors[311],
 			$errors[319],
-			$errors[323]
+			$errors[323],
+			$errors[330]
 		);
 
 		return $errors;
@@ -74,10 +75,10 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 335, 9, 1 );
+		$warnings = array_fill( 337, 7, 1 );
 
 		// Unset the lines related to version comments.
-		unset( $warnings[336], $warnings[341] );
+		unset( $warnings[341] );
 
 		return $warnings;
 	}

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -34,6 +34,7 @@ comments_link( 'deprecated', 'deprecated' );
 comments_number( '', '', '', 'deprecated' );
 convert_chars( '', 'deprecated' );
 discover_pingback_server_uri( '', 'deprecated' );
+get_category_parents( '', '', '', '', array( 'deprecated') );
 get_delete_post_link( '', 'deprecated' );
 get_last_updated( 'deprecated' );
 get_the_author( 'deprecated' );
@@ -61,6 +62,4 @@ wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 4.8.
-
-get_category_parents( '', '', '', '', array( 'deprecated') );
+// All will give an WARNING as they have been deprecated after WP 4.9.

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -27,7 +27,7 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		$errors = array_fill( 28, 35, 1 );
+		$errors = array_fill( 28, 36, 1 );
 
 		$errors[22] = 1;
 		$errors[23] = 1;
@@ -35,7 +35,7 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 
 		// Override number of errors.
 		$errors[33] = 2;
-		$errors[47] = 2;
+		$errors[48] = 2;
 
 		return $errors;
 	}
@@ -46,9 +46,7 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			66 => 1,
-		);
+		return array();
 	}
 
 }

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -70,7 +70,7 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.8"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 5.2 being out, it should now be 4.9.

Includes (not) updating the list of deprecated functions. Input for this based on @JDGrimes's WP deprecated code scanner.