### PR TITLE
Add `rest_sanitize_boolean()` to unslashing sanitizing functions

### DIFF
--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -137,15 +137,16 @@ trait SanitizationHelperTrait {
 	 * @var array<string, bool>
 	 */
 	private $unslashingSanitizingFunctions = array(
-		'absint'               => true,
-		'boolval'              => true,
-		'count'                => true,
-		'doubleval'            => true,
-		'floatval'             => true,
-		'intval'               => true,
-		'sanitize_key'         => true,
-		'sanitize_locale_name' => true,
-		'sizeof'               => true,
+		'absint'                => true,
+		'boolval'               => true,
+		'count'                 => true,
+		'doubleval'             => true,
+		'floatval'              => true,
+		'intval'                => true,
+		'rest_sanitize_boolean' => true,
+		'sanitize_key'          => true,
+		'sanitize_locale_name'  => true,
+		'sizeof'                => true,
 	);
 
 	/**


### PR DESCRIPTION
The `rest_sanitize_boolean()` function always returns a `bool` so it is essentially the same as `boolval()`.