### PR TITLE
WP/GetMetaSingle: simplify code using two class constants

### DIFF
--- a/WordPress/Sniffs/WP/GetMetaSingleSniff.php
+++ b/WordPress/Sniffs/WP/GetMetaSingleSniff.php
@@ -43,7 +43,7 @@ final class GetMetaSingleSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @var array<string, array<string, int|string>>
 	 */
-	const GENERIC_META_FUNCTIONS_FORMAT = array(
+	private const GENERIC_META_FUNCTIONS_FORMAT = array(
 		'condition'   => array(
 			'param_name' => 'meta_key',
 			'position'   => 3,
@@ -64,7 +64,7 @@ final class GetMetaSingleSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @var array<string, array<string, int|string>>
 	 */
-	const SPECIFIC_META_FUNCTIONS_FORMAT = array(
+	private const SPECIFIC_META_FUNCTIONS_FORMAT = array(
 		'condition'   => array(
 			'param_name' => 'key',
 			'position'   => 2,


### PR DESCRIPTION
# Description

Now that support for PHP < 7.2 has been dropped in PR #2614, we can simplify the sniff code by defining the two different function signature formats as class constants. This was not possible before, as PHP < 5.6 did not support defining class constants as arrays.

## Suggested changelog entry
_N/A_
