### PR TITLE
AbstractClassRestrictionsSniff: fix inconsequential typo

### DIFF
--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -134,7 +134,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_PARENTHESIS, \T_WHITESPACE, \T_SEMICOLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_TAG ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
-				$nameEnd = ( $this->phpcsFile->findNext( array( \T_CLOSE_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
+				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
 			}
 
 			if ( isset( $this->tokens[ $stackPtr + 2 ] ) && false !== $nameEnd ) {


### PR DESCRIPTION
# Description
The sniff looks for whitespace or a close curly at the end of a class declaration statement, but those don't end with a close curly, but with an open curly.

As it would be rare for anyone not to have whitespace before the open curly (which is also enforced by WPCS), this bug will probably never have had any consequences in real life, as the `findNext()` would stop at the whitespace anyway.

Having said that, I see quite a lot more wrong with the code in this abstract, but will leave that for the future abstract in PHPCSUtils to fix as spending lots of time on it here is not worth our time.


## Suggested changelog entry
_N/A_ (general maintenance should cover this)