### PR TITLE
Extend prefix blocklist with wporg prefix

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -88,8 +88,9 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	protected $prefix_blocklist = array(
 		'wordpress' => true,
 		'wp'        => true,
+		'wporg'     => true,
 		'_'         => true,
-		'php'       => true, // See #1728, the 'php' prefix is reserved by PHP itself.
+		'php'       => true,// See #1728, the 'php' prefix is reserved by PHP itself.
 	);
 
 	/**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
============================================================================================
Please read the CONTRIBUTING guide before submitting your pull request.

- Warning: AI-generated PRs are NOT welcome and may result in a ban from this repository.
- Small PRs using atomic, descriptive commits are hugely appreciated, as it will make
  reviewing your changes easier for the maintainers.
- Ensure that the code you are submitting meets copyright and licensing requirements to be included in this codebase.

Also, please make sure your pull request passes all continuous integration checks.
PRs which are failing their CI checks will likely be ignored by the maintainers.

============================================================================================
-->

# Description
<!--
What problem does this PR solve?
Describe the purpose of your changes in detail explaining which choices you have made and why.
-->
This PR extends the prefix blocklist used by the PrefixAllGlobalsSniff.

The `wporg` prefix is added to the blocklist to ensure WordPress-reserved prefixes are consistently treated as disallowed when checking for proper prefixing.

This helps prevent false positives and aligns the sniff behavior with WordPress naming conventions.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
See the https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md file if you need examples.
-->
Extend the prefix blocklist to include the `wporg` prefix.

## Related issues/external references

Fixes #2481 
