### PR TITLE
ContextHelper::is_in_array_comparison(): add basic tests

### DIFF
--- a/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.inc
@@ -4,6 +4,7 @@
  * The below should NOT be recognized as being inside an array comparison function call.
  */
 
+/* testBareVariable */ $value;
 some_function( /* testOtherFunctionCall */ $value );
 MyNamespace\in_array( /* testPartiallyQualifiedFunction */ $value, $haystack );
 \MyNamespace\array_search( /* testFullyQualifiedNamespacedFunction */ $value, $haystack );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.inc
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * The below should NOT be recognized as being inside an array comparison function call.
+ */
+
+some_function( /* testOtherFunctionCall */ $value );
+MyNamespace\in_array( /* testPartiallyQualifiedFunction */ $value, $haystack );
+\MyNamespace\array_search( /* testFullyQualifiedNamespacedFunction */ $value, $haystack );
+namespace\array_keys( $array, /* testNamespaceRelativeFunction */ $value ); // The method should start recognizing this as an array comparison function once it can resolve relative namespaces.
+namespace\Sub\in_array( /* testNamespaceRelativeSubFunction */ $value, $haystack );
+$obj->array_search( /* testObjectMethod */ $value, $haystack );
+$obj?->array_keys( $array, /* testNullsafeObjectMethod */ $value );
+ArrayHelper::in_array( /* testStaticMethod */ $value, $haystack );
+array_keys( /* testArrayKeysFirstParamOnly */ $array );
+array_keys( array: /* testArrayKeysWrongNamedParam */ $array, search_value: 'value', strict: true );
+
+/*
+ * The below should be recognized as being inside an array comparison function call.
+ */
+
+in_array( /* testInArray */ $value, $haystack );
+array_search( /* testArraySearch */ $value, $haystack );
+array_keys( $array, /* testArrayKeysWithFilterValue */ $value );
+array_keys( filter_value: /* testArrayKeysNamedParam */ $value, array: $array );
+IN_array( /* testMixedCaseFunction */ $value, $haystack );
+\array_search( /* testFullyQualifiedFunction */ $value, $haystack );
+\ARRAY_KEYS( $array, /* testFullyQualifiedUpperCaseFunction */ $value );
+in_array( my_function( /* testNestedFunctionCall */ $value ), $haystack );

--- a/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ContextHelper;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\ContextHelper;
+
+/**
+ * Tests for the `ContextHelper::is_in_array_comparison()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_array_comparison
+ */
+final class IsInArrayComparisonUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test is_in_array_comparison().
+	 *
+	 * @dataProvider dataIsInArrayComparison
+	 *
+	 * @param string $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsInArrayComparison( $testMarker, $expectedResult ) {
+		$stackPtr = $this->getTargetToken( $testMarker, \T_VARIABLE );
+		$result   = ContextHelper::is_in_array_comparison( self::$phpcsFile, $stackPtr );
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsInArrayComparison()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsInArrayComparison() {
+		return array(
+			// Cases that should return false.
+			'other_function_call' => array(
+				'testMarker'     => '/* testOtherFunctionCall */',
+				'expectedResult' => false,
+			),
+			'partially_qualified_function' => array(
+				'testMarker'     => '/* testPartiallyQualifiedFunction */',
+				'expectedResult' => false,
+			),
+			'fully_qualified_namespaced_function' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespacedFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeFunction */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_sub_function' => array(
+				'testMarker'     => '/* testNamespaceRelativeSubFunction */',
+				'expectedResult' => false,
+			),
+			'object_method' => array(
+				'testMarker'     => '/* testObjectMethod */',
+				'expectedResult' => false,
+			),
+			'nullsafe_object_method' => array(
+				'testMarker'     => '/* testNullsafeObjectMethod */',
+				'expectedResult' => false,
+			),
+			'static_method' => array(
+				'testMarker'     => '/* testStaticMethod */',
+				'expectedResult' => false,
+			),
+			'array_keys_first_param_only' => array(
+				'testMarker'     => '/* testArrayKeysFirstParamOnly */',
+				'expectedResult' => false,
+			),
+			'array_keys_wrong_named_param' => array(
+				'testMarker'     => '/* testArrayKeysWrongNamedParam */',
+				'expectedResult' => false,
+			),
+
+			// Cases that should return true.
+			'in_array' => array(
+				'testMarker'     => '/* testInArray */',
+				'expectedResult' => true,
+			),
+			'array_search' => array(
+				'testMarker'     => '/* testArraySearch */',
+				'expectedResult' => true,
+			),
+			'array_keys_with_filter_value' => array(
+				'testMarker'     => '/* testArrayKeysWithFilterValue */',
+				'expectedResult' => true,
+			),
+			'array_keys_named_param' => array(
+				'testMarker'     => '/* testArrayKeysNamedParam */',
+				'expectedResult' => true,
+			),
+			'mixed_case_function' => array(
+				'testMarker'     => '/* testMixedCaseFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_function' => array(
+				'testMarker'     => '/* testFullyQualifiedFunction */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_upper_case_function' => array(
+				'testMarker'     => '/* testFullyQualifiedUpperCaseFunction */',
+				'expectedResult' => true,
+			),
+			'nested_function_call' => array(
+				'testMarker'     => '/* testNestedFunctionCall */',
+				'expectedResult' => true,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.php
+++ b/WordPress/Tests/Helpers/ContextHelper/IsInArrayComparisonUnitTest.php
@@ -48,6 +48,10 @@ final class IsInArrayComparisonUnitTest extends UtilityMethodTestCase {
 	public static function dataIsInArrayComparison() {
 		return array(
 			// Cases that should return false.
+			'bare_variable' => array(
+				'testMarker'     => '/* testBareVariable */',
+				'expectedResult' => false,
+			),
 			'other_function_call' => array(
 				'testMarker'     => '/* testOtherFunctionCall */',
 				'expectedResult' => false,

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -19,7 +19,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since 1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
- * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_array_comparison
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `ContextHelper::is_in_array_comparison()` method.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272