### PR TITLE
WP/DiscouragedConstants: update sniff docblock to mention constants (re-)declaration check

### DIFF
--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -17,7 +17,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\ConstantsHelper;
 
 /**
- * Warns against usage of discouraged WP CONSTANTS and recommends alternatives.
+ * Warns against usage and (re-)declaration of discouraged WP constants and recommends alternatives.
  *
  * @since 0.14.0
  */


### PR DESCRIPTION
# Description

This PR suggests two small changes to the DiscouragedConstantsSniff class docblock found while working on #2680:

- Mention that the sniff also checks for constants (re-)declaration.
- Fixes casing of "CONSTANTS" to "constants".

## Suggested changelog entry

_N/A_
