### PR TITLE
WP/CronInterval: make callback function name lookup case-insensitive

### DIFF
--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -291,7 +291,7 @@ final class CronIntervalSniff extends Sniff {
 		for ( $ptr = 0; $ptr < $this->phpcsFile->numTokens; $ptr++ ) {
 			if ( \T_FUNCTION === $this->tokens[ $ptr ]['code'] ) {
 				$foundName = FunctionDeclarations::getName( $this->phpcsFile, $ptr );
-				if ( $foundName === $functionName ) {
+				if ( strcasecmp( $foundName, $functionName ) === 0 ) {
 					$functionPtr = $ptr;
 					break;
 				} elseif ( isset( $this->tokens[ $ptr ]['scope_closer'] ) ) {

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -164,9 +164,9 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 // Correctly handle fully qualified WP time constants.
 class FQNConstants {
 	public function add_schedules() {
-		add_filter( 'cron_schedules', array( $this, 'ADD_WEEKLY_SCHEDULE' ) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) ); // Ok: > 15 min.
 		\add_filter( 'cron_schedules', array( $this, 'add_eight_minute_schedule' ) ); // Warning: 8 min.
-		ADD_FILTER( 'cron_schedules', array( $this, 'add_hundred_minute_schedule' ) ); // Warning: time undetermined.
+		ADD_FILTER( 'cron_schedules', array( $this, 'ADD_HUNDRED_MINUTE_SCHEDULE' ) ); // Warning: time undetermined.
 		\Add_Filter( 'cron_schedules', array( $this, 'sneaky_fake_wp_constant_schedule' ) ); // Warning: time undetermined.
 	}
 

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -164,7 +164,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 // Correctly handle fully qualified WP time constants.
 class FQNConstants {
 	public function add_schedules() {
-		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', array( $this, 'ADD_WEEKLY_SCHEDULE' ) ); // Ok: > 15 min.
 		\add_filter( 'cron_schedules', array( $this, 'add_eight_minute_schedule' ) ); // Warning: 8 min.
 		ADD_FILTER( 'cron_schedules', array( $this, 'add_hundred_minute_schedule' ) ); // Warning: time undetermined.
 		\Add_Filter( 'cron_schedules', array( $this, 'sneaky_fake_wp_constant_schedule' ) ); // Warning: time undetermined.
@@ -284,7 +284,7 @@ class FirstClassCallables {
 	public function add_schedules() {
 		add_filter( 'cron_schedules', $this->cron_weekly_schedule(...) ); // Ok: > 15 min.
 		add_filter( 'cron_schedules', $this->cron_eight_minute_schedule(...) ); // Warning: 8 min.
-		add_filter( 'cron_schedules', self::cron_weekly_schedule(...) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', self::Cron_Weekly_Schedule(...) ); // Ok: > 15 min.
 		add_filter( 'cron_schedules', static::cron_eight_minute_schedule(...) ); // Warning: 8 min.
 		add_filter( 'cron_schedules', [$this, 'cron_weekly_schedule'](...) ); // Ok: > 15 min.
 		add_filter( 'cron_schedules', array($this, 'cron_eight_minute_schedule')(...) ); // Warning: 8 min.
@@ -328,6 +328,7 @@ function first_class_six_min_schedule( $schedules ) {
 add_filter( 'cron_schedules', first_class_six_min_schedule(...)); // Warning: 6 min.
 add_filter( 'cron_schedules', 'first_class_six_min_schedule'(...)); // Warning: 6 min.
 add_filter( 'cron_schedules', \first_class_six_min_schedule(...)); // Warning: 6 min.
+add_filter( 'cron_schedules', \FIRST_CLASS_SIX_MIN_SCHEDULE(...)); // Warning: 6 min.
 add_filter( 'cron_schedules', namespace\first_class_six_min_schedule(...)); // Warning: 6 min.
 
 /*

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -69,9 +69,10 @@ final class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			329 => 1,
 			330 => 1,
 			331 => 1,
-			351 => 1,
+			332 => 1,
 			352 => 1,
 			353 => 1,
+			354 => 1,
 		);
 	}
 }


### PR DESCRIPTION
# Description

The `WordPress.WP.CronInterval` sniff was incorrectly treating callback function names as case-sensitive when trying to locate the callback function definition. This led to false positives when the callback reference case did not match the function declaration case.

The fix ensures callback names are compared case-insensitively using `strcasecmp()` when searching for function declarations in the code.

## Suggested changelog entry

`WordPress.WP.CronInterval`: false positive when the callback function reference used different casing than the function declaration.
