### PR TITLE
Dependabot/gh-actions: move to bi-weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      time: "09:00"
+      interval: "cron"
+      cronjob: "10 22 5,20 * *" # At 22:10, every 5th and 20th day of the month.
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"


### PR DESCRIPTION
# Description
:point_right: Important: this is for **version** updates only, not for security updates, which are handled separately and don't depend on this configuration.

---

PR #2621 updated the GitHub Actions workflows used in this repo to use "pinned" versions for external action runners to improve workflow security.

The net result of this, is that Dependabot now sends PRs to all repos I (co-)maintain on a weekly basis for most repos. As the default day for the "weekly" interval is _Monday_ and most repos don't change this, it means that Dependabot has a huge queue on Mondays and that PRs come in bit by bit throughout the day and even spill over into Tuesday.

This constant stream of low level/easy PRs to merge is disruptive and time consuming, especially as I can't just go through them all in one go.

As these updates are rarely time-sensitive, it should be fine to receive them less frequently.

This commit tries to make it so by changing the Dependabot schedule for GitHub Actions to once every two weeks and late in the day when the queue should be mostly empty (as long as it's not a Monday), which should mean that if I apply this same change to all repos I am involved with, all these Dependabot PRs should come in around the same time.


## Suggested changelog entry
_N/A_

## Additional Context

As per the description, this is mostly a quality of life improvement for me as currently I can't seem to get any work done anymore on any given Monday.
