### PR TITLE
WP/EnqueuedResourceParameters: add tests for namespaced names

### DIFF
--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
@@ -42,7 +42,7 @@ wp_register_style( 'script-name', 'https://example.com/someScript.js', false, '1
 wp_register_style( 'script-name', 'https://example.com/someScript.js' ); // Warning - missing $ver.
 
 wp_enqueue_style( 'script-name', 'https://example.com/someScript.js', false, '1.0.0'); // OK.
-wp_enqueue_style( 'script-name', 'https://example.com/someScript.js' ); // Warning - missing $ver.
+WP_ENQUEUE_style( 'script-name', 'https://example.com/someScript.js' ); // Warning - missing $ver.
 
 wp_register_script( 'someScript-js' ); // OK.
 wp_enqueue_script( 'someScript-js' ); // OK.
@@ -108,3 +108,13 @@ wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array
 wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), \Null, true ); // Warning - 0, false or NULL are not allowed.
 wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), \true, \False ); // Ok.
 wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), \get_version(), \null ); // OK.
+
+/*
+ * Safeguard correct handling of all types of namespaced function calls.
+ */
+\wp_enqueue_script( 'script-name', 'https://example.com/someScript.js', false, '1.1.0' ); // Warning - missing $in_footer.
+\wp_REGISTER_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), '1.1.0' ); // Warning - missing $in_footer.
+MyNamespace\wp_register_style( 'style-name', 'https://example.com/style.css' ); // Ok.
+\MyNamespace\wp_enqueue_style( 'style-name', 'https://example.com/style.css' ); // Ok.
+namespace\wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), '1.1.0' ); // The sniff should start flagging this once it can resolve relative namespaces.
+namespace\Sub\wp_enqueue_style( 'style-name', 'https://example.com/style.css' ); // Ok.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
@@ -116,5 +116,5 @@ wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array
 \wp_REGISTER_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), '1.1.0' ); // Warning - missing $in_footer.
 MyNamespace\wp_register_style( 'style-name', 'https://example.com/style.css' ); // Ok.
 \MyNamespace\wp_enqueue_style( 'style-name', 'https://example.com/style.css' ); // Ok.
-namespace\wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), '1.1.0' ); // The sniff should start flagging this once it can resolve relative namespaces.
+namespace\wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), '1.1.0' ); // The sniff should start flagging this once it can resolve relative namespaces (once it does, it should be "Warning - missing $in_footer").
 namespace\Sub\wp_enqueue_style( 'style-name', 'https://example.com/style.css' ); // Ok.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -82,6 +82,8 @@ final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 					100 => 1,
 					107 => 1,
 					108 => 1,
+					115 => 1,
+					116 => 1,
 				);
 
 			default:


### PR DESCRIPTION
# Description

In preparation for PHPCS 4.0, which changes the tokenization of namespaced names, this PR adds tests with all forms of namespaced function calls (partially qualified, fully qualified, and namespace-relative using the `namespace` keyword) as well as fully qualified global function calls to the `WordPress.WP.EnqueuedResourceParameters` sniff.

Two different tests for fully qualified global function calls are included to cover all global functions referenced directly in the `EnqueuedResourceParametersSniff::process_parameters` method.

This is a follow-up to #2633, which did not include tests for this sniff to avoid conflicts with #2630, which has since been merged.

## Suggested changelog entry

_N/A_