### PR TITLE
WP/GlobalVariablesOverride: add XML documentation

### DIFF
--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -7,25 +7,25 @@
     <![CDATA[
     WordPress global variables should not be overridden.
 
-    Two WordPress global variables, `$content_width` and `$wp_cockneyreplace`, are 
+    Two WordPress global variables, `$content_width` and `$wp_cockneyreplace`, are
     specifically intended to be overridden by themes/plugins and are exempt from this rule.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Different variable name.">
+        <code title="Valid: Using non-WordPress global names.">
         <![CDATA[
 <em>$my_query</em> = new WP_Query( $args );
 
 
-<em>$GLOBALS['my_data']</em> = "some data";
+<em>$GLOBALS['my_data']</em> = 'some data';
         ]]>
         </code>
-        <code title="Invalid: Global variable overridden.">
+        <code title="Invalid: WordPress global variable overridden.">
         <![CDATA[
 <em>global $wp_query;</em>
 <em>$wp_query</em> = new WP_Query( $args );
 
-<em>$GLOBALS['wp_query']</em> = new WP_Query( $args );
+<em>$GLOBALS['post']</em> = get_post( 1 );
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Global Variables Override"
+    >
+    <standard>
+    <![CDATA[
+    WordPress global variables should not be overridden.
+
+    Two WordPress global variables, `$content_width` and `$wp_cockneyreplace`, are 
+    specifically intended to be overridden by themes/plugins and are exempt from this rule.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Different variable name.">
+        <![CDATA[
+<em>$my_query</em> = new WP_Query( $args );
+
+
+<em>$GLOBALS['my_data']</em> = "some data";
+        ]]>
+        </code>
+        <code title="Invalid: Global variable overridden.">
+        <![CDATA[
+<em>global $wp_query;</em>
+<em>$wp_query</em> = new WP_Query( $args );
+
+<em>$GLOBALS['wp_query']</em> = new WP_Query( $args );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -12,7 +12,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using non-WordPress global names.">
+        <code title="Valid: Declaring global variables with names not reserved for use by WordPress itself.">
         <![CDATA[
 <em>$prefix_query</em> = new WP_Query( $args );
 

--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    WordPress global variables should not be overridden.
+    Variables declared by WordPress in the global namespace should not be overridden by code extending WordPress.
 
     Two WordPress global variables, `$content_width` and `$wp_cockneyreplace`, are
     specifically intended to be overridden by themes/plugins and are exempt from this rule.
@@ -14,13 +14,13 @@
     <code_comparison>
         <code title="Valid: Using non-WordPress global names.">
         <![CDATA[
-<em>$my_query</em> = new WP_Query( $args );
+<em>$prefix_query</em> = new WP_Query( $args );
 
 
-<em>$GLOBALS['my_data']</em> = 'some data';
+<em>$GLOBALS['prefix_data']</em> = 'some data';
         ]]>
         </code>
-        <code title="Invalid: WordPress global variable overridden.">
+        <code title="Invalid: Overriding a WordPress defined global variable.">
         <![CDATA[
 <em>global $wp_query;</em>
 <em>$wp_query</em> = new WP_Query( $args );

--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -17,13 +17,17 @@
 <em>$prefix_query</em> = new WP_Query( $args );
 
 
+
+
 <em>$GLOBALS['prefix_data']</em> = 'some data';
         ]]>
         </code>
         <code title="Invalid: Overriding a WordPress defined global variable.">
         <![CDATA[
-<em>global $wp_query;</em>
-<em>$wp_query</em> = new WP_Query( $args );
+function prefix_custom_query( $args ) {
+    <em>global $wp_query;</em>
+    <em>$wp_query</em> = new WP_Query( $args );
+}
 
 <em>$GLOBALS['post']</em> = get_post( 1 );
         ]]>

--- a/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
+++ b/WordPress/Docs/WP/GlobalVariablesOverrideStandard.xml
@@ -16,10 +16,11 @@
         <![CDATA[
 <em>$prefix_query</em> = new WP_Query( $args );
 
-
-
-
 <em>$GLOBALS['prefix_data']</em> = 'some data';
+
+foreach ( $selected_posts as <em>$prefix_post</em> ) {
+    // Do something.
+}
         ]]>
         </code>
         <code title="Invalid: Overriding a WordPress defined global variable.">
@@ -27,9 +28,13 @@
 function prefix_custom_query( $args ) {
     <em>global $wp_query;</em>
     <em>$wp_query</em> = new WP_Query( $args );
+
+    <em>$GLOBALS['post']</em> = get_post( 1 );
 }
 
-<em>$GLOBALS['post']</em> = get_post( 1 );
+foreach ( $selected_posts as <em>$post</em> ) {
+    // Do something.
+}
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.WP.GlobalVariablesOverride` sniff.

The documentation is based on the work started by @paulopmt1 in #2586. I squashed the original commits and, in a separate commit, made subsequent changes based on the review left in #2586.

I suggest squashing those two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2586
Closes #2586

