### PR TITLE
GH Actions: improve "don't run on forks" conditions

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   on-pr-merge:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'WordPress' && github.event.pull_request.merged == true
+    if: github.event.repository.fork == false && github.event.pull_request.merged == true
 
     name: Clean up labels on PR merge
 
@@ -26,7 +26,7 @@ jobs:
 
   on-pr-close:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'WordPress' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
+    if: github.event.repository.fork == false && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
 
     name: Clean up labels on PR close
 
@@ -41,7 +41,7 @@ jobs:
 
   on-issue-close:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'WordPress' && github.event.issue.state == 'closed'
+    if: github.event.repository.fork == false && github.event.issue.state == 'closed'
 
     name: Clean up labels on issue close
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -66,15 +66,15 @@ jobs:
         run: composer lint
 
       - name: Run the unit tests without code coverage
-        if: ${{ github.repository_owner != 'WordPress' || github.ref_name != 'develop' }}
+        if: ${{ github.event.repository.fork == true || github.ref_name != 'develop' }}
         run: composer run-tests
 
       - name: Run the unit tests with code coverage
-        if: ${{ github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
+        if: ${{ github.event.repository.fork == false && github.ref_name == 'develop' }}
         run: composer coverage
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
+        if: ${{ success() && github.event.repository.fork == false && github.ref_name == 'develop' }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -128,15 +128,15 @@ jobs:
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests without code coverage
-        if: ${{ matrix.coverage == false || github.repository_owner != 'WordPress' }}
+        if: ${{ matrix.coverage == false || github.event.repository.fork == true }}
         run: composer run-tests
 
       - name: Run the unit tests with code coverage
-        if: ${{ matrix.coverage == true && github.repository_owner == 'WordPress' }}
+        if: ${{ matrix.coverage == true && github.event.repository.fork == false }}
         run: composer coverage
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && matrix.coverage == true && github.repository_owner == 'WordPress' }}
+        if: ${{ success() && matrix.coverage == true && github.event.repository.fork == false }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           files: ./build/logs/clover.xml


### PR DESCRIPTION
# Description
Remove the conditions containing a hard-coded repository name in favour of a more generic condition which should safeguard that select steps don't run on forks just the same.


## Suggested changelog entry
_N/A_