### PR TITLE
DB/DirectDatabaseQuery: allow for more caching functions

### DIFF
--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -82,7 +82,10 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 * @var array
 	 */
 	protected $cacheGetFunctions = array(
-		'wp_cache_get' => true,
+		'wp_cache_get'                 => true,
+		'wp_cache_get_multiple'        => true,
+		'wp_cache_get_multiple_salted' => true,
+		'wp_cache_get_salted'          => true,
 	);
 
 	/**
@@ -95,8 +98,12 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 * @var array
 	 */
 	protected $cacheSetFunctions = array(
-		'wp_cache_set' => true,
-		'wp_cache_add' => true,
+		'wp_cache_add'                 => true,
+		'wp_cache_add_multiple'        => true,
+		'wp_cache_set'                 => true,
+		'wp_cache_set_multiple'        => true,
+		'wp_cache_set_multiple_salted' => true,
+		'wp_cache_set_salted'          => true,
 	);
 
 	/**
@@ -109,18 +116,21 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 * @var array
 	 */
 	protected $cacheDeleteFunctions = array(
-		'wp_cache_delete'         => true,
-		'clean_attachment_cache'  => true,
-		'clean_blog_cache'        => true,
-		'clean_bookmark_cache'    => true,
-		'clean_category_cache'    => true,
-		'clean_comment_cache'     => true,
-		'clean_network_cache'     => true,
-		'clean_object_term_cache' => true,
-		'clean_page_cache'        => true,
-		'clean_post_cache'        => true,
-		'clean_term_cache'        => true,
-		'clean_user_cache'        => true,
+		'wp_cache_delete'          => true,
+		'wp_cache_delete_multiple' => true,
+		'wp_cache_flush_group'     => true,
+		'wp_cache_flush_runtime'   => true,
+		'clean_attachment_cache'   => true,
+		'clean_blog_cache'         => true,
+		'clean_bookmark_cache'     => true,
+		'clean_category_cache'     => true,
+		'clean_comment_cache'      => true,
+		'clean_network_cache'      => true,
+		'clean_object_term_cache'  => true,
+		'clean_page_cache'         => true,
+		'clean_post_cache'         => true,
+		'clean_term_cache'         => true,
+		'clean_user_cache'         => true,
 	);
 
 	/**

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.1.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.1.inc
@@ -475,3 +475,34 @@ function callToMultiLevelNamespaceRelativeCacheDelete() {
 	$wpdb->query( 'SELECT X FROM Y' ); // Warning direct DB call.
 	namespace\Sub\clean_blog_cache( 1 );
 }
+
+// Handle more caching functions.
+function cache_multiple() {
+	global $wpdb;
+	$data = wp_cache_get_multiple( ['keyA', 'keyB'] );
+	if ( false !== $data ) {
+		$data = $wpdb->get_results( $query ); // Warning direct DB call.
+		\wp_cache_add_multiple( $data );
+	}
+}
+
+function cache_multiple_salted() {
+	global $wpdb;
+	$data = \wp_cache_get_multiple_salted( ...$params );
+	if ( false !== $data ) {
+		$data = $wpdb->get_col( $query ); // Warning direct DB call.
+		wp_cache_set_multiple_salted( ...$params );
+	}
+}
+
+function cache_delete_multiple() {
+	global $wpdb;
+	$wpdb->replace( $query ); // Warning direct DB call.
+	WP_cache_delete_multiple( ['keyA', 'keyB'] );
+}
+
+function cache_flush_group() {
+	global $wpdb;
+	$wpdb->delete( $query ); // Warning direct DB call.
+	wp_cache_flush_group( 'group' );
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -109,6 +109,10 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 					461 => 1,
 					468 => 1,
 					475 => 1,
+					484 => 1,
+					493 => 1,
+					500 => 1,
+					506 => 1,
 				);
 			default:
 				return array();


### PR DESCRIPTION
# Description
While updating the pluggable function list for WP 6.9, I noticed there are now more cache functions in WP.

Based on the docs:
* [`wp_cache_get_multiple()`](https://developer.wordpress.org/reference/functions/wp_cache_get_multiple/) was added in WP 5.5.0.
* [`wp_cache_get_multiple_salted()`](https://developer.wordpress.org/reference/functions/wp_cache_get_multiple_salted/) was added in WP 6.9.0.
* [`wp_cache_get_salted()`](https://developer.wordpress.org/reference/functions/wp_cache_get_salted/) was added in WP 6.9.0.
* [`wp_cache_add_multiple()`](https://developer.wordpress.org/reference/functions/wp_cache_add_multiple/) was added in WP 6.0.0.
* [`wp_cache_set_multiple()`](https://developer.wordpress.org/reference/functions/wp_cache_set_multiple/) was added in WP 6.0.0.
* [`wp_cache_set_multiple_salted()`](https://developer.wordpress.org/reference/functions/wp_cache_set_multiple_salted/) was added in WP 6.9.0.
* [`wp_cache_set_salted()`](https://developer.wordpress.org/reference/functions/wp_cache_set_salted/) was added in WP 6.9.0.
* [`wp_cache_delete_multiple()`](https://developer.wordpress.org/reference/functions/wp_cache_delete_multiple/) was added in WP 6.0.0.
* [`wp_cache_flush_group()`](https://developer.wordpress.org/reference/functions/wp_cache_flush_group/) was added in WP 6.1.0.
* [`wp_cache_flush_runtime()`](https://developer.wordpress.org/reference/functions/wp_cache_flush_runtime/) was added in WP 6.0.0.

This commit adds these functions to the appropriate lists for the sniff to take into account.

Includes tests.


## Suggested changelog entry
`WordPress.DB.DirectDatabaseQuery` now recognizes more caching functions, like the `wp_cache_*_multiple()` functions as added in WordPress 6.0 and the `wp_cache_*_salted()` functions as added in WordPress 6.9.