### PR TITLE
GH Actions/unit-tests: don't run code coverage in forks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -135,15 +135,15 @@ jobs:
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests without code coverage
-        if: ${{ matrix.coverage == false }}
+        if: ${{ matrix.coverage == false || github.repository_owner != 'WordPress' }}
         run: composer run-tests
 
       - name: Run the unit tests with code coverage
-        if: ${{ matrix.coverage == true  }}
+        if: ${{ matrix.coverage == true && github.repository_owner == 'WordPress' }}
         run: composer coverage
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && matrix.coverage == true }}
+        if: ${{ success() && matrix.coverage == true && github.repository_owner == 'WordPress' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./build/logs/clover.xml


### PR DESCRIPTION
The `unit-tests` workflow runs code coverage for pushes to `main` and pull requests, but wasn't limited to this repo.

This resulted in failing builds for contributors who have actions enabled on their fork. The reason for the failure is that they don't have access to the `CODECOV_TOKEN`.

This commit changes the conditions on when to run the tests normally and when to run with code coverage to take the organisation where the repo lives into account. That should prevent the failing builds in forks.

Similar to #2542, which applied the same change to the `quicktest`workflow.