### PR TITLE
ValidHookName: bug fix  / skip over array keys

### DIFF
--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -83,3 +83,8 @@ do_action( "admin_Head_{${$object->getName()}}_Action_{${$object->getName()}}_Ac
 // Make sure that deprecated hook names are ignored for this sniff.
 do_action_deprecated( "admin_Head_$Post admin_Head_$Post" ); // Ok.
 apply_filters_deprecated( "admin_Head_$Post->ID admin_Head_$Post->ID" ); // Ok.
+
+// Ignore array keys.
+do_action( 'prefix_block_' . $block['blockName'] ); // Ok.
+do_action( 'prefix_block_' . $block  [  'blockName'  ] . '_More_hookname' ); // Error - use lowercase (second part of the hook name).
+do_action( "prefix_block_{$block['blockName']}" ); // Ok.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -68,6 +68,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					79 => 1,
 					80 => 1,
 					81 => 1,
+					89 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':


### PR DESCRIPTION
String array keys for variable array access would also be examined as part of the hook name, while those should be skipped over as they are not part of the _hook_name.

This fixes that.

Includes unit test.

This commit also lowers the nesting level of the loop by continuing early whenever possible.