### PR TITLE
ContextHelper::is_in_function_call(): handle $valid_functions keys case-insensitively

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -199,8 +199,9 @@ final class ContextHelper {
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile       The file being scanned.
 	 * @param int                         $stackPtr        The index of the token in the stack.
 	 * @param array                       $valid_functions List of valid function names.
-	 *                                                     Note: The keys to this array should be the function names
-	 *                                                     in lowercase. Values are irrelevant.
+	 *                                                     Note: The keys to this array should be the function names.
+	 *                                                     Values are irrelevant. The matching of function names found in
+	 *                                                     the code against the keys in this array is done case-insensitively.
 	 * @param bool                        $global_function Optional. Whether to make sure that the function call is
 	 *                                                     to a global function. If `false`, calls to methods, be it static
 	 *                                                     `Class::method()` or via an object `$obj->method()`, and
@@ -217,6 +218,8 @@ final class ContextHelper {
 	 * @return int|bool Stack pointer to the function call T_STRING token or false otherwise.
 	 */
 	public static function is_in_function_call( File $phpcsFile, $stackPtr, array $valid_functions, $global_function = true, $allow_nested = false ) {
+		$valid_functions = array_change_key_case( $valid_functions, \CASE_LOWER );
+
 		$tokens = $phpcsFile->getTokens();
 		if ( ! isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 			return false;

--- a/WordPress/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.php
@@ -155,21 +155,47 @@ final class IsInFunctionCallUnitTest extends UtilityMethodTestCase {
 	}
 
 	/**
-	 * Test to document that is_in_function_call() does not match when $valid_functions keys are not lowercase.
+	 * Test that is_in_function_call() matches regardless of the case of $valid_functions keys.
+	 *
+	 * @dataProvider dataIsInFunctionCallShouldMatchRegardlessOfValidFunctionsKeyCase
+	 *
+	 * @param string $functionName The function name to use as a key in $valid_functions.
 	 *
 	 * @return void
 	 */
-	public function testIsInFunctionCallShouldReturnFalseWhenValidFunctionsKeysAreNotLowercase() {
+	public function testIsInFunctionCallShouldMatchRegardlessOfValidFunctionsKeyCase( $functionName ) {
 		$insideFunctionPtr = $this->getTargetToken( '/* testLowercaseNameInsideCall */', \T_VARIABLE );
+		$expected          = $this->getTargetToken( '/* testLowercaseName */', \T_STRING );
 		$result            = ContextHelper::is_in_function_call(
 			self::$phpcsFile,
 			$insideFunctionPtr,
 			array(
-				'Valid_Function1' => true,
+				$functionName => true,
 			)
 		);
 
-		$this->assertFalse( $result );
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsInFunctionCallShouldMatchRegardlessOfValidFunctionsKeyCase()
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function dataIsInFunctionCallShouldMatchRegardlessOfValidFunctionsKeyCase() {
+		return array(
+			'lowercase key' => array(
+				'functionName' => 'valid_function1',
+			),
+			'uppercase key' => array(
+				'functionName' => 'VALID_FUNCTION1',
+			),
+			'mixed case key' => array(
+				'functionName' => 'Valid_Function1',
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
# Description

Follow-up to #2626 as discussed [during code review](https://github.com/WordPress/WordPress-Coding-Standards/pull/2626#discussion_r2847972654).

The `ContextHelper::is_in_function_call()` method already lowercased the token content before matching, but required callers to pass `$valid_functions` keys in lowercase. This normalizes the keys internally using `array_change_key_case()`, so callers no longer need to worry about passing lowercase function names.

## Suggested changelog entry

- `ContextHelper::is_in_function_call()`: the `$valid_functions` parameter keys are now matched case-insensitively. Previously, keys had to be lowercase.

## Related issues/external references

Follow-up to #2626.
