### PR TITLE
Add GlobalVariablesOverride standard doc

### DIFF
--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -5,36 +5,27 @@
     >
     <standard>
     <![CDATA[
-    WordPress global variables should not be overridden. This includes variables imported with 
-    the `global` statement within functions, variables assigned via the `$GLOBALS` superglobal array,
-    and variables assigned in the global namespace.
+    WordPress global variables should not be overridden.
 
-    A few select WordPress global variables like `$content_width` and `$wp_cockneyreplace` are 
+    Two WordPress global variables, `$content_width` and `$wp_cockneyreplace`, are 
     specifically intended to be overridden by themes/plugins and are exempt from this rule.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: Different variable name.">
         <![CDATA[
-$my_query = new WP_Query( $args );
+<em>$my_query</em> = new WP_Query( $args );
+
+
+<em>$GLOBALS['my_data']</em> = "some data";
         ]]>
         </code>
         <code title="Invalid: Global variable overridden.">
         <![CDATA[
 <em>global $wp_query;</em>
-<em>$wp_query = new WP_Query( $args );</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <code_comparison>
-        <code title="Valid: Custom Superglobal variable.">
-        <![CDATA[
-$GLOBALS['my_data'] = array( 'key' => 'value' );
-        ]]>
-        </code>
-        <code title="Invalid: WordPress Superglobal variable overridden.">
-        <![CDATA[
-<em>$GLOBALS['wp_query'] = new WP_Query( $args );</em>
+<em>$wp_query</em> = new WP_Query( $args );
+
+<em>$GLOBALS['wp_query']</em> = new WP_Query( $args );
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
Related to https://github.com/WordPress/WordPress-Coding-Standards/issues/1722

We're adding a new xml standard file to [GlobalVariablesOverrideSniff](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php)

<img width="1138" height="605" alt="image" src="https://github.com/user-attachments/assets/75285282-d1f9-40ea-bbf8-e16fabac967e" />
