### PR TITLE
Security/EscapeOutput: fix false positive and add tests for namespaced names

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -741,7 +741,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 					// Special case get_search_query() which is unsafe if $escaped = false.
 					if ( 'get_search_query' === strtolower( $functionName ) ) {
 						$escaped_param = PassedParameters::getParameter( $this->phpcsFile, $ptr, 1, 'escaped' );
-						if ( false !== $escaped_param && 'true' !== $escaped_param['clean'] ) {
+						if ( false !== $escaped_param && 'true' !== strtolower( ltrim( $escaped_param['clean'], '\\' ) ) ) {
 							$this->phpcsFile->addError(
 								'Output from get_search_query() is unsafe due to $escaped parameter being set to "false".',
 								$ptr,

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -801,3 +801,13 @@ echo implode( '<br>', MyNamespace\array_map( 'esc_html', $items ) ); // Bad x 2.
 echo implode( '<br>', \MyNamespace\map_deep( $items, 'esc_html' ) ); // Bad.
 echo implode( '<br>', namespace\array_map( 'esc_html', $items ) ); // Bad x 2. The sniff should stop flagging this once it can resolve relative namespaces.
 echo implode( '<br>', namespace\Sub\map_deep( $items, 'esc_html' ) ); // Bad.
+
+/*
+ * Safeguard correct handling of get_search_query() with FQN and non-standard case booleans for the $escaped parameter.
+ */
+echo \get_search_query( TRUE ); // Ok.
+echo \get_search_query( \true ); // Ok.
+echo \get_search_query( \True ); // Ok.
+echo \get_search_query( FaLsE ); // Bad.
+echo \get_search_query( \false ); // Bad.
+echo \get_search_query( \FALSE ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -205,6 +205,9 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 					801 => 1,
 					802 => 2,
 					803 => 1,
+					811 => 1,
+					812 => 1,
+					813 => 1,
 				);
 
 			case 'EscapeOutputUnitTest.6.inc':


### PR DESCRIPTION
# Description

In preparation for PHPCS 4.0, which changes the tokenization of namespaced names, this PR adds tests with all variants of namespace names (unqualified, partially qualified, fully qualified, and namespace relative) to the `WordPress.Security.EscapeOutput` sniff. This is a continuation of #2581, where tests were added for all sniffs extending `AbstractFunctionRestrictions` except `EscapeOutput`.

This PR also includes tests to ensure the `basename( __FILE__ )` pattern recognition in `_deprecated_file()` only applies to global `basename()` function calls, not to other constructs that might look similar (such as namespaced variants or class methods).

Besides that, it fixes in a separate commit a false positive bug that was discovered during the PR review, where the sniff would incorrectly handle FQN and/or non-standard case `true` passed to `get_search_query()`.

## Suggested changelog entry

Fixed:
- `WordPress.Security.EscapeOutput`: false positive for `get_search_query()` when the `$escaped` parameter was passed as fully qualified `true` or as `true` using a non-standard case.