### PR TITLE
Update `phpcs.xml.dist.sample` and add related item to release checklist

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -15,6 +15,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] PHPCSUtils: check if there have been [releases][phpcsutils-releases] since the last WordPressCS release and update WordPressCS code to take advantage of any new utilities - PR #xxx
 - [ ] PHPCSExtra: check if there have been [releases][phpcsextra-releases] since the last WordPressCS release and check through the changelog to see if there is anything WordPressCS could take advantage of - PR #xxx
 - [ ] Check if the minimum WP version property needs updating in `MinimumWPVersionTrait::$default_minimum_wp_version` and if so, action it - PR #xxx
+- [ ] Check if the `minimum_wp_version` and `testVersion` properties in `phpcs.xml.dist.sample` need updating and if so, action it - PR #xxx
 - [ ] Check if any of the list based sniffs need updating and if so, action it.
     :pencil2: Make sure the "last updated" annotation in the docblocks for these lists has also been updated!
     List based sniffs:

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -78,7 +78,7 @@
 	https://github.com/PHPCompatibility/PHPCompatibility
 	-->
 	<!--
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php</include-pattern>
 	</rule>
@@ -100,7 +100,7 @@
 	the wiki:
 	https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_wp_version" value="6.5"/>
+	<config name="minimum_wp_version" value="6.6"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
# Description

This PR updates the `phpcs.xml.dist.sample` file to reflect that WP 6.6 is now the minimum supported version (three versions behind the latest release). It also updates the `testVersion` property from `7.0-` to `7.2-` since [WP 6.6 dropped support for PHP 7.0 and 7.1](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/). This file was last updated on https://github.com/WordPress/WordPress-Coding-Standards/pull/2608.

WP 6.9 is [scheduled](https://make.wordpress.org/core/6-9/) to be released on December 2nd. I'm not sure if we want to wait until its release to merge this PR if approved.

Also, I'm suggesting adding an item to the release checklist to verify if these properties need updating as part of the release process, as discussed in https://github.com/WordPress/WordPress-Coding-Standards/pull/2656#issuecomment-3573120442.

## Suggested changelog entry

_N/A_
