### PR TITLE
Remove outdated Funding section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: "https://opencollective.com/php_codesniffer"

--- a/README.md
+++ b/README.md
@@ -253,10 +253,6 @@ At this moment, WordPressCS offer the following tools:
 
 See [CONTRIBUTING](.github/CONTRIBUTING.md), including information about [unit testing](.github/CONTRIBUTING.md#unit-testing) the standard.
 
-## Funding
-
-If you want to sponsor the work on WordPressCS, you can do so by donating to the [PHP_CodeSniffer Open Collective](https://opencollective.com/php_codesniffer).
-
 ## License
 
 See [LICENSE](LICENSE) (MIT).


### PR DESCRIPTION
# Description

Removes the Funding section from the README and the `.github/FUNDING.yml` file.

This is a vestige of the Coding Standards being a separate project, and is no longer accurate now that WordPressCS is maintained as part of the WordPress project.

## Suggested changelog entry

None required.

## Related issues/external references

Partially supersedes #2724