### PR TITLE
Release checklist: minor updates to the publicize section

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -45,7 +45,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 
 - [ ] Merge this PR.
 - [ ] Make sure all CI builds are green.
-- [ ] Tag and create a release against `main` (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
+- [ ] Tag and create a release against `main` (careful, GH defaults to `develop`!) & copy & paste the changelog to it.  
     :pencil2: Check if anything from the link collection at the bottom of the changelog needs to be copied in!
     - Remove square brackets from all ticket links or make them proper full links (as GH markdown parser doesn't parse these correctly).
     - Change all contributor links to full inline links (as GH markdown parser on the Releases page doesn't parse these correctly).
@@ -63,7 +63,10 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 
 - [ ] [Major releases only] Publish post about the release on Make WordPress.
 - [ ] Tweet, toot, etc about the release from your personal account (there is no official WPCS account).
-- [ ] Post about it in #core channel on the WordPress.org Slack.
+- [ ] Post about it in #core channel on the WordPress.org Slack.  
+    :pencil2: No need to post in the #core-coding-standard channel as that gets an automated release notification anyway.
+    - [ ] Optionally post in #plugin-review if a sniff was added in a release which was requested by the plugin review team.
+    - [ ] Optionally post in #core-docs if significant updates were made to the documentation ruleset.
 - [ ] Create a Marketing team ["amplify request"][amplify-request].
 - [ ] Submit for the ["Monthy Dev Roundup"][dev-roundup].
 


### PR DESCRIPTION
As discussed in https://github.com/WordPress/WordPress-Coding-Standards/pull/2558#issuecomment-3129842916, I'm opening this PR to suggest a few updates/clarifications to the release checklist document:

- Clarify which account to use when posting to social media about the release.
- Clarify which Slack channel to post to.
- Replace "Month in WordPress" with a Marketing team amplify request, as the former doesn't exist anymore and was replaced by the latter (see https://make.wordpress.org/community/month-in-wordpress-submissions/).