### PR TITLE
ContextHelper::is_in_isset_or_empty(): add basic tests

### DIFF
--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * The below should NOT be recognized as being inside an isset/empty check.
+ */
+
+some_function( /* testOtherFunctionCall */ $value );
+array_key_exists( /* testMissingArrayParam */ $key );
+key_exists( /* testKeyParamNotArrayParam */ $value, $array );
+MyNamespace\key_exists( 'key', /* testPartiallyQualifiedFunction */ $array );
+\MyNamespace\array_key_exists( 'key', /* testFullyQualifiedNamespacedFunction */ $array );
+namespace\array_key_exists( 'key', /* testNamespaceRelativeFunction */ $array ); // The method should start recognizing this once it can resolve relative namespaces.
+namespace\Sub\key_exists( 'key', /* testNamespaceRelativeSubFunction */ $array );
+$obj->array_key_exists( 'key', /* testObjectMethod */ $array );
+$obj?->key_exists( 'key', /* testNullsafeObjectMethod */ $array );
+MyClass::array_key_exists( 'key', /* testStaticMethod */ $array );
+key_exists( 'key', my_function( /* testNestedFunctionCall */ $array ) );
+
+/*
+ * The below should be recognized as being inside an isset/empty check.
+ */
+
+isset( /* testIsset */ $value );
+empty( /* testEmpty */ $value );
+array_key_exists( 'key', /* testUnqualifiedFunction */ $array );
+Key_Exists( 'key', /* testMixedCaseFunction */ $array );
+\array_key_exists( 'key', /* testFullyQualifiedFunction */ $array );
+\KEY_EXISTS( 'key', /* testFullyQualifiedUpperCaseFunction */ $array );
+array_key_exists( array: /* testNamedParamReversedOrder */ $array, key: 'foo' );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
@@ -4,6 +4,7 @@
  * The below should NOT be recognized as being inside an isset/empty check.
  */
 
+/* testBareVariable */ $value;
 some_function( /* testOtherFunctionCall */ $value );
 array_key_exists( /* testMissingArrayParam */ $key );
 key_exists( /* testKeyParamNotArrayParam */ $value, $array );
@@ -14,7 +15,7 @@ namespace\Sub\key_exists( 'key', /* testNamespaceRelativeSubFunction */ $array )
 $obj->array_key_exists( 'key', /* testObjectMethod */ $array );
 $obj?->key_exists( 'key', /* testNullsafeObjectMethod */ $array );
 MyClass::array_key_exists( 'key', /* testStaticMethod */ $array );
-key_exists( 'key', my_function( /* testNestedFunctionCall */ $array ) );
+key_exists( 'key', my_function( /* testNestedNonTargetFunctionCall */ $array ) );
 
 /*
  * The below should be recognized as being inside an isset/empty check.
@@ -27,3 +28,4 @@ Key_Exists( 'key', /* testMixedCaseFunction */ $array );
 \array_key_exists( 'key', /* testFullyQualifiedFunction */ $array );
 \KEY_EXISTS( 'key', /* testFullyQualifiedUpperCaseFunction */ $array );
 array_key_exists( array: /* testNamedParamReversedOrder */ $array, key: 'foo' );
+array_key_exists( 'key', \key_exists( 'key', /* testNestedValidFunctionCall */ $array ) );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.inc
@@ -16,6 +16,9 @@ $obj->array_key_exists( 'key', /* testObjectMethod */ $array );
 $obj?->key_exists( 'key', /* testNullsafeObjectMethod */ $array );
 MyClass::array_key_exists( 'key', /* testStaticMethod */ $array );
 key_exists( 'key', my_function( /* testNestedNonTargetFunctionCall */ $array ) );
+$obj->isset( /* testIssetObjectMethod */ $value );
+Foo::empty( /* testEmptyStaticMethod */ $value );
+MyNamespace\isset( /* testIssetNamespacedFunction */ $value );
 
 /*
  * The below should be recognized as being inside an isset/empty check.

--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
@@ -96,6 +96,18 @@ final class IsInIssetOrEmptyUnitTest extends UtilityMethodTestCase {
 				'testMarker'     => '/* testNestedNonTargetFunctionCall */',
 				'expectedResult' => false,
 			),
+			'isset_object_method' => array(
+				'testMarker'     => '/* testIssetObjectMethod */',
+				'expectedResult' => false,
+			),
+			'empty_static_method' => array(
+				'testMarker'     => '/* testEmptyStaticMethod */',
+				'expectedResult' => false,
+			),
+			'isset_namespaced_function' => array(
+				'testMarker'     => '/* testIssetNamespacedFunction */',
+				'expectedResult' => false,
+			),
 
 			// Cases that should return true.
 			'isset' => array(

--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ContextHelper;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\ContextHelper;
+
+/**
+ * Tests for the `ContextHelper::is_in_isset_or_empty()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_isset_or_empty
+ */
+final class IsInIssetOrEmptyUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test is_in_isset_or_empty().
+	 *
+	 * @dataProvider dataIsInIssetOrEmpty
+	 *
+	 * @param string $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsInIssetOrEmpty( $testMarker, $expectedResult ) {
+		$stackPtr = $this->getTargetToken( $testMarker, \T_VARIABLE );
+		$result   = ContextHelper::is_in_isset_or_empty( self::$phpcsFile, $stackPtr );
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsInIssetOrEmpty()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsInIssetOrEmpty() {
+		return array(
+			// Cases that should return false.
+			'other_function_call' => array(
+				'testMarker'     => '/* testOtherFunctionCall */',
+				'expectedResult' => false,
+			),
+			'missing_array_param' => array(
+				'testMarker'     => '/* testMissingArrayParam */',
+				'expectedResult' => false,
+			),
+			'key_param_not_array_param' => array(
+				'testMarker'     => '/* testKeyParamNotArrayParam */',
+				'expectedResult' => false,
+			),
+			'partially_qualified_function' => array(
+				'testMarker'     => '/* testPartiallyQualifiedFunction */',
+				'expectedResult' => false,
+			),
+			'fully_qualified_namespaced_function' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespacedFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_sub_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeSubFunction */',
+				'expectedResult' => false,
+			),
+			'object_method' => array(
+				'testMarker'     => '/* testObjectMethod */',
+				'expectedResult' => false,
+			),
+			'nullsafe_object_method' => array(
+				'testMarker'     => '/* testNullsafeObjectMethod */',
+				'expectedResult' => false,
+			),
+			'static_method' => array(
+				'testMarker'     => '/* testStaticMethod */',
+				'expectedResult' => false,
+			),
+			'nested_function_call' => array(
+				'testMarker'     => '/* testNestedFunctionCall */',
+				'expectedResult' => false,
+			),
+
+			// Cases that should return true.
+			'isset' => array(
+				'testMarker'     => '/* testIsset */',
+				'expectedResult' => true,
+			),
+			'empty' => array(
+				'testMarker'     => '/* testEmpty */',
+				'expectedResult' => true,
+			),
+			'unqualified_function' => array(
+				'testMarker'     => '/* testUnqualifiedFunction */',
+				'expectedResult' => true,
+			),
+			'mixed_case_function' => array(
+				'testMarker'     => '/* testMixedCaseFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_function' => array(
+				'testMarker'     => '/* testFullyQualifiedFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_upper_case_function' => array(
+				'testMarker'     => '/* testFullyQualifiedUpperCaseFunction */',
+				'expectedResult' => true,
+			),
+			'named_param_reversed_order' => array(
+				'testMarker'     => '/* testNamedParamReversedOrder */',
+				'expectedResult' => true,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInIssetOrEmptyUnitTest.php
@@ -48,6 +48,10 @@ final class IsInIssetOrEmptyUnitTest extends UtilityMethodTestCase {
 	public static function dataIsInIssetOrEmpty() {
 		return array(
 			// Cases that should return false.
+			'bare_variable' => array(
+				'testMarker'     => '/* testBareVariable */',
+				'expectedResult' => false,
+			),
 			'other_function_call' => array(
 				'testMarker'     => '/* testOtherFunctionCall */',
 				'expectedResult' => false,
@@ -88,8 +92,8 @@ final class IsInIssetOrEmptyUnitTest extends UtilityMethodTestCase {
 				'testMarker'     => '/* testStaticMethod */',
 				'expectedResult' => false,
 			),
-			'nested_function_call' => array(
-				'testMarker'     => '/* testNestedFunctionCall */',
+			'nested_non_target_function_call' => array(
+				'testMarker'     => '/* testNestedNonTargetFunctionCall */',
 				'expectedResult' => false,
 			),
 
@@ -120,6 +124,10 @@ final class IsInIssetOrEmptyUnitTest extends UtilityMethodTestCase {
 			),
 			'named_param_reversed_order' => array(
 				'testMarker'     => '/* testNamedParamReversedOrder */',
+				'expectedResult' => true,
+			),
+			'nested_valid_function_call' => array(
+				'testMarker'     => '/* testNestedValidFunctionCall */',
 				'expectedResult' => true,
 			),
 		);

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -19,7 +19,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since 1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
- * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_isset_or_empty
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_array_comparison
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `ContextHelper::is_in_isset_or_empty()` method.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272