### PR TITLE
ConstantsHelper::is_use_of_global_constant(): do not treat `use const` alias as global constant usage

### DIFF
--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -79,6 +79,7 @@ final class ConstantsHelper {
 			\T_INSTANCEOF => true,
 			\T_INSTEADOF  => true,
 			\T_GOTO       => true,
+			\T_AS         => true,
 		);
 		$tokens_to_ignore += Tokens::$ooScopeTokens;
 		$tokens_to_ignore += Collections::objectOperators();

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -61,7 +61,7 @@ echo BACKGROUND_COLOR;
 echo BACKGROUND_IMAGE;
 
 use const STYLESHEETPATH as SSP;
-use const ABC as STYLESHEETPATH;
+use const ABC as STYLESHEETPATH; // This is ok, as `STYLESHEETPATH` is not a global constant here.
 
 switch(	STYLESHEETPATH ) {
 	case STYLESHEETPATH:

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -49,7 +49,6 @@ final class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 			60  => 1,
 			61  => 1,
 			63  => 1,
-			64  => 1,
 			66  => 1,
 			67  => 1,
 			71  => 1,


### PR DESCRIPTION
`ConstantsHelper::is_use_of_global_constant()` was incorrectly identifying a constant alias as a global constant.