### PR TITLE
Documentation: fix broken WordPress VIP links in sniff docblocks

### DIFF
--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -19,7 +19,7 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag Database direct queries.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#direct-database-queries
+ * @link https://docs.wpvip.com/php_codesniffer/warnings/#h-direct-database-queries
  *
  * @since 0.3.0
  * @since 0.6.0  Removed the add_unique_message() function as it is no longer needed.

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -14,7 +14,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag potentially slow queries.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
+ * @link https://docs.wpvip.com/php_codesniffer/warnings/#h-functions-that-use-joins-taxonomy-relation-queries-cat-tax-queries-subselects-or-api-calls
  *
  * @since 0.3.0
  * @since 0.13.0 Class name changed: this class is now namespaced.

--- a/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
@@ -29,7 +29,7 @@ final class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			/*
 			 * Disallow the changing the timezone.
 			 *
-			 * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#manipulating-the-timezone-server-side
+			 * @link https://docs.wpvip.com/php_codesniffer/errors/#h-manipulating-the-timezone-server-side
 			 */
 			'timezone_change' => array(
 				'type'      => 'error',

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -15,7 +15,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * Warn about __FILE__ for page registration.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-__file__-for-page-registration
+ * @link https://docs.wpvip.com/php_codesniffer/warnings/#h-using-file-for-page-registration
  *
  * @since 0.3.0
  * @since 0.11.0 Refactored to extend the new WordPressCS native

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -22,7 +22,7 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag cron schedules less than 15 minutes.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cron-schedules-less-than-15-minutes-or-expensive-events
+ * @link https://docs.wpvip.com/php_codesniffer/warnings/#h-cron-schedules-less-than-15-minutes-or-expensive-events
  *
  * @since 0.3.0
  * @since 0.11.0 - Extends the WordPressCS native `Sniff` class.

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -18,8 +18,6 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Makes sure scripts and styles are enqueued and not explicitly echo'd.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#inline-resources
- *
  * @since 0.3.0
  * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since 0.13.0 Class name changed: this class is now namespaced.

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -16,7 +16,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag returning high or infinite posts_per_page.
  *
- * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#no-limit-queries
+ * @link https://docs.wpvip.com/php_codesniffer/warnings/#h-no-limit-queries
  *
  * @since 0.3.0
  * @since 0.13.0 Class name changed: this class is now namespaced.


### PR DESCRIPTION
# Description

Update old https://vip.wordpress.com/documentation URLs to new https://docs.wpvip.com URLs in multiple sniff docblocks. The old links are redirecting to a generic page that doesn't provide any useful information about the related sniff.

I was not able to find the corresponding new link for `EnqueuedResourcesSniff`, so I opted to remove the old link. I'm not familiar with WordPress VIP docs so I might have missed the new location.

It seems it is not the first time that WordPress VIP changed those URLs without configuring proper redirects (see #1499).

## Suggested changelog entry
_N/A_