### PR TITLE
PHP/TypeCasts: add XML documentation

### DIFF
--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Type Casts"
+>
+    <standard>
+    <![CDATA[
+      Enforce normalized and safe type casts.
+
+      • Use (float) instead of legacy float casts.
+      • Do not use the (unset) cast. Use unset().
+      • Avoid the (binary) cast (discouraged).
+    ]]>
+    </standard>
+
+    <code_comparison>
+        <code title="Valid: Using normalized float casts.">
+        <![CDATA[
+$price = <em>(float)</em> $value;
+$size  = <em>(float)</em> $value;
+        ]]>
+        </code>
+        <code title="Invalid: Using legacy float casts.">
+        <![CDATA[
+$price = <em>(double)</em> $value;
+$size  = <em>(real)</em>   $value;
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Valid: Use unset().">
+        <![CDATA[
+unset( $value );
+        ]]>
+        </code>
+        <code title="Invalid: Using the (unset) cast.">
+        <![CDATA[
+result = <em>(unset)</em> $value;
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Valid: Prefer a clear alternative.">
+        <![CDATA[
+bytes = (string) $value;
+        ]]>
+        </code>
+        <code title="Invalid: Using the (binary) cast.">
+        <![CDATA[
+bytes = <em>(binary)</em> $value;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -2,54 +2,58 @@
 <documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
     title="Type Casts"
->
+    >
     <standard>
     <![CDATA[
-      Enforce normalized and safe type casts.
-
-      • Use (float) instead of legacy float casts.
-      • Do not use the (unset) cast. Use unset().
-      • Avoid the (binary) cast (discouraged).
+    The (float) cast must be used instead of the (double) and (real) casts. The (real) cast was deprecated in PHP 7.4 and removed in PHP 8.0. The (double) cast was deprecated in PHP 8.5.
     ]]>
     </standard>
-
     <code_comparison>
-        <code title="Valid: Using normalized float casts.">
+        <code title="Valid: Using the normalized (float) cast.">
         <![CDATA[
 $price = <em>(float)</em> $value;
-$size  = <em>(float)</em> $value;
         ]]>
         </code>
         <code title="Invalid: Using legacy float casts.">
         <![CDATA[
 $price = <em>(double)</em> $value;
-$size  = <em>(real)</em>   $value;
+$size  = <em>(real)</em> $value;
         ]]>
         </code>
     </code_comparison>
-
+    <standard>
+    <![CDATA[
+    The (unset) cast must not be used. It was deprecated in PHP 7.2 and removed in PHP 8.0. Use unset() to unset a variable instead.
+    ]]>
+    </standard>
     <code_comparison>
-        <code title="Valid: Use unset().">
+        <code title="Valid: Using the unset() language construct.">
         <![CDATA[
-unset( $value );
+<em>unset</em>( $value );
         ]]>
         </code>
         <code title="Invalid: Using the (unset) cast.">
         <![CDATA[
-result = <em>(unset)</em> $value;
+$result = <em>(unset)</em> $value;
         ]]>
         </code>
     </code_comparison>
-
+    <standard>
+    <![CDATA[
+    Using the (binary) cast or the b prefix is discouraged. The (binary) cast was deprecated in PHP 8.5. Use the (string) cast or a regular string literal instead.
+    ]]>
+    </standard>
     <code_comparison>
-        <code title="Valid: Prefer a clear alternative.">
+        <code title="Valid: Using (string) and a string literal.">
         <![CDATA[
-bytes = (string) $value;
+$bytes = <em>(string)</em> $value;
+$text  = <em>'hello'</em>;
         ]]>
         </code>
-        <code title="Invalid: Using the (binary) cast.">
+        <code title="Invalid: Using (binary) and the b prefix.">
         <![CDATA[
-bytes = <em>(binary)</em> $value;
+$bytes = <em>(binary)</em> $value;
+$text  = <em>b</em>'hello';
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/PHP/TypeCastsStandard.xml
+++ b/WordPress/Docs/PHP/TypeCastsStandard.xml
@@ -5,11 +5,11 @@
     >
     <standard>
     <![CDATA[
-    The (float) cast must be used instead of the (double) and (real) casts. The (real) cast was deprecated in PHP 7.4 and removed in PHP 8.0. The (double) cast was deprecated in PHP 8.5.
+    The float cast must be used instead of the double and real casts. The real cast was deprecated in PHP 7.4 and removed in PHP 8.0. The double cast was deprecated in PHP 8.5.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using the normalized (float) cast.">
+        <code title="Valid: Using the normalized float cast.">
         <![CDATA[
 $price = <em>(float)</em> $value;
         ]]>
@@ -23,7 +23,7 @@ $size  = <em>(real)</em> $value;
     </code_comparison>
     <standard>
     <![CDATA[
-    The (unset) cast must not be used. It was deprecated in PHP 7.2 and removed in PHP 8.0. Use unset() to unset a variable instead.
+    The unset cast must not be used. It was deprecated in PHP 7.2 and removed in PHP 8.0. Use unset() to unset a variable instead.
     ]]>
     </standard>
     <code_comparison>
@@ -32,7 +32,7 @@ $size  = <em>(real)</em> $value;
 <em>unset</em>( $value );
         ]]>
         </code>
-        <code title="Invalid: Using the (unset) cast.">
+        <code title="Invalid: Using the unset cast.">
         <![CDATA[
 $result = <em>(unset)</em> $value;
         ]]>
@@ -40,17 +40,17 @@ $result = <em>(unset)</em> $value;
     </code_comparison>
     <standard>
     <![CDATA[
-    Using the (binary) cast or the b prefix is discouraged. The (binary) cast was deprecated in PHP 8.5. Use the (string) cast or a regular string literal instead.
+    Using the binary cast or the b prefix is discouraged. The binary cast was deprecated in PHP 8.5. Use the string cast or a regular string literal instead.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using (string) and a string literal.">
+        <code title="Valid: Using the string cast and a string literal.">
         <![CDATA[
 $bytes = <em>(string)</em> $value;
 $text  = <em>'hello'</em>;
         ]]>
         </code>
-        <code title="Invalid: Using (binary) and the b prefix.">
+        <code title="Invalid: Using the binary cast and the b prefix.">
         <![CDATA[
 $bytes = <em>(binary)</em> $value;
 $text  = <em>b</em>'hello';


### PR DESCRIPTION
# Description

This PR adds XML documentation for the `WordPress.PHP.TypeCasts` sniff.

The documentation is based on the work started by @brentwilson-clariio in #2591. I used the original commits and, in a separate commit, made the changes discussed in the review of #2591, plus I opted to replace the single bulleted standard block with three separate standard blocks, one per error/warning, and context indicating when each cast was deprecated and/or removed from PHP.

Regarding the `(unset)` cast, the sniff message suggests using `unset()` instead, so I kept that in the documentation from the original PR. But I'm not sure about it, as the behavior is different. As far as I can see, `(unset) $a` returns `null` while `unset($a)` unsets the variable `$a`.

I suggest squashing the commits before merging. I'm opening the PR without doing that to make it easier to tell my changes apart from the original changes.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #1722
Supersedes: #2591
Closes #2591
