### PR TITLE
Security/ValidatedSanitizedInput: recognise casts through grouping parens

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -355,9 +355,27 @@ final class ContextHelper {
 			return false;
 		}
 
-		$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
-
-		return isset( self::$safe_casts[ $tokens[ $prev ]['code'] ] );
+		// Walk outward through surrounding grouping parentheses. A leading
+		// cast sanitizes the enclosed value whether or not there are
+		// intermediate parens / coalesce operators — e.g. both
+		// `(int) $_GET['x']` and `(int) ( $_GET['x'] ?? 0 )` yield an int.
+		// Stop at the first non-empty token that isn't an open parenthesis;
+		// function-call parens (preceded by T_STRING) fall through to the
+		// not-a-cast branch correctly.
+		$check = $stackPtr;
+		do {
+			$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $check - 1 ), null, true );
+			if ( false === $prev ) {
+				return false;
+			}
+			if ( isset( self::$safe_casts[ $tokens[ $prev ]['code'] ] ) ) {
+				return true;
+			}
+			if ( \T_OPEN_PARENTHESIS !== $tokens[ $prev ]['code'] ) {
+				return false;
+			}
+			$check = $prev;
+		} while ( true );
 	}
 
 	/**

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -500,3 +500,25 @@ function test_in_match_condition_is_regarded_as_comparison() {
 		};
 	}
 }
+
+/*
+ * Type casts (int, float, bool) sanitize the enclosed value even when
+ * separated from the superglobal by grouping parentheses — e.g. the
+ * common `(int) ( $_GET['id'] ?? 0 )` idiom. Ref issue #2210.
+ */
+function test_cast_around_grouping_parens() {
+	$a = (int) ( $_POST['foo']    ?? 0 );     // OK.
+	$b = (int) ( $_GET['bar']     ?? 0 );     // OK.
+	$c = (bool) ( $_POST['flag']  ?? false ); // OK.
+	$d = (float) ( $_POST['rate'] ?? 0.0 );   // OK.
+	$e = (int) ( ( $_POST['n']    ?? 0 ) );   // OK — nested grouping parens.
+
+	// (string) is not in the safe-cast list, so this is still unsanitised.
+	$g = (string) ( $_POST['s'] ?? '' );      // Bad x 2 - unslash + sanitize.
+
+	// Array cast isn't treated as safe either.
+	$h = (array) ( $_POST['arr'] ?? array() ); // Bad x 2 - unslash + sanitize.
+
+	// Non-cast leading token: no rescue from the paren-walk.
+	$i = abs( $_POST['foo'] ?? 0 );           // Bad x 2 - unslash + sanitize.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -114,6 +114,9 @@ final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 					497 => 1,
 					498 => 1,
 					499 => 3,
+					517 => 2,
+					520 => 2,
+					523 => 2,
 				);
 
 			case 'ValidatedSanitizedInputUnitTest.2.inc':


### PR DESCRIPTION
Fixes #2723. Related to #2210 (different sanitiser mechanism — see that issue for context).

## Summary

`ContextHelper::is_safe_casted()` currently only inspects the token immediately preceding the superglobal. The common idiom

```php
$id = (int) ( $_GET['id'] ?? 0 );
```

puts a `(` between the cast and the superglobal, so the helper returns `false`, and `WordPress.Security.ValidatedSanitizedInput` fires two false-positive errors (`InputNotSanitized` + `MissingUnslash`) for a line that is in fact validated (`??`), unslashed (slashes don't survive the cast), and sanitised (only output is a PHP scalar of the cast type).

Rewriting to `(int) absint( wp_unslash( $_GET['id'] ?? 0 ) )` adds no safety.

## Change

When searching for a preceding safe cast, walk outward through surrounding grouping parentheses. Stop at the first non-paren, non-cast token. Effect:

- `(int) ( $_GET['x'] ?? 0 )` → safe ✅ (new)
- `(bool) ( $_POST['f'] ?? false )` → safe ✅ (new)
- `(float) ( $_POST['rate'] ?? 0.0 )` → safe ✅ (new)
- `(int) ( ( $_POST['n'] ?? 0 ) )` → safe ✅ (new, nested grouping)
- `(int) $_GET['x']` → safe ✅ (unchanged)
- `func( $_GET['x'] )` → not safe via this path ✅ (preceding token before the call parens is a `T_STRING`, not a cast, so the walk terminates correctly)
- `(string) ( $_GET['x'] ?? '' )` → not safe ✅ (`(string)` isn't in the safe-cast list, still reports)
- `(array) ( $_POST['arr'] ?? array() )` → not safe ✅

## Scope — cases deliberately left for a follow-up

This PR only teaches the helper to see through *grouping* parens whose leading context is the cast itself. Anything that puts a non-paren token between the outer `(` and the superglobal still walks straight into that token and stops. Concretely:

```php
// Ternary: superglobal's preceding non-empty token is `?`, not `(` or a cast.
$n = (int) ( isset( $_POST['n'] ) ? $_POST['n'] : 0 );

// Arithmetic: `+` sits between the superglobal and the grouping paren.
$n = (int) ( strlen( $_POST['x'] ) + 1 );

// Same shape for `- * / . ?? ?:` etc.
```

The fix for those is a different algorithm — walk the superglobal's `nested_parenthesis` stack outward and, for each enclosing pair, check the token immediately before the `(`. If it's a cast, the value is safe regardless of what operators sit in between. That walk also needs to respect `parenthesis_owner` (stop at `if`/`while`/`for`/etc.) and treat function-call parens correctly. I'd rather ship this PR covering the `?? default` idiom first and do the `nested_parenthesis` walk as a follow-up.

#2210 (implicit numeric coercion in arithmetic expressions) is a separate sanitiser mechanism and needs a separate fix.

## Tests

Added `test_cast_around_grouping_parens()` to `ValidatedSanitizedInputUnitTest.1.inc` covering the handled cases (no expected errors) and the still-flagged ones (`(string)`, `(array)`, function call — 2 errors each).

## Test plan

- [ ] `vendor/bin/phpunit --filter ValidatedSanitizedInputUnitTest` passes.
- [ ] Running the sniff against the updated fixture, error counts per line match `getErrorList()`.

---
*PR drafted with AI assistance (Claude).*