### PR TITLE
AbstractFunctionParameterSniff: don't ignore first class callables

### DIFF
--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -78,8 +78,8 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 			 * No need for extensive defensive coding as the `is_targetted_token()` method has already
 			 * validated the open and close parentheses exist.
 			 */
-			$next          = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
-			$firstNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next + 1 ), null, true );
+			$openParens    = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			$firstNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $openParens + 1 ), null, true );
 			if ( \T_ELLIPSIS === $this->tokens[ $firstNonEmpty ]['code'] ) {
 				return $this->process_first_class_callable( $stackPtr, $group_name, $matched_content );
 			} else {


### PR DESCRIPTION
... but pass them to a dedicated `process_first_class_callable()` method instead to allow sniffs to decide whether to flag these or not.

Typical use-case for why first class callables should not be ignored by default:
A sniff which ALWAYS flags the use of a certain function, but has different error messages depending on whether parameters are passed or not.

In that situation, I believe first class callables should be treated the same as other uses of the target function.
First class callables are basically syntax sugar for closures (example: https://3v4l.org/cra8s)  and if the sniff would flag the use of the target function within a closure, it is only reasonable to also flag the use of the target function as a first class callable.

This commit implements this.

The commit does not include tests as there are no sniffs in WPCS for which the above would apply. However, I have manually tested this change via a sniff in an external standard for which this change is relevant.

Follow up on #2518, also see: https://github.com/WordPress/WordPress-Coding-Standards/pull/2518#issuecomment-3084890977