### PR TITLE
WP/AlternativeFunctions: add XML documentation

### DIFF
--- a/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
+++ b/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="WordPress Alternative Functions"
+    >
+    <standard>
+    <![CDATA[
+    Use WordPress functions instead of native PHP functions to maintain compatibility and benefit from WordPress's additional security and performance improvements.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using wp_json_encode() to encode JSON data.">
+        <![CDATA[
+        <em>wp_json_encode( $data );</em>
+        ]]>
+        </code>
+        <code title="Invalid: Using PHP's json_encode() to encode JSON data.">
+        <![CDATA[
+        <em>json_encode( $data );</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    WordPress provides the wp_remote_* functions for making HTTP requests. Avoid using file_get_contents() or cURL directly.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using wp_remote_get() for HTTP requests.">
+        <![CDATA[
+        $response = <em>wp_remote_get( $url );</em>
+        ]]>
+        </code>
+        <code title="Invalid: Using file_get_contents() for HTTP requests.">
+        <![CDATA[
+        $response = <em>file_get_contents( $url );</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Use WordPress's translation functions to ensure text is translatable and localized.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using _e() or __() for translatable text.">
+        <![CDATA[
+<em>_e( 'Hello, World!', 'text-domain' );</em>
+$hello = <em>__( 'Hello, World!', 'text-domain' );</em>
+        ]]>
+        </code>
+        <code title="Invalid: Echoing plain text strings.">
+        <![CDATA[
+        <em>echo 'Hello, World!';</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Always use WordPress functions for escaping output to prevent XSS vulnerabilities.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using esc_html() to escape HTML output.">
+        <![CDATA[
+        <em>echo esc_html( $user_input );</em>
+        ]]>
+        </code>
+        <code title="Invalid: Outputting user input without escaping.">
+        <![CDATA[
+        <em>echo $user_input;</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
+++ b/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
@@ -6,6 +6,8 @@
     <standard>
     <![CDATA[
     Use WordPress functions instead of certain native PHP functions.
+
+    These WordPress functions typically improve consistency across different PHP versions, operating systems, and server configurations, and/or provide a more comprehensive or robust version of the PHP native function. Using them can make the code more portable and reliable.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
+++ b/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
@@ -9,24 +9,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using the WordPress alternatives.">
+        <code title="Valid: Using a WordPress alternative function.">
         <![CDATA[
 $response = <em>wp_remote_get</em>( $url );
-$json = <em>wp_json_encode</em>( $data );
-$parts = <em>wp_parse_url</em>( $url );
-$text = <em>wp_strip_all_tags</em>( $html );
-$number = <em>wp_rand</em>( 1, 100 );
-$deleted = <em>wp_delete_file</em>( $file );
         ]]>
         </code>
-        <code title="Invalid: Using the discouraged PHP functions.">
+        <code title="Invalid: Using a discouraged PHP function.">
         <![CDATA[
 $response = <em>file_get_contents</em>( $url );
-$json = <em>json_encode</em>( $data );
-$parts = <em>parse_url</em>( $url );
-$text = <em>strip_tags</em>( $html );
-$number = <em>rand</em>( 1, 100 );
-$deleted = <em>unlink</em>( $file );
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
+++ b/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
@@ -13,12 +13,12 @@
     <code_comparison>
         <code title="Valid: Using a WordPress alternative function.">
         <![CDATA[
-$response = <em>wp_remote_get</em>( $url );
+$number = <em>wp_rand</em>( 1, 100 );
         ]]>
         </code>
         <code title="Invalid: Using a discouraged PHP function.">
         <![CDATA[
-$response = <em>file_get_contents</em>( $url );
+$number = <em>mt_rand</em>( 1, 100 );
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
+++ b/WordPress/Docs/WP/AlternativeFunctionsStandard.xml
@@ -1,74 +1,32 @@
 <?xml version="1.0"?>
 <documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
-    title="WordPress Alternative Functions"
+    title="Alternative Functions"
     >
     <standard>
     <![CDATA[
-    Use WordPress functions instead of native PHP functions to maintain compatibility and benefit from WordPress's additional security and performance improvements.
+    Use WordPress functions instead of certain native PHP functions.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using wp_json_encode() to encode JSON data.">
+        <code title="Valid: Using the WordPress alternatives.">
         <![CDATA[
-        <em>wp_json_encode( $data );</em>
+$response = <em>wp_remote_get</em>( $url );
+$json = <em>wp_json_encode</em>( $data );
+$parts = <em>wp_parse_url</em>( $url );
+$text = <em>wp_strip_all_tags</em>( $html );
+$number = <em>wp_rand</em>( 1, 100 );
+$deleted = <em>wp_delete_file</em>( $file );
         ]]>
         </code>
-        <code title="Invalid: Using PHP's json_encode() to encode JSON data.">
+        <code title="Invalid: Using the discouraged PHP functions.">
         <![CDATA[
-        <em>json_encode( $data );</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <standard>
-    <![CDATA[
-    WordPress provides the wp_remote_* functions for making HTTP requests. Avoid using file_get_contents() or cURL directly.
-    ]]>
-    </standard>
-    <code_comparison>
-        <code title="Valid: Using wp_remote_get() for HTTP requests.">
-        <![CDATA[
-        $response = <em>wp_remote_get( $url );</em>
-        ]]>
-        </code>
-        <code title="Invalid: Using file_get_contents() for HTTP requests.">
-        <![CDATA[
-        $response = <em>file_get_contents( $url );</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <standard>
-    <![CDATA[
-    Use WordPress's translation functions to ensure text is translatable and localized.
-    ]]>
-    </standard>
-    <code_comparison>
-        <code title="Valid: Using _e() or __() for translatable text.">
-        <![CDATA[
-<em>_e( 'Hello, World!', 'text-domain' );</em>
-$hello = <em>__( 'Hello, World!', 'text-domain' );</em>
-        ]]>
-        </code>
-        <code title="Invalid: Echoing plain text strings.">
-        <![CDATA[
-        <em>echo 'Hello, World!';</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <standard>
-    <![CDATA[
-    Always use WordPress functions for escaping output to prevent XSS vulnerabilities.
-    ]]>
-    </standard>
-    <code_comparison>
-        <code title="Valid: Using esc_html() to escape HTML output.">
-        <![CDATA[
-        <em>echo esc_html( $user_input );</em>
-        ]]>
-        </code>
-        <code title="Invalid: Outputting user input without escaping.">
-        <![CDATA[
-        <em>echo $user_input;</em>
+$response = <em>file_get_contents</em>( $url );
+$json = <em>json_encode</em>( $data );
+$parts = <em>parse_url</em>( $url );
+$text = <em>strip_tags</em>( $html );
+$number = <em>rand</em>( 1, 100 );
+$deleted = <em>unlink</em>( $file );
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.WP.AlternativeFunctions` sniff.

The documentation is based on the work started by @pamprn09 in #2496 and @bhubbard in #2588. I squashed the original commits and, in a separate commit, made subsequent changes based on code review suggestions.

I suggest squashing those two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

While reviewing #2588, I [mentioned](https://github.com/WordPress/WordPress-Coding-Standards/pull/2588#pullrequestreview-3174377013) the following:

> I wonder whether the documentation should contain a single generic `<standard>`/`<code_comparison>` block that mentions that some PHP functions shouldn't be used and WP functions should be used instead, or if it should contain one `<standard>`/`<code_comparison>` per function group. I can see examples of both approaches in the codebase: `WordPress.WP.DeprecatedFunctions` uses the generic and short approach, while `WordPress.DateTime.RestrictedFunctions` uses the function group approach (but the sniff contains just two function groups, while `WordPress.WP.AlternativeFunctions` contains much more than that).

In this PR, I opted for the first approach and created a single `<standard>`/`<code_comparison>` block. I include a few examples using the main "categories" of functions flagged by the sniff, without including every single group, to avoid having too many examples. Let me know if you prefer one `<standard>`/`<code_comparison>` per function group or something else.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2496 and #2588
Closes #2496
Closes #2588