### PR TITLE
CS: start using PHPCompatibility 10

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -57,7 +57,20 @@
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_attributeFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_matchFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_name_relativeFound"/>
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_enumFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_public_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_protected_setFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_private_setFound"/>
+		<exclude name="PHPCompatibility.Constants.RemovedConstants.t_bad_characterFound"/>
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"phpcsstandards/phpcsextra": "^1.5.0"
 	},
 	"require-dev": {
-		"phpcompatibility/php-compatibility": "^9.0",
+		"phpcompatibility/php-compatibility": "^10.0.0@dev",
 		"phpunit/phpunit": "^8.0 || ^9.0",
 		"phpcsstandards/phpcsdevtools": "^1.2.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
@@ -36,6 +36,8 @@
 		"ext-iconv": "For improved results",
 		"ext-mbstring": "For improved results"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
# Description
Long anticipated, finally here: PHPCompatibility 10.0.0-alpha1 :tada:

PHPCompatibility 10.0.0 brings huge improvements in both what is being detected (> 50 new sniffs), as well as the detection accuracy for pre-existing sniffs.

Even though still "unstable", it is stable enough for our purposes and the advantages of using it outweigh the disadvantage of it being an unstable version. By setting the `minimum-stability` and `prefer-stable` settings in the `composer.json`, we can ensure that we don't get the `dev-develop` branch, but rather get a `10.0.0` tag, unstable or not.

And what with the improved detection, a number of new PHP token constants previously not flagged, are now flagged, so let's ignore them as PHPCS polyfills these.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibility/wiki/Upgrading-to-PHPCompatibility-10.0
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1


## Suggested changelog entry
_N/A_