### PR TITLE
Example ruleset: update some recommended settings

### DIFF
--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -78,7 +78,7 @@
 	https://github.com/PHPCompatibility/PHPCompatibility
 	-->
 	<!--
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.0-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php</include-pattern>
 	</rule>
@@ -100,7 +100,7 @@
 	the wiki:
 	https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_wp_version" value="6.0"/>
+	<config name="minimum_wp_version" value="6.5"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
# Description
* Generally we recommend for the `minimum_wp_version` to be ~3 versions behind the latest WP release (currently 6.8.2).
* To align with this, I'm setting the `testVersion` for PHPCompatibility to PHP 7.0 or higher (which was the minimum PHP version in WP 6.5).


## Suggested changelog entry
_N/A_ (part of "various housekeeping")

## Related issues/external references

Loosely related to #2471
