### PR TITLE
WP/ClassNameCase: fix typo

### DIFF
--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -826,7 +826,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	/**
 	 * List of all GetID3 classes in lowercase.
 	 *
-	 * This array is automatically generated in the class constructor based on the $phpmailer_classes property.
+	 * This array is automatically generated in the class constructor based on the $getid3_classes property.
 	 *
 	 * @since 3.0.0
 	 *


### PR DESCRIPTION
# Description

This PR fixes a small typo in a docblock I found while working on an upcoming PR to update the `WordPress.WP.ClassNameCase` sniff to reflect the changes in WP 7.0.

## Suggested changelog entry

N/A
