### PR TITLE
Travis: run the code style related and ruleset checks in separate stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
         - diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml")
         - diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample")
 
-    # Make sure the rulesets don't thrown unexpected errors or warnings.
+    # Make sure the rulesets don't throw unexpected errors or warnings.
     # This check needs to be run against a high PHP version to prevent triggering the syntax error check.
     # It also needs to be run against all PHPCS versions WPCS is tested against.
     - stage: rulesets

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,67 @@ env:
   # Lowest supported release in the 3.x series with which WPCS is compatible.
   - PHPCS_BRANCH="3.3.1"
 
-matrix:
+stages:
+  - sniff
+  - rulesets
+  - test
+
+jobs:
   fast_finish: true
   include:
-    # Run PHPCS against WPCS. I just picked to run it against 7.2.
-    - php: 7.2
-      env: PHPCS_BRANCH="dev-master" SNIFF=1
+    - stage: sniff
+      php: 7.3
+      env: PHPCS_BRANCH="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
+      script:
+        # WordPress Coding Standards.
+        # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+        # @link http://pear.php.net/package/PHP_CodeSniffer/
+        - $(pwd)/vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1
+
+        # Validate the xml files.
+        # @link http://xmlsoft.org/xmllint.html
+        # For the build to properly error when validating against a scheme, these each have to be in their own condition.
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample
+
+        # Check the code-style consistency of the xml files.
+        - diff -B --tabsize=4 ./WordPress/ruleset.xml <(xmllint --format "./WordPress/ruleset.xml")
+        - diff -B --tabsize=4 ./WordPress-Core/ruleset.xml <(xmllint --format "./WordPress-Core/ruleset.xml")
+        - diff -B --tabsize=4 ./WordPress-Docs/ruleset.xml <(xmllint --format "./WordPress-Docs/ruleset.xml")
+        - diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml")
+        - diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample")
+
+    # Make sure the rulesets don't thrown unexpected errors or warnings.
+    # This check needs to be run against a high PHP version to prevent triggering the syntax error check.
+    # It also needs to be run against all PHPCS versions WPCS is tested against.
+    - stage: rulesets
+      php: 7.3
+      env: PHPCS_BRANCH="dev-master"
+      script:
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Core
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Docs
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Extra
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress
+
+        # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
+        # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
+        # For the first run, the exit code will be 1 (= all fixable errors fixed).
+        # `travis_retry` should then kick in to run the fixer again which should now return 0 (= no fixable errors found).
+        # All error codes for the PHPCBF: https://github.com/squizlabs/PHP_CodeSniffer/issues/1270#issuecomment-272768413
+        - travis_retry $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary
+
+    - stage: rulesets
+      php: 7.3
+      env: PHPCS_BRANCH="3.3.1"
+      script:
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Core
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Docs
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Extra
+        - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -51,7 +102,7 @@ before_install:
     - export PHPUNIT_DIR=/tmp/phpunit
     - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --update-no-dev --no-suggest --no-scripts
     - |
-      if [[ "$SNIFF" == "1" ]]; then
+      if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" ]]; then
           composer install --dev --no-suggest
           # The `dev` required DealerDirect Composer plugin takes care of the installed_paths.
       else
@@ -63,42 +114,17 @@ before_install:
     - if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then wget -P $PHPUNIT_DIR https://phar.phpunit.de/phpunit-7.phar && chmod +x $PHPUNIT_DIR/phpunit-7.phar; fi
 
 script:
-    # Lint the PHP files against parse errors.
-    - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
-    # Run the unit tests.
-    - |
-      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-        php $PHPUNIT_DIR/phpunit-7.phar --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
-      else
-        phpunit --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
-      fi
-    # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
-    # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
-    # For the first run, the exit code will be 1 (= all fixable errors fixed).
-    # `travis_retry` should then kick in to run the fixer again which should now return 0 (= no fixable errors found).
-    # All error codes for the PHPCBF: https://github.com/squizlabs/PHP_CodeSniffer/issues/1270#issuecomment-272768413
-    - if [[ "$SNIFF" == "1" ]]; then travis_retry $(pwd)/vendor/bin/phpcbf -p ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary; fi
-    # Make sure the rulesets don't thrown unexpected errors or warnings.
-    # This check needs to be run against a high PHP version to prevent triggering the syntax error check.
-    # It also needs to be run against all PHPCS versions WPCS is tested against.
-    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Core; fi
-    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Docs; fi
-    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress-Extra; fi
-    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then $(pwd)/vendor/bin/phpcs -s ./bin/class-ruleset-test.php --standard=WordPress; fi
-    # WordPress Coding Standards.
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link http://pear.php.net/package/PHP_CodeSniffer/
-    - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
-    # Validate the xml files.
-    # @link http://xmlsoft.org/xmllint.html
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml; fi
-    - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample; fi
-    # Check the code-style consistency of the xml files.
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress/ruleset.xml <(xmllint --format "./WordPress/ruleset.xml"); fi
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-Core/ruleset.xml <(xmllint --format "./WordPress-Core/ruleset.xml"); fi
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-Docs/ruleset.xml <(xmllint --format "./WordPress-Docs/ruleset.xml"); fi
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml"); fi
-    - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample"); fi
-    # Validate the composer.json file.
-    # @link https://getcomposer.org/doc/03-cli.md#validate
-    - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all --strict; fi
+  # Lint the PHP files against parse errors.
+  - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all --strict; fi
+
+  # Run the unit tests.
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+      php $PHPUNIT_DIR/phpunit-7.phar --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    else
+      phpunit --filter WordPress --bootstrap="$(pwd)/vendor/squizlabs/php_codesniffer/tests/bootstrap.php" $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    fi


### PR DESCRIPTION
Travis now offers stages. Using stages we can:
- Run the code style related checks before running any unit tests and stop the build early if any are detected.
- Remove the duplicate unit test runs - i.e. previously we had an extra (third) build against PHP 7.2 (now changed to 7.3) which would run the code style related checks, but would also re-run the unit tests. This extra build will now no longer run the unit tests.

While this does mean that the unit tests will run with a slight delay (the `Sniff` and `Rulesets` stages have to finish before they start), it also means that we:
* Get code style errors reported earlier as it's been moved to be the first stage and the build will just stop if any are found.
* We won't be wasting Travis's resources on builds which will have to be re-run anyway.
* The output of the Travis jobs will be a _lot_ easier to decipher as it only shows the output related to that particular stage.

Ref: https://docs.travis-ci.com/user/build-stages/

Note that `Allowed failures` is no longer listed as a separate block in the Travis result overview, but is _is_ respected.

For more discussion about this:
* https://github.com/travis-ci/travis-ci/issues/7789
* https://travis-ci.community/t/always-show-allow-failures-allowed-failures-when-build-stages-are-used/217
* https://travis-ci.community/t/work-out-kinks-in-interactions-between-stages-allow-fail-and-fast-finish/1090
* https://github.com/travis-ci/travis-ci/issues/9677