### PR TITLE
Docs: Add documentation for WordPress.Security.EscapeOutput

### DIFF
--- a/WordPress/Docs/Security/EscapeOutputStandard.xml
+++ b/WordPress/Docs/Security/EscapeOutputStandard.xml
@@ -1,37 +1,46 @@
 <?xml version="1.0"?>
 <documentation title="Escape Output">
     <standard>
-        <![CDATA[
-Short: Dynamic output must be escaped.
+    <![CDATA[
+      Dynamic output must be escaped.
 
-Long: This sniff checks that any dynamic data sent to the browser
-is properly escaped using a WordPress escaping function, such as
-`esc_html()`, `esc_attr()`, or `wp_kses_post()`. Escaping prevents
-cross-site scripting (XSS) vulnerabilities and ensures output is safe.
-        ]]>
+      This sniff checks that any dynamic data sent to the browser
+      is escaped using a WordPress escaping function, such as
+      esc_html(), esc_attr(), or wp_kses_post(). Escaping prevents
+      cross-site scripting (XSS) vulnerabilities and ensures
+      output is safe.
+    ]]>
     </standard>
 
     <code_comparison>
-        <code title="Invalid: unescaped echo" language="php"><![CDATA[
+        <code title="Invalid: unescaped echo">
+        <![CDATA[
 <?php
 $name = $_GET['name'];
-echo <em>$name</em>; // ❌ Unescaped user input
-        ]]></code>
-        <code title="Valid: escaped echo" language="php"><![CDATA[
+echo <em>$name</em>;
+        ]]>
+        </code>
+        <code title="Valid: escaped echo">
+        <![CDATA[
 <?php
 $name = $_GET['name'];
-echo <em>esc_html( $name )</em>; // ✅ Safe output
-        ]]></code>
+echo <em>esc_html( $name )</em>;
+        ]]>
+        </code>
     </code_comparison>
 
     <code_comparison>
-        <code title="Invalid: unescaped printf" language="php"><![CDATA[
+        <code title="Invalid: unescaped printf">
+        <![CDATA[
 <?php
-printf( 'Hello %s', <em>$name</em> ); // ❌ Dangerous
-        ]]></code>
-        <code title="Valid: escaped printf" language="php"><![CDATA[
+printf( 'Hello %s', <em>$name</em> );
+        ]]>
+        </code>
+        <code title="Valid: escaped printf">
+        <![CDATA[
 <?php
-printf( 'Hello %s', <em>esc_html( $name )</em> ); // ✅ Escaped
-        ]]></code>
+printf( 'Hello %s', <em>esc_html( $name )</em> );
+        ]]>
+        </code>
     </code_comparison>
 </documentation>

--- a/WordPress/Docs/Security/EscapeOutputStandard.xml
+++ b/WordPress/Docs/Security/EscapeOutputStandard.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<documentation title="Escape Output">
+    <standard>
+        <![CDATA[
+Short: Dynamic output must be escaped.
+
+Long: This sniff checks that any dynamic data sent to the browser
+is properly escaped using a WordPress escaping function, such as
+`esc_html()`, `esc_attr()`, or `wp_kses_post()`. Escaping prevents
+cross-site scripting (XSS) vulnerabilities and ensures output is safe.
+        ]]>
+    </standard>
+
+    <code_comparison>
+        <code title="Invalid: unescaped echo" language="php"><![CDATA[
+<?php
+$name = $_GET['name'];
+echo <em>$name</em>; // ❌ Unescaped user input
+        ]]></code>
+        <code title="Valid: escaped echo" language="php"><![CDATA[
+<?php
+$name = $_GET['name'];
+echo <em>esc_html( $name )</em>; // ✅ Safe output
+        ]]></code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Invalid: unescaped printf" language="php"><![CDATA[
+<?php
+printf( 'Hello %s', <em>$name</em> ); // ❌ Dangerous
+        ]]></code>
+        <code title="Valid: escaped printf" language="php"><![CDATA[
+<?php
+printf( 'Hello %s', <em>esc_html( $name )</em> ); // ✅ Escaped
+        ]]></code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
Related to #1722

Adds `WordPress/Docs/Security/EscapeOutputStandard.xml` with short description and invalid/valid examples (echo, printf).
Tested with:
vendor/bin/phpcs --standard=WordPress --generator=Text --sniffs=WordPress.Security.EscapeOutput