### PR TITLE
PHP/NoSilencedErrors: add XML documentation

### DIFF
--- a/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
+++ b/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Discourage the use of the PHP error silencing operator"
+    >
+    <standard>
+    <![CDATA[
+    Silencing errors is strongly discouraged. Use proper error checking instead.
+
+    Using the error operator with certain functions is allowed because no amount of error checking can fully prevent PHP from throwing errors when these functions are executed. The functions where this is permitted include, but are not limited to:
+
+    - `file_exists()`
+    - `file_get_contents()`
+    - `filesize()`
+    - `filetype()`
+    - `fopen()`
+    - `ftp_login()`
+    - `ftp_rename()`
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using proper error checking when calling functions not in the allowed list.">
+        <![CDATA[
+$conn_id = ftp_connect( $ftp_server );
+if ( ! $conn_id ) {
+  // Handle it as needed.
+}
+        ]]>
+        </code>
+        <code title="Invalid: Using the error operator to silence errors.">
+        <![CDATA[
+$conn_id = <em>@ftp_connect( $ftp_server );</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
+++ b/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
@@ -5,18 +5,18 @@
     >
     <standard>
     <![CDATA[
-    The error silencing operator (@) should not be used. It suppresses errors instead of handling them properly, making debugging more difficult.
+    The error silencing operator (@) should not be used. Errors should be addressed through proper checking rather than being silenced.
 
-    As an exception, the operator is allowed for certain functions where errors cannot be prevented through error checking.
+    As an exception, the operator is allowed for certain functions where warnings cannot be prevented through error checking.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: Calling a function without error silencing.">
         <![CDATA[
-$connection = <em></em>ftp_connect( $ftp_server );
+$connection = <em>ftp_connect</em>( $ftp_server );
         ]]>
         </code>
-        <code title="Invalid: Using the @ operator to silence errors.">
+        <code title="Invalid: Using the @ operator to silence warnings and errors.">
         <![CDATA[
 $connection = <em>@</em>ftp_connect( $ftp_server );
         ]]>

--- a/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
+++ b/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
@@ -5,20 +5,24 @@
     >
     <standard>
     <![CDATA[
-    The error silencing operator (@) should not be used. Errors should be addressed through proper checking rather than being silenced.
+    The error silencing operator (@) should not be used. In the vast majority of cases, there is no need for the error silencing operator if the parameters passed to a function are checked ahead of the call.
 
-    As an exception, the operator is allowed for certain functions where warnings cannot be prevented through error checking.
+    As an exception, the operator is allowed for certain functions where warnings cannot be prevented.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: Calling a function without error silencing.">
         <![CDATA[
-$connection = <em>ftp_connect</em>( $ftp_server );
+if ( isset( $replace_pairs[''] ) ) {
+    unset( $replace_pairs[''] );
+}
+
+$result = <em></em>strtr( $str, $replace_pairs );
         ]]>
         </code>
-        <code title="Invalid: Using the @ operator to silence warnings and errors.">
+        <code title="Invalid: Using the @ operator to silence warnings.">
         <![CDATA[
-$connection = <em>@</em>ftp_connect( $ftp_server );
+$result = <em>@</em>strtr( $str, $replace_pairs );
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
+++ b/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
@@ -1,35 +1,22 @@
 <?xml version="1.0"?>
 <documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
-    title="Discourage the use of the PHP error silencing operator"
+    title="No Silenced Errors"
     >
     <standard>
     <![CDATA[
-    Silencing errors is strongly discouraged. Use proper error checking instead.
-
-    Using the error operator with certain functions is allowed because no amount of error checking can fully prevent PHP from throwing errors when these functions are executed. The functions where this is permitted include, but are not limited to:
-
-    - `file_exists()`
-    - `file_get_contents()`
-    - `filesize()`
-    - `filetype()`
-    - `fopen()`
-    - `ftp_login()`
-    - `ftp_rename()`
+    The error silencing operator (@) should not be used. As an exception, the operator is allowed for certain functions where errors cannot be prevented through error checking.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using proper error checking when calling functions not in the allowed list.">
+        <code title="Valid: Calling a function without error silencing.">
         <![CDATA[
-$conn_id = ftp_connect( $ftp_server );
-if ( ! $conn_id ) {
-  // Handle it as needed.
-}
+$connection = <em></em>ftp_connect( $ftp_server );
         ]]>
         </code>
-        <code title="Invalid: Using the error operator to silence errors.">
+        <code title="Invalid: Using the @ operator to silence errors.">
         <![CDATA[
-$conn_id = <em>@ftp_connect( $ftp_server );</em>
+$connection = <em>@</em>ftp_connect( $ftp_server );
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
+++ b/WordPress/Docs/PHP/NoSilencedErrorsStandard.xml
@@ -5,7 +5,9 @@
     >
     <standard>
     <![CDATA[
-    The error silencing operator (@) should not be used. As an exception, the operator is allowed for certain functions where errors cannot be prevented through error checking.
+    The error silencing operator (@) should not be used. It suppresses errors instead of handling them properly, making debugging more difficult.
+
+    As an exception, the operator is allowed for certain functions where errors cannot be prevented through error checking.
     ]]>
     </standard>
     <code_comparison>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.PHP.NoSilencedErrors` sniff.

The documentation is based on the work started by @gogdzl in #2495. I squashed the original commit and, in a separate commit, applied the changes suggested during the review of #2495:
- Fix the title to match the sniff name.
- Use "should not" since the sniff produces a warning (RFC 2119).
- Be specific about the `@` operator in the standard description.
- Mention the exception for certain functions without listing them.
- Remove the allowed functions list from the description.
- Simplify the code examples to focus on the presence/absence of `@`.
- Rename the variable from `$conn_id` to `$connection`.

I suggest squashing the two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2495
Closes #2495