### PR TITLE
PHP/RestrictedPHPFunctions: update error message to focus on security risk

### DIFF
--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -35,7 +35,7 @@ final class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSnif
 		return array(
 			'create_function' => array(
 				'type'      => 'error',
-				'message'   => '%s() is deprecated as of PHP 7.2 and removed in PHP 8.0. Please use declared named or anonymous functions instead.',
+				'message'   => '%s() must not be used as it can pose a security risk. Use a declared function or an anonymous function (closure) instead.',
 				'functions' => array(
 					'create_function',
 				),


### PR DESCRIPTION
# Description

Updates the error message for the `create_function` group to focus on the security risk instead of referencing PHP deprecation/removal, as that is PHPCompatibility's domain.

This was suggested by @jrfnl in https://github.com/WordPress/WordPress-Coding-Standards/pull/2693#pullrequestreview-3841152274.

@jrfnl, is this more or less what you had in mind, or do you prefer a different approach?

## Suggested changelog entry

`WordPress.PHP.RestrictedPHPFunctions`: improved the clarity of the error message for the error triggered when `create_function` is found.

## Related issues/external references

https://github.com/WordPress/WordPress-Coding-Standards/pull/2693#pullrequestreview-3841152274