### PR TITLE
Docs: Add documentation for WordPress.PHP.TypeCasts

### DIFF
--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -1,37 +1,55 @@
 <?xml version="1.0"?>
-<documentation title="Type Casts">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Type Casts"
+>
     <standard>
     <![CDATA[
-      This sniff normalizes float type cast keywords.
+      Enforce normalized and safe type casts.
 
-      Use (float) instead of legacy synonyms:
-      - Disallowed: (double), (real)
-      - Allowed:    (float)
-
-      Note: Other type-cast rules in the WordPress standard
-      are enforced by different sniffs:
-      - Short forms like (int), (bool), (string):
-        PSR12.Keywords.ShortFormTypeKeywords
-      - No spaces inside parentheses:
-        Squiz.WhiteSpace.CastSpacing
-      - Exactly one space after the cast:
-        Generic.Formatting.SpaceAfterCast
+      • Use (float) instead of legacy float casts.
+      • Do not use the (unset) cast. Use unset().
+      • Avoid the (binary) cast (discouraged).
     ]]>
     </standard>
 
     <code_comparison>
-        <code title="Invalid: legacy float casts">
+        <code title="Invalid: Using legacy float casts.">
         <![CDATA[
-<?php
 $price = <em>(double)</em> $value;
 $size  = <em>(real)</em>   $value;
         ]]>
         </code>
-        <code title="Valid: normalized float cast">
+        <code title="Valid: Using normalized float casts.">
         <![CDATA[
-<?php
 $price = <em>(float)</em> $value;
 $size  = <em>(float)</em> $value;
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Invalid: Using the (unset) cast.">
+        <![CDATA[
+$result = <em>(unset)</em> $value;
+        ]]>
+        </code>
+        <code title="Valid: Use unset().">
+        <![CDATA[
+unset( $value );
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Invalid: Using the (binary) cast.">
+        <![CDATA[
+$bytes = <em>(binary)</em> $value;
+        ]]>
+        </code>
+        <code title="Valid: Prefer a clear alternative.">
+        <![CDATA[
+$bytes = (string) $value;
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -14,42 +14,42 @@
     </standard>
 
     <code_comparison>
-        <code title="Invalid: Using legacy float casts.">
-        <![CDATA[
-$price = <em>(double)</em> $value;
-$size  = <em>(real)</em>   $value;
-        ]]>
-        </code>
         <code title="Valid: Using normalized float casts.">
         <![CDATA[
 $price = <em>(float)</em> $value;
 $size  = <em>(float)</em> $value;
         ]]>
         </code>
+        <code title="Invalid: Using legacy float casts.">
+        <![CDATA[
+$price = <em>(double)</em> $value;
+$size  = <em>(real)</em>   $value;
+        ]]>
+        </code>
     </code_comparison>
 
     <code_comparison>
-        <code title="Invalid: Using the (unset) cast.">
-        <![CDATA[
-$result = <em>(unset)</em> $value;
-        ]]>
-        </code>
         <code title="Valid: Use unset().">
         <![CDATA[
 unset( $value );
         ]]>
         </code>
+        <code title="Invalid: Using the (unset) cast.">
+        <![CDATA[
+result = <em>(unset)</em> $value;
+        ]]>
+        </code>
     </code_comparison>
 
     <code_comparison>
-        <code title="Invalid: Using the (binary) cast.">
-        <![CDATA[
-$bytes = <em>(binary)</em> $value;
-        ]]>
-        </code>
         <code title="Valid: Prefer a clear alternative.">
         <![CDATA[
-$bytes = (string) $value;
+bytes = (string) $value;
+        ]]>
+        </code>
+        <code title="Invalid: Using the (binary) cast.">
+        <![CDATA[
+bytes = <em>(binary)</em> $value;
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<documentation title="Type Casts">
+    <standard>
+    <![CDATA[
+      This sniff normalizes float type cast keywords.
+
+      Use (float) instead of legacy synonyms:
+      - Disallowed: (double), (real)
+      - Allowed:    (float)
+
+      Note: Other type-cast rules in the WordPress standard
+      are enforced by different sniffs:
+      - Short forms like (int), (bool), (string):
+        PSR12.Keywords.ShortFormTypeKeywords
+      - No spaces inside parentheses:
+        Squiz.WhiteSpace.CastSpacing
+      - Exactly one space after the cast:
+        Generic.Formatting.SpaceAfterCast
+    ]]>
+    </standard>
+
+    <code_comparison>
+        <code title="Invalid: legacy float casts">
+        <![CDATA[
+<?php
+$price = <em>(double)</em> $value;
+$size  = <em>(real)</em>   $value;
+        ]]>
+        </code>
+        <code title="Valid: normalized float cast">
+        <![CDATA[
+<?php
+$price = <em>(float)</em> $value;
+$size  = <em>(float)</em> $value;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
Related to #1722

This PR adds a new documentation file:
`WordPress/Docs/PHP/TypeCastsStandard.xml`

### What it covers
Documents the rule enforced by the `WordPress.PHP.TypeCasts` sniff:
- Normalizes legacy float casts (`(double)`, `(real)`) to `(float)`.

### Notes
Other type-cast related rules in the WordPress standard are enforced by separate sniffs:
- Short form keywords (`(int)`, `(bool)`, `(string)`): PSR12.Keywords.ShortFormTypeKeywords
- No spaces inside parentheses: Squiz.WhiteSpace.CastSpacing
- Exactly one space after the cast: Generic.Formatting.SpaceAfterCast