### PR TITLE
Update the minimum_wp_version to WP 6.6

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.5';
+	private $default_minimum_wp_version = '6.6';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.1.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.1.inc
@@ -418,14 +418,14 @@ the_block_template_skip_link();
 wp_admin_bar_header();
 wp_img_tag_add_decoding_attr();
 wp_update_https_detection_errors();
-
-/*
- * Warning.
- */
 /* ============ WP 6.5 ============ */
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();
 block_core_query_ensure_interactivity_dependency();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.6 ============ */
 wp_interactivity_process_directives_of_interactive_blocks();
 wp_render_elements_support();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -32,7 +32,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'DeprecatedFunctionsUnitTest.1.inc':
 				$start_line = 8;
-				$end_line   = 420;
+				$end_line   = 424;
 				$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 				// Unset the lines related to version comments.
@@ -84,7 +84,8 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 					$errors[373],
 					$errors[383],
 					$errors[386],
-					$errors[410]
+					$errors[410],
+					$errors[421]
 				);
 
 				return $errors;
@@ -109,13 +110,12 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {
 			case 'DeprecatedFunctionsUnitTest.1.inc':
-				$start_line = 426;
+				$start_line = 430;
 				$end_line   = 446;
 				$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 				// Unset the lines related to version comments.
 				unset(
-					$warnings[429],
 					$warnings[432],
 					$warnings[442],
 					$warnings[444]

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -95,8 +95,8 @@ wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
-
-// All will give an WARNING as they have been deprecated after WP 6.5.
 inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
+
+// All will give an WARNING as they have been deprecated after WP 6.6.
 wp_render_elements_support_styles('deprecated');
 _wp_can_use_pcre_u('deprecated');

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 97;
+		$end_line   = 98;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -52,7 +52,6 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			100 => 1,
 			101 => 1,
 			102 => 1,
 		);


### PR DESCRIPTION
# Description
The minimum version should be three versions behind the latest WP release, so what with 6.9.0 slated for release on Dec 2nd, it should now become 6.6.

Includes updating the tests to match.

## Suggested changelog entry
Changed
- The default value for `minimum_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#various-sniffs-set-the-minimum-supported-wp-version), has been updated to `6.6`.


## Related issues/external references

Previous: #2121, #2321. #2436, #2553
