### PR TITLE
Security/ValidatedSanitizedInput: add XML documentation

### DIFF
--- a/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
+++ b/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Validated Sanitized Input"
+    >
+    <standard>
+    <![CDATA[
+    All user input data ($_POST, $_GET, $_REQUEST, $_SERVER, $_COOKIE, $_FILES, $_SESSION, $_ENV) must be validated, unslashed, and sanitized before use to prevent security vulnerabilities like XSS, SQL injection, and code injection attacks.
+
+    Validation ensures the input key exists (using isset(), empty(), array_key_exists(), or null coalescing operators). Unslashing removes WordPress's automatic backslashes using wp_unslash() or similar functions. Sanitization cleans the data using appropriate functions like sanitize_text_field(), absint(), etc.
+    ]]>
+    </standard>
+    <standard>
+    <![CDATA[
+    String interpolation with superglobals requires validation and sanitization. Using $_POST, $_GET, etc. directly in strings can lead to XSS attacks if the input contains malicious code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: String interpolation with proper validation and sanitization.">
+        <![CDATA[
+if ( isset( $_POST['name'] ) ) {
+    $safe_name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+    echo "Hello " . $safe_name;
+}
+        ]]>
+        </code>
+        <code title="Invalid: String interpolation without validation or sanitization.">
+        <![CDATA[
+echo "Hello {$_POST['name']}";
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    All superglobal array access must be validated to ensure the key exists before use. This prevents undefined index notices and potential security issues.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Input is validated before use.">
+        <![CDATA[
+if ( isset( $_POST['name'] ) ) {
+    $name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+}
+        ]]>
+        </code>
+        <code title="Invalid: Input used without validation.">
+        <![CDATA[
+$name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    All validated input must be sanitized to remove or escape potentially malicious content before processing or output.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Input is validated and sanitized.">
+        <![CDATA[
+if ( isset( $_POST['text'] ) ) {
+    $text = sanitize_text_field( wp_unslash( $_POST['text'] ) );
+}
+        ]]>
+        </code>
+        <code title="Invalid: Input validated but not sanitized.">
+        <![CDATA[
+if ( isset( $_POST['text'] ) ) {
+    $text = wp_unslash( $_POST['text'] );
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    WordPress automatically adds backslashes to certain superglobals. These must be removed using wp_unslash() or similar functions before sanitization to prevent double-escaping issues.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Input is unslashed before sanitization.">
+        <![CDATA[
+if ( isset( $_POST['data'] ) ) {
+    $clean = sanitize_text_field( wp_unslash( $_POST['data'] ) );
+}
+        ]]>
+        </code>
+        <code title="Invalid: Missing unslashing before sanitization.">
+        <![CDATA[
+if ( isset( $_POST['data'] ) ) {
+    $clean = sanitize_text_field( $_POST['data'] );
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
+++ b/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
@@ -5,26 +5,9 @@
     >
     <standard>
     <![CDATA[
-    Superglobals ($_COOKIE, $_ENV, $_FILES, $_GET, $_POST, $_REQUEST, $_SERVER, $_SESSION) must be properly handled before use: array keys must be checked for existence and values must be sanitized.
+    Superglobals ($_COOKIE, $_ENV, $_FILES, $_GET, $_POST, $_REQUEST, $_SERVER, $_SESSION) must be properly handled before use: array keys must be checked for existence and values must be sanitized. Failing to do so can lead to security vulnerabilities such as SQL injection and CSRF attacks.
     ]]>
     </standard>
-    <standard>
-    <![CDATA[
-    Superglobals must not be used directly in string interpolation or heredocs. The array key might not exist, or its value could contain malicious content that gets included in the string without sanitization.
-    ]]>
-    </standard>
-    <code_comparison>
-        <code title="Valid: No superglobal in string interpolation.">
-        <![CDATA[
-// No superglobal in string interpolation.
-        ]]>
-        </code>
-        <code title="Invalid: Superglobal used in string interpolation.">
-        <![CDATA[
-echo "Hello <em>{$_GET['name']}</em>";
-        ]]>
-        </code>
-    </code_comparison>
     <standard>
     <![CDATA[
     Superglobal array keys must be checked for existence before use. Accessing a key that does not exist can lead to unexpected behavior.
@@ -35,7 +18,7 @@ echo "Hello <em>{$_GET['name']}</em>";
         <![CDATA[
 if ( <em>isset( $_POST['name'] )</em> ) {
     $name = sanitize_text_field(
-        wp_unslash( <em>$_POST['name']</em> )
+        wp_unslash( $_POST['name'] )
     );
 }
         ]]>
@@ -56,6 +39,12 @@ $name = sanitize_text_field(
     <code_comparison>
         <code title="Valid: Input is sanitized.">
         <![CDATA[
+if ( isset( $_FILES['upload']['name'] ) ) {
+    $filename = <em>sanitize_file_name</em>(
+        $_FILES['upload']['name']
+    );
+}
+
 if ( isset( $_POST['email'] ) ) {
     $email = <em>sanitize_email</em>(
         wp_unslash( $_POST['email'] )
@@ -65,6 +54,12 @@ if ( isset( $_POST['email'] ) ) {
         </code>
         <code title="Invalid: Input used without sanitization.">
         <![CDATA[
+if ( isset( $_FILES['upload']['name'] ) ) {
+    $filename = <em>$_FILES['upload']['name']</em>;
+}
+
+
+
 if ( isset( $_POST['email'] ) ) {
     $email = wp_unslash(
         <em>$_POST['email']</em>
@@ -95,6 +90,28 @@ if ( isset( $_SERVER['REQUEST_URI'] ) ) {
         <em>$_SERVER['REQUEST_URI']</em>
     );
 }
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Superglobals must not be used directly in string interpolation or heredocs. The array key might not exist, or its value could contain malicious content that gets included in the string without sanitization.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Use a sanitized variable in the string.">
+        <![CDATA[
+if ( isset( $_GET['name'] ) ) {
+    $name = sanitize_text_field(
+        wp_unslash( $_GET['name'] )
+    );
+    echo "Hello <em>$name</em>";
+}
+        ]]>
+        </code>
+        <code title="Invalid: Superglobal used in string interpolation.">
+        <![CDATA[
+echo "Hello <em>{$_GET['name']}</em>";
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
+++ b/WordPress/Docs/Security/ValidatedSanitizedInputStandard.xml
@@ -5,88 +5,95 @@
     >
     <standard>
     <![CDATA[
-    All user input data ($_POST, $_GET, $_REQUEST, $_SERVER, $_COOKIE, $_FILES, $_SESSION, $_ENV) must be validated, unslashed, and sanitized before use to prevent security vulnerabilities like XSS, SQL injection, and code injection attacks.
-
-    Validation ensures the input key exists (using isset(), empty(), array_key_exists(), or null coalescing operators). Unslashing removes WordPress's automatic backslashes using wp_unslash() or similar functions. Sanitization cleans the data using appropriate functions like sanitize_text_field(), absint(), etc.
+    Superglobals ($_COOKIE, $_ENV, $_FILES, $_GET, $_POST, $_REQUEST, $_SERVER, $_SESSION) must be properly handled before use: array keys must be checked for existence and values must be sanitized.
     ]]>
     </standard>
     <standard>
     <![CDATA[
-    String interpolation with superglobals requires validation and sanitization. Using $_POST, $_GET, etc. directly in strings can lead to XSS attacks if the input contains malicious code.
+    Superglobals must not be used directly in string interpolation or heredocs. The array key might not exist, or its value could contain malicious content that gets included in the string without sanitization.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: String interpolation with proper validation and sanitization.">
+        <code title="Valid: No superglobal in string interpolation.">
         <![CDATA[
-if ( isset( $_POST['name'] ) ) {
-    $safe_name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
-    echo "Hello " . $safe_name;
-}
+// No superglobal in string interpolation.
         ]]>
         </code>
-        <code title="Invalid: String interpolation without validation or sanitization.">
+        <code title="Invalid: Superglobal used in string interpolation.">
         <![CDATA[
-echo "Hello {$_POST['name']}";
+echo "Hello <em>{$_GET['name']}</em>";
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    All superglobal array access must be validated to ensure the key exists before use. This prevents undefined index notices and potential security issues.
+    Superglobal array keys must be checked for existence before use. Accessing a key that does not exist can lead to unexpected behavior.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: Input is validated before use.">
         <![CDATA[
-if ( isset( $_POST['name'] ) ) {
-    $name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+if ( <em>isset( $_POST['name'] )</em> ) {
+    $name = sanitize_text_field(
+        wp_unslash( <em>$_POST['name']</em> )
+    );
 }
         ]]>
         </code>
         <code title="Invalid: Input used without validation.">
         <![CDATA[
-$name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+$name = sanitize_text_field(
+    wp_unslash( <em>$_POST['name']</em> )
+);
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    All validated input must be sanitized to remove or escape potentially malicious content before processing or output.
+    All input must be sanitized to remove potentially malicious content before it is used.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Input is validated and sanitized.">
+        <code title="Valid: Input is sanitized.">
         <![CDATA[
-if ( isset( $_POST['text'] ) ) {
-    $text = sanitize_text_field( wp_unslash( $_POST['text'] ) );
+if ( isset( $_POST['email'] ) ) {
+    $email = <em>sanitize_email</em>(
+        wp_unslash( $_POST['email'] )
+    );
 }
         ]]>
         </code>
-        <code title="Invalid: Input validated but not sanitized.">
+        <code title="Invalid: Input used without sanitization.">
         <![CDATA[
-if ( isset( $_POST['text'] ) ) {
-    $text = wp_unslash( $_POST['text'] );
+if ( isset( $_POST['email'] ) ) {
+    $email = wp_unslash(
+        <em>$_POST['email']</em>
+    );
 }
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    WordPress automatically adds backslashes to certain superglobals. These must be removed using wp_unslash() or similar functions before sanitization to prevent double-escaping issues.
+    WordPress adds slashes to $_COOKIE, $_GET, $_POST, $_REQUEST, and $_SERVER elements. These must be passed through an unslashing function before sanitization to ensure the data is processed correctly.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: Input is unslashed before sanitization.">
         <![CDATA[
-if ( isset( $_POST['data'] ) ) {
-    $clean = sanitize_text_field( wp_unslash( $_POST['data'] ) );
+if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+    $url = sanitize_url(
+        <em>wp_unslash</em>( $_SERVER['REQUEST_URI'] )
+    );
 }
         ]]>
         </code>
         <code title="Invalid: Missing unslashing before sanitization.">
         <![CDATA[
-if ( isset( $_POST['data'] ) ) {
-    $clean = sanitize_text_field( $_POST['data'] );
+if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+    $url = sanitize_url(
+        <em>$_SERVER['REQUEST_URI']</em>
+    );
 }
         ]]>
         </code>


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.Security.ValidatedSanitizedInput` sniff.

The documentation is based on the work started by @rooh-wp311 in #2587. I used the original commit and, in a separate commit, made the following changes to the original version of the documentation:

- Add introductory standard block explaining what the sniff checks, using language that avoids the overloaded term "validated".
- Rewrite standard descriptions to explain why each rule exists.
- Add `<em>` tags to highlight key parts in code examples.
- Remove specific mention of XSS as the attack vector.
- Focus each section on its specific error without mixing concerns.
- List which superglobals require `wp_unslash()` in `MissingUnslash` section.
- Use varied superglobals and sanitizing functions across code examples.
- Keep code examples within 48-character column width.

I suggest squashing the two commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2587
Closes #2587