### PR TITLE
Security/ValidatedSanitizedInput: improve `InputNotValidated` error message

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -175,7 +175,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 
 		if ( false === $validated ) {
 			$this->phpcsFile->addError(
-				'Detected usage of a possibly undefined superglobal array index: %s. Use isset() or empty() to check the index exists before using it',
+				'Detected usage of a possibly undefined superglobal array index: %s. Check that the array index exists before using it.',
 				$stackPtr,
 				'InputNotValidated',
 				$error_data


### PR DESCRIPTION
# Description

The error message for `InputNotValidated` previously listed specific methods (isset() and empty()), but the list was incomplete. Rather than expanding it, this PR adopts a more generic message that won't require updates when new validation methods are added.

@jrfnl, I made a small modification to the phrase that you suggested by adding "that" after "check". This way the sentences reads a bit better to me, but let me know if you disagree.

> Detected usage of a possibly undefined superglobal array index: %s. Check that the array index exists before using it.

## Suggested changelog entry

Changed: 

`WordPress.Security.ValidatedSanitizedInput`: the `InputNotValidated` error message is now more generic.

## Related issues/external references

Discussed in #2641
