### PR TITLE
PHP/DevelopmentFunctions: add XML documentation

### DIFF
--- a/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Development Functions"
+    >
+    <standard>
+    <![CDATA[
+    Debug code should not normally be used in production.
+
+    Typically, this rule verifies if function calls to the PHP native `error_log()`, `var_dump()`, `var_export()`, `print_r()`, `trigger_error()`, `set_error_handler()`, `debug_backtrace`, `debug_print_backtrace` and `wp_debug_backtrace_summary()` functions are present in the code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: (Not) using var_dump().">
+        <![CDATA[
+// var_dump() should not be used.
+        ]]>
+        </code>
+        <code title="Invalid: Calling the PHP native `var_dump()` function.">
+        <![CDATA[
+<em>var_dump( $bar );</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Please refrain from using functions that can lead to full path disclosure.
+
+    Typically, this rule verifies if function calls to the PHP native `error_reporting()` and `phpinfo()` functions are present in the code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: (Not) using `phpinfo()`.">
+        <![CDATA[
+// php_info() should not be used.
+        ]]>
+        </code>
+        <code title="Invalid: Calling the PHP native `phpinfo()` function.">
+        <![CDATA[
+<em>phpinfo();</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
@@ -5,12 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Debug functions, like var_dump() and print_r(), should not be used in production code.
-    ]]>
-    </standard>
-    <standard>
-    <![CDATA[
-    Functions that can lead to full path disclosure, like phpinfo(), should not be used.
+    Certain development functions should not be used. This includes debug functions like var_dump() and print_r(), as well as functions that can lead to full path disclosure like phpinfo().
     ]]>
     </standard>
 </documentation>

--- a/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
@@ -5,36 +5,12 @@
     >
     <standard>
     <![CDATA[
-    Debug functions should not be used in production code.
+    Debug functions, like var_dump() and print_r(), should not be used in production code.
     ]]>
     </standard>
-    <code_comparison>
-        <code title="Valid: Not using debug functions.">
-        <![CDATA[
-// Code without debug functions.
-        ]]>
-        </code>
-        <code title="Invalid: Calling a debug function.">
-        <![CDATA[
-<em>var_dump( $bar );</em>
-        ]]>
-        </code>
-    </code_comparison>
     <standard>
     <![CDATA[
-    Functions that can lead to full path disclosure should not be used.
+    Functions that can lead to full path disclosure, like phpinfo(), should not be used.
     ]]>
     </standard>
-    <code_comparison>
-        <code title="Valid: Not using functions that can lead to full path disclosure.">
-        <![CDATA[
-// No full path disclosure functions.
-        ]]>
-        </code>
-        <code title="Invalid: Using a function that can lead to full path disclosure.">
-        <![CDATA[
-<em>phpinfo();</em>
-        ]]>
-        </code>
-    </code_comparison>
 </documentation>

--- a/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/DevelopmentFunctionsStandard.xml
@@ -5,18 +5,16 @@
     >
     <standard>
     <![CDATA[
-    Debug code should not normally be used in production.
-
-    Typically, this rule verifies if function calls to the PHP native `error_log()`, `var_dump()`, `var_export()`, `print_r()`, `trigger_error()`, `set_error_handler()`, `debug_backtrace`, `debug_print_backtrace` and `wp_debug_backtrace_summary()` functions are present in the code.
+    Debug functions should not be used in production code.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: (Not) using var_dump().">
+        <code title="Valid: Not using debug functions.">
         <![CDATA[
-// var_dump() should not be used.
+// Code without debug functions.
         ]]>
         </code>
-        <code title="Invalid: Calling the PHP native `var_dump()` function.">
+        <code title="Invalid: Calling a debug function.">
         <![CDATA[
 <em>var_dump( $bar );</em>
         ]]>
@@ -24,18 +22,16 @@
     </code_comparison>
     <standard>
     <![CDATA[
-    Please refrain from using functions that can lead to full path disclosure.
-
-    Typically, this rule verifies if function calls to the PHP native `error_reporting()` and `phpinfo()` functions are present in the code.
+    Functions that can lead to full path disclosure should not be used.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: (Not) using `phpinfo()`.">
+        <code title="Valid: Not using functions that can lead to full path disclosure.">
         <![CDATA[
-// php_info() should not be used.
+// No full path disclosure functions.
         ]]>
         </code>
-        <code title="Invalid: Calling the PHP native `phpinfo()` function.">
+        <code title="Invalid: Using a function that can lead to full path disclosure.">
         <![CDATA[
 <em>phpinfo();</em>
         ]]>


### PR DESCRIPTION
## Description

This PR adds XML documentation for the `WordPress.PHP.DevelopmentFunctions` sniff.

The documentation is based on the work started by @gogdzl in #2490. I used the original commits and then made subsequent changes, mostly based on the review left in #2490.

I suggest squashing those commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

I opted to remove the function lists from the standard descriptions to avoid the maintenance burden of keeping docs in sync when functions are added or removed. Also, this approach is consistent with other similar sniffs like `DB/RestrictedFunctions` and `WP/DeprecatedFunctions` that also don't list all flagged functions.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2490
Closes: #2490
