### PR TITLE
PHP/NoSilencedErrors: remove tolerance for `parse_url()`

### DIFF
--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -142,7 +142,6 @@ final class NoSilencedErrorsSniff extends Sniff {
 		// Miscellaneous other functions.
 		'imagecreatefromstring'        => true,
 		'imagecreatefromwebp'          => true,
-		'parse_url'                    => true, // Pre-PHP 5.3.3 an E_WARNING was thrown when URL parsing failed.
 		'unserialize'                  => true,
 	);
 


### PR DESCRIPTION
# Description
The `parse_url()` function was in the list of functions allowed to use error silencing due to it throwing an `E_WARNING` in certain circumstances in PHP < 5.3.3.

I believe by now, we should no longer need to take PHP < 5.3.3 into account, so this exception should no longer be permitted.


## Suggested changelog entry
`WordPress.PHP.NoSilencedErrors`: error silencing is no longer accepted for the `parse_url()` function.