### PR TITLE
WordPress-Extra: demand for exit/die to always use parentheses

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -208,4 +208,7 @@
 	<!-- Forbid parentheses for attribute instantiations without parameters. -->
 	<rule ref="Universal.Attributes.DisallowAttributeParentheses"/>
 
+	<!-- Require parentheses when calling exit/die. -->
+	<rule ref="Universal.PHP.RequireExitDieParentheses"/>
+
 </ruleset>


### PR DESCRIPTION
# Description
_Follow up after PR #2646, pulled separately as the decision point is different._

PHPCSExtra offers two new sniffs to choose from related to whether `exit`/`die` calls should use parentheses or not.

This PR proposes to add one of these rules to WordPress-Extra, with an eye to eventually moving the rule to WordPress-Core after a Make post.

WordPress Core currently contains 395 calls to `exit`/`die`.

If we look at the metrics the new sniffs generate, the current state of WordPress-Core is inconsistent, though leans towards only requiring parentheses when parameters are passed:
```
Exit/die with parentheses:
        no                     =>  275 ( 69.62%)
        yes, with parameter(s) =>   74 ( 18.73%)
        yes                    =>   46 ( 11.65%)
        -----------------------------------------
        total                  =>  395 (100.00%)
```

Having said that, the WordPress Coding Standards handbook already contains the following rule regarding object instantiations, for which parentheses are also optional:

> When instantiating a new object instance, parenthesis must always be used, even when not strictly necessary.

Ref: https://github.com/WordPress/wpcs-docs/blob/master/wordpress-coding-standards/php.md#object-instantiation

In this commit, I propose to add a rule to demand that calls to `exit`/`die` always use parentheses.

Reasoning:
* Creates consistency with the "object instantiations" rule.
* Yes, it will cause code-churn in Core if the rule would get adopted in Core, but it will also create more consistency between calls to `exit`/`die`.
* Demanding parentheses is also in line with PERCS, which means that the rule doesn't raise the barrier to entry for new contributors to WordPress.

👉🏻 Having said this, I can also imagine us holding off on adding this rule to WordPress-Extra and going straight for a Make post to add the rule to WordPress-Core.
This would avoid/prevent confusion if a discussion about this on Make would yield another decision (forbid parentheses except when there are parameters).

**_In other words, this PR is very much a suggestion, not a definitive proposal, and whether or not we should merge it will depend on people leaving opinions about this topic._**

So.... opinions please ?

## Suggested changelog entry
- `WordPress-Extra`: the following additional sniffs has been added to the ruleset: `Universal.PHP.RequireExitDieParentheses`.
