### PR TITLE
UnslashingFunctionsHelper::is_unslashing_function(): add tests

### DIFF
--- a/WordPress/Tests/Helpers/UnslashingFunctionsHelper/IsUnslashingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/UnslashingFunctionsHelper/IsUnslashingFunctionUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\UnslashingFunctionsHelper;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper;
+
+/**
+ * Tests for the `UnslashingFunctionsHelper::is_unslashing_function()` method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper::is_unslashing_function()
+ */
+final class IsUnslashingFunctionUnitTest extends TestCase {
+
+	/**
+	 * Test is_unslashing_function().
+	 *
+	 * @dataProvider dataIsUnslashingFunction
+	 *
+	 * @param string $functionName   The function name to test.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsUnslashingFunction( $functionName, $expectedResult ) {
+		$this->assertSame(
+			$expectedResult,
+			UnslashingFunctionsHelper::is_unslashing_function( $functionName )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 * @see testIsUnslashingFunction()
+	 */
+	public static function dataIsUnslashingFunction() {
+		return array(
+			'lowercase_name'             => array(
+				'functionName'   => 'wp_unslash',
+				'expectedResult' => true,
+			),
+			'mixedcase_name'             => array(
+				'functionName'   => 'sTrIpSlAsHeS_DeEp',
+				'expectedResult' => true,
+			),
+			'not_an_unslashing_function' => array(
+				'functionName'   => 'stripslashes',
+				'expectedResult' => false,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/UnslashingFunctionsHelper/IsUnslashingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/UnslashingFunctionsHelper/IsUnslashingFunctionUnitTest.php
@@ -17,7 +17,7 @@ use WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper;
  *
  * @since 3.4.0
  *
- * @covers \WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper::is_unslashing_function()
+ * @covers \WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper::is_unslashing_function
  */
 final class IsUnslashingFunctionUnitTest extends TestCase {
 
@@ -41,8 +41,9 @@ final class IsUnslashingFunctionUnitTest extends TestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array<string, bool|string>>
 	 * @see testIsUnslashingFunction()
+	 *
+	 * @return array<string, array<string, bool|string>>
 	 */
 	public static function dataIsUnslashingFunction() {
 		return array(


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `UnslashingFunctionsHelper::is_unslashing_function()` method.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272