### PR TITLE
PrintingFunctionsTrait: add tests

### DIFF
--- a/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
+++ b/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\PrintingFunctionsTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\PrintingFunctionsTrait;
+
+/**
+ * Tests for the `PrintingFunctionsTrait::get_printing_functions()` method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait::get_printing_functions
+ */
+final class GetPrintingFunctionsUnitTest extends TestCase {
+
+	/**
+	 * Test class using the PrintingFunctionsTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->testClass = new class() {
+			use PrintingFunctionsTrait;
+		};
+	}
+
+	/**
+	 * Test that get_printing_functions() returns an array containing a known
+	 * built-in printing function.
+	 *
+	 * @return void
+	 */
+	public function testGetPrintingFunctionsContainsKnownFunction() {
+		$result = $this->testClass->get_printing_functions();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'printf', $result );
+		$this->assertTrue( $result['printf'] );
+	}
+
+	/**
+	 * Test that get_printing_functions() includes custom printing functions.
+	 *
+	 * @return void
+	 */
+	public function testGetPrintingFunctionsIncludesCustomFunctions() {
+		$defaultCount                             = count( $this->testClass->get_printing_functions() );
+		$this->testClass->customPrintingFunctions = array( 'my_custom_print' );
+
+		$result = $this->testClass->get_printing_functions();
+
+		$this->assertCount( $defaultCount + 1, $result );
+		$this->assertArrayHasKey( 'my_custom_print', $result );
+		$this->assertFalse( $result['my_custom_print'] );
+	}
+
+	/**
+	 * Test that get_printing_functions() updates the result when custom
+	 * printing functions are changed.
+	 *
+	 * @return void
+	 */
+	public function testGetPrintingFunctionsUpdatesWhenCustomFunctionsChange() {
+		$this->testClass->customPrintingFunctions = array( 'first_custom' );
+		$result                                   = $this->testClass->get_printing_functions();
+		$this->assertArrayHasKey( 'first_custom', $result );
+		$this->assertFalse( $result['first_custom'] );
+
+		$this->testClass->customPrintingFunctions = array( 'second_custom' );
+		$result                                   = $this->testClass->get_printing_functions();
+		$this->assertArrayHasKey( 'second_custom', $result );
+		$this->assertFalse( $result['second_custom'] );
+		$this->assertArrayNotHasKey( 'first_custom', $result );
+	}
+}

--- a/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
+++ b/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
@@ -57,7 +57,7 @@ final class GetPrintingFunctionsUnitTest extends TestCase {
 		$result = $this->testClass->get_printing_functions();
 
 		$this->assertIsArray( $result, 'Function list is not an array' );
-		$this->assertCount( $this->testClass->get_default_function_count(), $result, 'Number of default printing functions does not match' );
+		$this->assertCount( $this->testClass->get_default_function_count(), $result, 'Number of printing functions does not match expectation' );
 		$this->assertArrayHasKey( 'printf', $result, 'printf() is not in the function list' );
 		$this->assertTrue( $result['printf'], 'printf() value should be true, indicating a default function' );
 	}
@@ -72,7 +72,8 @@ final class GetPrintingFunctionsUnitTest extends TestCase {
 
 		$result = $this->testClass->get_printing_functions();
 
-		$this->assertCount( $this->testClass->get_default_function_count() + 1, $result, 'Total count should be default functions + 1 custom function' );
+		$expectedCount = $this->testClass->get_default_function_count() + 1;
+		$this->assertCount( $expectedCount, $result, 'Total count should be default functions + 1 custom function' );
 		$this->assertArrayHasKey( 'my_custom_print', $result, 'Custom function is not in the function list' );
 		$this->assertFalse( $result['my_custom_print'], 'my_custom_print() value should be false, indicating a custom function' );
 	}

--- a/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
+++ b/WordPress/Tests/Helpers/PrintingFunctionsTrait/GetPrintingFunctionsUnitTest.php
@@ -36,21 +36,30 @@ final class GetPrintingFunctionsUnitTest extends TestCase {
 	protected function setUp(): void {
 		$this->testClass = new class() {
 			use PrintingFunctionsTrait;
+
+			/**
+			 * Retrieve the number of default printing functions.
+			 *
+			 * @return int
+			 */
+			public function get_default_function_count() {
+				return count( $this->printingFunctions );
+			}
 		};
 	}
 
 	/**
-	 * Test that get_printing_functions() returns an array containing a known
-	 * built-in printing function.
+	 * Test get_printing_functions() when no custom printing functions have been added.
 	 *
 	 * @return void
 	 */
-	public function testGetPrintingFunctionsContainsKnownFunction() {
+	public function testGetPrintingFunctionsWithoutCustomFunctions() {
 		$result = $this->testClass->get_printing_functions();
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'printf', $result );
-		$this->assertTrue( $result['printf'] );
+		$this->assertIsArray( $result, 'Function list is not an array' );
+		$this->assertCount( $this->testClass->get_default_function_count(), $result, 'Number of default printing functions does not match' );
+		$this->assertArrayHasKey( 'printf', $result, 'printf() is not in the function list' );
+		$this->assertTrue( $result['printf'], 'printf() value should be true, indicating a default function' );
 	}
 
 	/**
@@ -59,14 +68,13 @@ final class GetPrintingFunctionsUnitTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetPrintingFunctionsIncludesCustomFunctions() {
-		$defaultCount                             = count( $this->testClass->get_printing_functions() );
 		$this->testClass->customPrintingFunctions = array( 'my_custom_print' );
 
 		$result = $this->testClass->get_printing_functions();
 
-		$this->assertCount( $defaultCount + 1, $result );
-		$this->assertArrayHasKey( 'my_custom_print', $result );
-		$this->assertFalse( $result['my_custom_print'] );
+		$this->assertCount( $this->testClass->get_default_function_count() + 1, $result, 'Total count should be default functions + 1 custom function' );
+		$this->assertArrayHasKey( 'my_custom_print', $result, 'Custom function is not in the function list' );
+		$this->assertFalse( $result['my_custom_print'], 'my_custom_print() value should be false, indicating a custom function' );
 	}
 
 	/**
@@ -78,13 +86,13 @@ final class GetPrintingFunctionsUnitTest extends TestCase {
 	public function testGetPrintingFunctionsUpdatesWhenCustomFunctionsChange() {
 		$this->testClass->customPrintingFunctions = array( 'first_custom' );
 		$result                                   = $this->testClass->get_printing_functions();
-		$this->assertArrayHasKey( 'first_custom', $result );
-		$this->assertFalse( $result['first_custom'] );
+		$this->assertArrayHasKey( 'first_custom', $result, 'first_custom() is not in the function list' );
+		$this->assertFalse( $result['first_custom'], 'first_custom() value should be false, indicating a custom function' );
 
 		$this->testClass->customPrintingFunctions = array( 'second_custom' );
 		$result                                   = $this->testClass->get_printing_functions();
-		$this->assertArrayHasKey( 'second_custom', $result );
-		$this->assertFalse( $result['second_custom'] );
-		$this->assertArrayNotHasKey( 'first_custom', $result );
+		$this->assertArrayHasKey( 'second_custom', $result, 'second_custom() is not in the function list' );
+		$this->assertFalse( $result['second_custom'], 'second_custom() value should be false, indicating a custom function' );
+		$this->assertArrayNotHasKey( 'first_custom', $result, 'first_custom() should no longer be in the function list' );
 	}
 }

--- a/WordPress/Tests/Helpers/PrintingFunctionsTrait/IsPrintingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/PrintingFunctionsTrait/IsPrintingFunctionUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\PrintingFunctionsTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\PrintingFunctionsTrait;
+
+/**
+ * Tests for the `PrintingFunctionsTrait::is_printing_function()` method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait::is_printing_function
+ */
+final class IsPrintingFunctionUnitTest extends TestCase {
+
+	/**
+	 * Test class using the PrintingFunctionsTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private static $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		self::$testClass = new class() {
+			use PrintingFunctionsTrait;
+		};
+	}
+
+	/**
+	 * Test is_printing_function().
+	 *
+	 * @dataProvider dataIsPrintingFunction
+	 *
+	 * @param string $functionName   The function name to test.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsPrintingFunction( $functionName, $expectedResult ) {
+		$this->assertSame(
+			$expectedResult,
+			self::$testClass->is_printing_function( $functionName )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsPrintingFunction()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsPrintingFunction() {
+		return array(
+			'lowercase_name'          => array(
+				'functionName'   => 'printf',
+				'expectedResult' => true,
+			),
+			'mixedcase_name'          => array(
+				'functionName'   => 'vPrInTf',
+				'expectedResult' => true,
+			),
+			'not_a_printing_function' => array(
+				'functionName'   => 'echo',
+				'expectedResult' => false,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/PrintingFunctionsTrait/IsPrintingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/PrintingFunctionsTrait/IsPrintingFunctionUnitTest.php
@@ -34,9 +34,10 @@ final class IsPrintingFunctionUnitTest extends TestCase {
 	 * @return void
 	 */
 	public static function setUpBeforeClass(): void {
-		self::$testClass = new class() {
+		self::$testClass                          = new class() {
 			use PrintingFunctionsTrait;
 		};
+		self::$testClass->customPrintingFunctions = array( 'my_custom_function' );
 	}
 
 	/**
@@ -65,17 +66,21 @@ final class IsPrintingFunctionUnitTest extends TestCase {
 	 */
 	public static function dataIsPrintingFunction() {
 		return array(
-			'lowercase_name'          => array(
-				'functionName'   => 'printf',
-				'expectedResult' => true,
-			),
-			'mixedcase_name'          => array(
-				'functionName'   => 'vPrInTf',
-				'expectedResult' => true,
-			),
 			'not_a_printing_function' => array(
 				'functionName'   => 'echo',
 				'expectedResult' => false,
+			),
+			'lowercase_name' => array(
+				'functionName'   => 'printf',
+				'expectedResult' => true,
+			),
+			'mixedcase_name' => array(
+				'functionName'   => 'vPrInTf',
+				'expectedResult' => true,
+			),
+			'custom_printing_function' => array(
+				'functionName'   => 'my_custom_function',
+				'expectedResult' => true,
 			),
 		);
 	}


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `PrintingFunctionsTrait::is_printing_function()` and `PrintingFunctionsTrait::get_printing_functions()` methods.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272