### PR TITLE
Update warning message for file system operations

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -153,7 +153,7 @@ final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff 
 
 			'file_system_operations' => array(
 				'type'      => 'warning',
-				'message'   => 'File operations should use WP_Filesystem methods instead of direct PHP filesystem calls. Found: %s().',
+				'message'   => 'File operations are discouraged, and should use WP_Filesystem methods for Upgrade routines. Found: %s().',
 				'since'     => '2.5.0',
 				'functions' => array(
 					'chgrp',


### PR DESCRIPTION
Update the message to indicate that WP_Filesystem should not be used for general file IO.

# Description

The coding standards suggest using WP_Filesystem instead of all file-operations, which often sends developers down a path that they really shouldn't have.

This just clarifies that perhaps they shouldn't perform file operations, and to use WP_Filesystem for upgrade-routines (Which the classes are intended for).

This might get some pushback from some people who feel WP_Filesystem should be used if it exists, but it's an abstraction that applies for a constantly reducing set of sites, which run on read-only filesystems and require FTP to interact with the WordPress files.
Generally, WP_Filesystem either uses direct IO, or, FTP which requires interactive prompting, which most plugins/themes that use WP_Filesystem are not handling anyway.

I will note it's possible for WP_Filesystem to be configured with hard-coded credentials, but that's even more rare.

Pushing people onto this class just doesn't benefit anyone.

I would almost suggest that the mention of WP_Filesystem should be removed entirely, and this just be left as a "You really shouldn't do file operations if this is running often" type warning.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
See the https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md file if you need examples.
-->


## Related issues/external references

Fixes #
