### PR TITLE
GH Actions: update for upstream branch rename

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PHPCS_DEV: 'dev-master'
+  PHPCS_DEV: '3.x-dev'
   UTILS_DEV: 'dev-develop'
   EXTRA_DEV: 'dev-develop'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PHPCS_DEV: 'dev-master'
+  PHPCS_DEV: '3.x-dev'
   UTILS_DEV: 'dev-develop'
   EXTRA_DEV: 'dev-develop'
 

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  * @since 2.0.0  Now offers name suggestions for variables in violation.
  *
  * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
- * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  */
 final class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\Sniff;
  * Last synced with base class 2021-11-20 at commit 7f11ffc8222b123c06345afd3261221561c3bb29.
  * Note: This class has diverged quite far from the original. All the same, checking occasionally
  * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
- * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
 final class ControlStructureSpacingSniff extends Sniff {
 

--- a/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * - When the `::` operator is used in `::class`, no new line(s) before or after the object operator are allowed.
  *
  * @since 3.0.0
- * @link  https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+ * @link  https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
  */
 final class ObjectOperatorSpacingSniff extends Squiz_ObjectOperatorSpacingSniff {
 

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -31,7 +31,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * Last verified with base class June 2023 at commit 085b1e091b0f2e451333c0bc26dd50bba39402c4.
- * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
 final class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 


### PR DESCRIPTION
# Description

PHPCS has renamed the `master` branch to `3.x`.

This commit account for that.

* Change `dev-master` to `3.x-dev` in workflows.
* Update links referencing the upstream code to use `HEAD` instead of the branch name.


## Suggested changelog entry
_N/A_