### PR TITLE
PHP/RestrictedPHPFunctions: add XML documentation

### DIFF
--- a/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Restricted PHP Functions"
+    >
+    <standard>
+    <![CDATA[
+    The restricted function create_function() should not be used.
+
+    create_function() is deprecated as of PHP 7.2 and removed in PHP 8.0. Please use declared named or anonymous functions instead.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using anonymous function (closure).">
+        <![CDATA[
+add_action( 'init', function() {
+    return foo( 'bar' );
+} );
+        ]]>
+        </code>
+        <code title="Invalid: Using create_function().">
+        <![CDATA[
+add_action( 'init', <em>create_function( '',
+    'return foo( "bar" );'
+)</em> );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
@@ -5,22 +5,28 @@
     >
     <standard>
     <![CDATA[
-    Certain PHP functions must not be used, as they have been deprecated and removed from PHP or pose security risks. Use the recommended alternatives instead.
+    Certain PHP functions must not be used, as they pose security risks. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using an anonymous function.">
+        <code title="Valid: Using an anonymous function (closure).">
         <![CDATA[
-$function = <em>function ()</em> {
-    return foo( 'bar' );
-};
+add_action(
+    'init',
+    <em>function () {
+        return foo( 'bar' );
+    }</em>
+);
         ]]>
         </code>
         <code title="Invalid: Using create_function().">
         <![CDATA[
-$function = <em>create_function</em>(
-    '',
-    'return foo( "bar" );'
+add_action(
+    'init',
+    <em>create_function(
+        '',
+        'return foo( "bar" );'
+    )</em>
 );
         ]]>
         </code>

--- a/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
@@ -5,24 +5,23 @@
     >
     <standard>
     <![CDATA[
-    The restricted function create_function() should not be used.
-
-    create_function() is deprecated as of PHP 7.2 and removed in PHP 8.0. Please use declared named or anonymous functions instead.
+    Certain PHP functions must not be used. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using anonymous function (closure).">
+        <code title="Valid: Using an anonymous function.">
         <![CDATA[
-add_action( 'init', function() {
+$function = <em>function ()</em> {
     return foo( 'bar' );
-} );
+};
         ]]>
         </code>
         <code title="Invalid: Using create_function().">
         <![CDATA[
-add_action( 'init', <em>create_function( '',
+$function = <em>create_function</em>(
+    '',
     'return foo( "bar" );'
-)</em> );
+);
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Certain PHP functions must not be used. Use the recommended alternatives instead.
+    Certain PHP functions must not be used, as they have been deprecated and removed from PHP or pose security risks. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
+++ b/WordPress/Docs/PHP/RestrictedPHPFunctionsStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Certain PHP functions must not be used, as they pose security risks. Use the recommended alternatives instead.
+    Certain PHP functions must not be used. Use the recommended alternatives instead.
     ]]>
     </standard>
     <code_comparison>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.PHP.RestrictedPHPFunctions` sniff.

It is based on the work started by @gogdzl in #2491. I squashed the original commits and, in a separate commit, reworked the documentation to address some of the changes suggested during the review of #2491 and a few more that I decided while working on this PR:

- Make the standard description generic instead of mentioning `create_function()` specifically, following the pattern used by other docs like `DeprecatedFunctionsStandard.xml`.
- Use "must not" instead of "should not" since the sniff produces an error.
- Simplify the code examples by removing the `add_action()` wrapper.
- Reposition the `<em>` tags to the valid code example.

I suggest squashing the two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2491
Closes #2491
