### PR TITLE
CodeAnalysis/AssignmentInTernaryCondition: add XML documentation

### DIFF
--- a/WordPress/Docs/CodeAnalysis/AssignmentInTernaryConditionStandard.xml
+++ b/WordPress/Docs/CodeAnalysis/AssignmentInTernaryConditionStandard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Assignment In Ternary Condition"
+    >
+    <standard>
+    <![CDATA[
+    Variables should not be assigned in the condition of a ternary expression. This is likely a mistake, as more often than not, a comparison was intended.
+
+    Side-note: This sniff can only detect assignments in ternary conditions when parentheses are used around either the ternary expression or its condition.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Comparison operator used in ternary condition.">
+        <![CDATA[
+echo ( $a <em>===</em> 'a' ) ? 'b' : 'c';
+        ]]>
+        </code>
+        <code title="Invalid: Assignment in ternary condition.">
+        <![CDATA[
+echo ( $a <em>=</em> 'a' ) ? 'b' : 'c';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.CodeAnalysis.AssignmentInTernaryCondition` sniff.

The documentation is based on the work started by @Nic-Sevic in #2488. I squashed the original commits and, in a separate commit, made subsequent changes based on the review left in #2488.

I suggest squashing those two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2488
Closes #2488
