### PR TITLE
PHP/RestrictedPHPFunctions: rephrase error message

### DIFF
--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -35,7 +35,7 @@ final class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSnif
 		return array(
 			'create_function' => array(
 				'type'      => 'error',
-				'message'   => '%s() is deprecated as of PHP 7.2 and removed in PHP 8.0. Please use declared named or anonymous functions instead.',
+				'message'   => '%s() internally performs an eval(), which makes this a very dangerous function. For this reason, it was deprecated as of PHP 7.2 and removed in PHP 8.0. Please use anonymous functions, or declare a named function instead.',
 				'functions' => array(
 					'create_function',
 				),


### PR DESCRIPTION
## Suggested changelog entry
WordPress.PHP.RestrictedPHPFunctions: the error message has been improved.

## Related issues/external references

Follow up on the conversation about this phrasing in https://github.com/WordPress/WordPress-Coding-Standards/pull/2491#discussion_r1775744625 and https://github.com/WordPress/WordPress-Coding-Standards/pull/2693#discussion_r2841053023

Also related to: https://github.com/WordPress/wpcs-docs/pull/158
