### PR TITLE
ContextHelper::is_in_type_test(): add tests

### DIFF
--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
@@ -4,6 +4,7 @@
  * The below should NOT be recognized as being inside a type test function call.
  */
 
+/* testBareVariable */ $value;
 some_function( /* testOtherFunctionCall */ $value );
 MyNamespace\is_numeric( /* testPartiallyQualifiedFunction */ $value );
 \MyNamespace\is_array( /* testFullyQualifiedNamespacedFunction */ $value );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
@@ -12,7 +12,7 @@ namespace\Sub\is_float( /* testNamespaceRelativeSubFunction */ $value );
 $obj->is_string( /* testObjectMethod */ $value );
 $obj?->is_object( /* testNullsafeObjectMethod */ $value );
 TypeChecker::is_int( /* testStaticMethod */ $value );
-is_scalar( my_function( /* testNestedFunctionCall */ $value ) );
+is_scalar( my_function( /* testNestedNonTargetFunctionCall */ $value ) );
 
 /*
  * The below should be recognized as being inside a type test function call.
@@ -22,3 +22,4 @@ is_array( /* testUnqualifiedFunction */ $value );
 Is_Bool( /* testMixedCaseFunction */ $value );
 \is_string( /* testFullyQualifiedFunction */ $value );
 \IS_NUMERIC( /* testFullyQualifiedUpperCaseFunction */ $value );
+is_int( is_float( /* testNestedTypeTestCall */ $value ) );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * The below should NOT be recognized as being inside a type test function call.
+ */
+
+some_function( /* testOtherFunctionCall */ $value );
+MyNamespace\is_numeric( /* testPartiallyQualifiedFunction */ $value );
+\MyNamespace\is_array( /* testFullyQualifiedNamespacedFunction */ $value );
+namespace\is_bool( /* testNamespaceRelativeFunction */ $value ); // The method should start recognizing this as a type test function once it can resolve relative namespaces.
+namespace\Sub\is_float( /* testNamespaceRelativeSubFunction */ $value );
+$obj->is_string( /* testObjectMethod */ $value );
+$obj?->is_object( /* testNullsafeObjectMethod */ $value );
+TypeChecker::is_int( /* testStaticMethod */ $value );
+is_scalar( my_function( /* testNestedFunctionCall */ $value ) );
+
+/*
+ * The below should be recognized as being inside a type test function call.
+ */
+
+is_array( /* testUnqualifiedFunction */ $value );
+Is_Bool( /* testMixedCaseFunction */ $value );
+\is_string( /* testFullyQualifiedFunction */ $value );
+\IS_NUMERIC( /* testFullyQualifiedUpperCaseFunction */ $value );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ContextHelper;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\ContextHelper;
+
+/**
+ * Tests for the `ContextHelper::is_in_type_test()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
+ */
+final class IsInTypeTestUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test is_in_type_test().
+	 *
+	 * @dataProvider dataIsInTypeTest
+	 *
+	 * @param string $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsInTypeTest( $testMarker, $expectedResult ) {
+		$stackPtr = $this->getTargetToken( $testMarker, \T_VARIABLE );
+		$result   = ContextHelper::is_in_type_test( self::$phpcsFile, $stackPtr );
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsInTypeTest()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsInTypeTest() {
+		return array(
+			// Cases that should return false.
+			'other_function_call' => array(
+				'testMarker'     => '/* testOtherFunctionCall */',
+				'expectedResult' => false,
+			),
+			'partially_qualified_function' => array(
+				'testMarker'     => '/* testPartiallyQualifiedFunction */',
+				'expectedResult' => false,
+			),
+			'fully_qualified_namespaced_function' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespacedFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_sub_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeSubFunction */',
+				'expectedResult' => false,
+			),
+			'object_method' => array(
+				'testMarker'     => '/* testObjectMethod */',
+				'expectedResult' => false,
+			),
+			'nullsafe_object_method' => array(
+				'testMarker'     => '/* testNullsafeObjectMethod */',
+				'expectedResult' => false,
+			),
+			'static_method' => array(
+				'testMarker'     => '/* testStaticMethod */',
+				'expectedResult' => false,
+			),
+			'nested_function_call' => array(
+				'testMarker'     => '/* testNestedFunctionCall */',
+				'expectedResult' => false,
+			),
+
+			// Cases that should return true.
+			'unqualified_function' => array(
+				'testMarker'     => '/* testUnqualifiedFunction */',
+				'expectedResult' => true,
+			),
+			'mixed_case_function' => array(
+				'testMarker'     => '/* testMixedCaseFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_function' => array(
+				'testMarker'     => '/* testFullyQualifiedFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_upper_case_function' => array(
+				'testMarker'     => '/* testFullyQualifiedUpperCaseFunction */',
+				'expectedResult' => true,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
@@ -48,6 +48,10 @@ final class IsInTypeTestUnitTest extends UtilityMethodTestCase {
 	public static function dataIsInTypeTest() {
 		return array(
 			// Cases that should return false.
+			'bare_variable' => array(
+				'testMarker'     => '/* testBareVariable */',
+				'expectedResult' => false,
+			),
 			'other_function_call' => array(
 				'testMarker'     => '/* testOtherFunctionCall */',
 				'expectedResult' => false,

--- a/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInTypeTestUnitTest.php
@@ -80,8 +80,8 @@ final class IsInTypeTestUnitTest extends UtilityMethodTestCase {
 				'testMarker'     => '/* testStaticMethod */',
 				'expectedResult' => false,
 			),
-			'nested_function_call' => array(
-				'testMarker'     => '/* testNestedFunctionCall */',
+			'nested_non_target_function_call' => array(
+				'testMarker'     => '/* testNestedNonTargetFunctionCall */',
 				'expectedResult' => false,
 			),
 
@@ -100,6 +100,10 @@ final class IsInTypeTestUnitTest extends UtilityMethodTestCase {
 			),
 			'fully_qualified_upper_case_function' => array(
 				'testMarker'     => '/* testFullyQualifiedUpperCaseFunction */',
+				'expectedResult' => true,
+			),
+			'nested_type_test_call' => array(
+				'testMarker'     => '/* testNestedTypeTestCall */',
 				'expectedResult' => true,
 			),
 		);

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -18,7 +18,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since 0.13.0 Class name changed: this class is now namespaced.
  * @since 1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
- * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `ContextHelper::is_in_type_test()` method.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272