### PR TITLE
Security/EscapeOutput: make basename( __FILE__ ) pattern matching case-insensitive

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -438,7 +438,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 
 			if ( false !== $file_param ) {
 				// Check for a particular code pattern which can safely be ignored.
-				if ( preg_match( '`^[\\\\]?basename\s*\(\s*__FILE__\s*\)$`', $file_param['clean'] ) === 1 ) {
+				if ( preg_match( '`^[\\\\]?basename\s*\(\s*__FILE__\s*\)$`i', $file_param['clean'] ) === 1 ) {
 					unset( $params[1], $params['file'] ); // Remove the param, whether passed positionally or named.
 				}
 			}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -365,7 +365,7 @@ $obj = new User_Error( $foo ); // OK.
 
 // Make sure special casing of select functions is handled case-insensitively.
 Trigger_ERROR( 'This is fine', $second_param_should_be_ignored ); // OK.
-_Deprecated_File( basename( __FILE__ ), '1.3.0' ); // OK.
+_Deprecated_File( BASENAME( __file__ ), '1.3.0' ); // OK.
 _EX( 'all_params_should_be_ignored_if_function_is_reported_as_unsafe', 'another_param' ); // Bad x 1 for unsafe function.
 
 // Allow for comments in the $file parameter.


### PR DESCRIPTION
# Description

The `WordPress.Security.EscapeOutputsniff` has special handling for `_deprecated_file()` calls where the first parameter follows the `basename( __FILE__ )` pattern.

The regex pattern was case-sensitive, which meant it would only match lowercase `basename()` and uppercase `__FILE__`. This is incorrect because both function names and magic constants (https://3v4l.org/8nAEV and https://www.php.net/manual/en/language.constants.magic.php) in PHP are case-insensitive.

This PR fixes the regex pattern to be case-insensitive.

## Suggested changelog entry

`WordPress.Security.EscapeOutput`: false negative for `_deprecated_file()` calls when the `basename( __FILE__ )` pattern used non-standard casing for `basename()` and/or `__FILE__`.

