### PR TITLE
WP/CapitalPDangit: add tests for namespaced names

### DIFF
--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -244,3 +244,12 @@ class TypeClassConstants {
 	// Ensures no false positives on incorrect casing in a class constant type name.
     public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
 }
+
+/*
+ * Safeguard correct handling of all types of namespaced calls to the define() function.
+ */
+\DEFINE( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
+MyNamespace\define( 'WORDPRESS_SOMETHING', 'wordpress' ); // Bad.
+\MyNamespace\Define( 'WORDPRESS_SOMETHING', 'wordpress' ); // Bad.
+namespace\Sub\define( 'WORDPRESS_SOMETHING', 'wordpress' ); // Bad.
+namespace\define( 'WORDPRESS_SOMETHING', 'wordpress' ); // The sniff should stop flagging this once it can resolve relative namespaces.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -244,3 +244,12 @@ class TypeClassConstants {
 	// Ensures no false positives on incorrect casing in a class constant type name.
     public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
 }
+
+/*
+ * Safeguard correct handling of all types of namespaced calls to the define() function.
+ */
+\DEFINE( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
+MyNamespace\define( 'WORDPRESS_SOMETHING', 'WordPress' ); // Bad.
+\MyNamespace\Define( 'WORDPRESS_SOMETHING', 'WordPress' ); // Bad.
+namespace\Sub\define( 'WORDPRESS_SOMETHING', 'WordPress' ); // Bad.
+namespace\define( 'WORDPRESS_SOMETHING', 'WordPress' ); // The sniff should stop flagging this once it can resolve relative namespaces.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -69,6 +69,10 @@ final class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 					204 => 1,
 					205 => 1,
 					224 => 1,
+					252 => 1,
+					253 => 1,
+					254 => 1,
+					255 => 1,
 				);
 
 			case 'CapitalPDangitUnitTest.2.inc':


### PR DESCRIPTION
# Description

In preparation for PHPCS 4.0, which changes the tokenization of namespaced names, this PR adds tests with all forms of namespaced function calls (partially qualified, fully qualified, and namespace-relative using the `namespace` keyword) to the `WordPress.WP.CapitalPDangit` sniff. The tests focus on calls to the `define()` function and namespaced variants that share the same name.

## Suggested changelog entry
_N/A_