### PR TITLE
Arrays/ArrayDeclarationSpacing: add XML documentation

### DIFF
--- a/WordPress/Docs/Arrays/ArrayDeclarationSpacingStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayDeclarationSpacingStandard.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Array Declaration Spacing"
+    >
+    <standard>
+    <![CDATA[
+    Multi-item arrays with explicit keys must be declared as multi-line arrays.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Multi-item array with explicit keys declared as multi-line.">
+        <![CDATA[
+$args = array(
+    <em>'cat'   => 1</em>,
+    <em>'paged' => 2</em>,
+);
+        ]]>
+        </code>
+        <code title="Invalid: Single line multi-item array with explicit keys.">
+        <![CDATA[
+$args = array( <em>'cat' => 1, 'paged' => 2</em> );
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Each item in a multi-line array must be on a new line.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Only one array item per line.">
+        <![CDATA[
+$post_types = array(
+    <em>'post'</em>,
+    <em>'page'</em>,
+);
+
+$args = array(
+    <em>'cat'   => 1</em>,
+    <em>'paged' => 2</em>,
+);
+        ]]>
+        </code>
+        <code title="Invalid: More than one item per line in a multi-line array.">
+        <![CDATA[
+$post_types = array(
+    <em>'post', 'page'</em>,
+);
+
+
+$args = array(
+    <em>'cat' => 1, 'paged' => 2</em>,
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.Arrays.ArrayDeclarationSpacing` sniff.

The documentation is based on the work started by @RafaelFunchal in #2489 and @mattgaldino in #2593. I squashed the original commits and, in a separate commit, made subsequent changes based on code review suggestions.

I suggest squashing those two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2489 and #2593
Closes #2489
Closes #2593