### PR TITLE
Improve Composer installation wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For the best results, it is recommended to also ensure the following additional 
 
 As of [WordPressCS 3.0.0](https://make.wordpress.org/core/2023/08/21/wordpresscs-3-0-0-is-now-available/), installation via Composer using the below instructions is the only supported type of installation.
 
-[Composer](https://getcomposer.org/) will automatically install the project dependencies and register the rulesets from WordPressCS and other external standards with PHP_CodeSniffer using the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
+[Composer](https://getcomposer.org/) automatically installs the project dependencies and registers the rulesets from WordPressCS, as well as other external standards, with PHP_CodeSniffer using the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
 
 > If you are upgrading from an older WordPressCS version to version 3.0.0, please read the [Upgrade guide for ruleset maintainers and end-users](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers) first!
 


### PR DESCRIPTION
This PR improves the wording in the README to make the Composer installation instructions clearer and easier to understand, without changing the original meaning.