### PR TITLE
WP/DiscouragedConstants: add XML documentation

### DIFF
--- a/WordPress/Docs/WP/DiscouragedConstantsStandard.xml
+++ b/WordPress/Docs/WP/DiscouragedConstantsStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Discouraged Constants"
+    >
+    <standard>
+    <![CDATA[
+    The use of certain WordPress constants is discouraged. Examples include `TEMPLATEPATH` and `STYLESHEETPATH`.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Function used instead of constant.">
+        <![CDATA[
+$subdir = <em>get_template_directory()</em> . '/subdir';
+        ]]>
+        </code>
+        <code title="Invalid: The TEMPLATEPATH constant is used in the code.">
+        <![CDATA[
+$subdir = <em>TEMPLATEPATH</em> . '/subdir';
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The use of certain WordPress constants is discouraged. Examples include `TEMPLATEPATH` and `STYLESHEETPATH`.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Function used instead of constant.">
+        <![CDATA[
+$dir = <em>get_stylesheet_directory()</em>;
+        ]]>
+        </code>
+        <code title="Invalid: The STYLESHEETPATH constant is used in the code.">
+        <![CDATA[
+$dir = <em>STYLESHEETPATH</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/WP/DiscouragedConstantsStandard.xml
+++ b/WordPress/Docs/WP/DiscouragedConstantsStandard.xml
@@ -5,35 +5,41 @@
     >
     <standard>
     <![CDATA[
-    The use of certain WordPress constants is discouraged. Examples include `TEMPLATEPATH` and `STYLESHEETPATH`.
+    The use of certain WordPress native constants is discouraged. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Function used instead of constant.">
+        <code title="Valid: Function used instead of discouraged WP constant.">
         <![CDATA[
-$subdir = <em>get_template_directory()</em> . '/subdir';
+$dir = <em>get_stylesheet_directory()</em>;
         ]]>
         </code>
-        <code title="Invalid: The TEMPLATEPATH constant is used in the code.">
+        <code title="Invalid: Discouraged WP constant is used.">
         <![CDATA[
-$subdir = <em>TEMPLATEPATH</em> . '/subdir';
+$dir = <em>STYLESHEETPATH</em>;
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    The use of certain WordPress constants is discouraged. Examples include `TEMPLATEPATH` and `STYLESHEETPATH`.
+    The (re-)declaration of certain WordPress native constants is discouraged. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Function used instead of constant.">
+        <code title="Valid: Using recommended alternative instead of (re-)declaring WP constant.">
         <![CDATA[
-$dir = <em>get_stylesheet_directory()</em>;
+<em>add_theme_support</em>(
+    <em>'custom-header'</em>,
+    array( 'width' => 200 )
+);
         ]]>
         </code>
-        <code title="Invalid: The STYLESHEETPATH constant is used in the code.">
+        <code title="Invalid: (Re-)declaring a WP constant.">
         <![CDATA[
-$dir = <em>STYLESHEETPATH</em>;
+define(
+    <em>'HEADER_IMAGE_WIDTH'</em>,
+    200
+);
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.WP.DiscouragedConstants` sniff.

The documentation is based on the work started by @RafaelFunchal in #2493 and @paulopmt1 in #2589. I squashed the original commits and, in a separate commit, made subsequent changes based on the review left in #2589.

I suggest squashing those two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes #2589 and #2493
Closes #2589 
Closes #2493
