### PR TITLE
DB/RestrictedFunctions: add XML documentation

### DIFF
--- a/WordPress/Docs/DB/RestrictedFunctionsStandard.xml
+++ b/WordPress/Docs/DB/RestrictedFunctionsStandard.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Restricted Database Functions"
+    >
+    <standard>
+    <![CDATA[
+    Avoid touching the database directly with PHP library functions. Use the $wpdb object and associated functions instead.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using a WordPress function to fetch posts.">
+        <![CDATA[
+$results = <em>get_posts()</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Using the MySQLi library to fetch posts.">
+        <![CDATA[
+$results = <em>mysqli_query</em>(
+    $mysql,
+    "SELECT * FROM wp_posts LIMIT 5"
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Using WordPress functions to insert a post.">
+        <![CDATA[
+<em>wp_insert_post</em>(
+    array( 'post_title' => 'Title' )
+);
+
+// or...
+
+global $wpdb;
+<em>$wpdb->insert</em>(
+    $wpdb->posts,
+    array( 'post_title' => 'Title' ),
+    array( '%s' )
+);
+        ]]>
+        </code>
+        <code title="Invalid: Using MySQLi library to insert a post.">
+        <![CDATA[
+<em>mysqli_query</em>(
+    $mysql,
+    "INSERT INTO wp_posts (post_title)
+    VALUES ('Title')"
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.DB.RestrictedFunctions` sniff.

The documentation is based on the work started by @paulgibbs in #2453. I used the original commit, and then made subsequent changes, mostly based on the review left in #2453.

I suggest squashing those commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2453
