### PR TITLE
ConstantsHelper::is_use_of_global_constant(): add tests

### DIFF
--- a/WordPress/Tests/Helpers/ConstantsHelper/IsUseOfGlobalConstantUnitTest.inc
+++ b/WordPress/Tests/Helpers/ConstantsHelper/IsUseOfGlobalConstantUnitTest.inc
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * The below should NOT be recognized as use of a global constant.
+ */
+
+/* testVariableAssignment */
+$a = 'foo';
+
+/* testFunctionCall */
+some_function();
+
+/* testFunctionDeclaration */
+function PHP_OS() {}
+
+/* testClassInstantiation */
+$obj = new PHP_OS();
+
+/* testStaticMethodCall */
+PHP_OS::someMethod();
+
+/* testStaticClassConstantAccess */
+PHP_OS::SOME_CONST;
+
+/* testClassNameResolution */
+PHP_OS::class;
+
+/* testNamespaceDeclaration */
+namespace PHP_OS;
+
+/* testUseStatement */
+use PHP_OS\SomeClass;
+
+class MyClass extends /* testClassExtends */ PHP_OS {}
+class AnotherClass implements /* testClassImplements */ PHP_OS {}
+
+/* testClassInstantiationNoParentheses */
+$obj = new PHP_OS;
+
+/* testInstanceof */
+if ( $a instanceof PHP_OS ) {}
+
+class MyClass {
+	use TraitA, PHP_OS {
+		TraitA::conflictMethod insteadof /* testPrecededByInsteadOf */ PHP_OS;
+	}
+}
+
+/* testGotoLabel */
+goto PHP_OS;
+
+use const ABC as /* testPrecededByAs */ PHP_OS;
+
+/* testClassDeclaration */
+class PHP_OS {}
+
+/* testInterfaceDeclaration */
+interface PHP_OS {}
+
+/* testTraitDeclaration */
+trait PHP_OS {}
+
+/* testEnumDeclaration */
+enum PHP_OS {}
+
+/* testObjectPropertyAccess */
+$obj->PHP_OS;
+
+/* testNullsafeObjectPropertyAccess */
+$obj?->PHP_OS;
+
+SomeClass::/* testClassConstantAccess */PHP_OS;
+
+class ScopeModifiersTest {
+	/* testPrecededByPublic */
+	public PHP_OS $prop1;
+
+	/* testPrecededByProtected */
+	protected PHP_OS $prop2;
+
+	/* testPrecededByPrivate */
+	private PHP_OS $prop3;
+
+	/* testPrecededByPublicSet */
+	public public(set) PHP_OS $prop4;
+
+	/* testPrecededByProtectedSet */
+	public protected(set) PHP_OS $prop5;
+
+	/* testPrecededByPrivateSet */
+	public private(set) PHP_OS $prop6;
+}
+
+/* testPartiallyQualifiedNamespacedConstant */
+MyNamespace\PHP_OS;
+
+/* testFullyQualifiedNamespacedConstant */
+\MyNamespace\PHP_OS;
+
+/* testNamespaceRelativeConstant */
+namespace\PHP_OS; // This should be considered use of a global constant in the future once the method is able to resolve relative namespaces.
+
+/* testNamespaceRelativeSubConstant */
+namespace\Sub\PHP_OS;
+
+class Foo {
+	/* testClassConstantDeclaration */
+	const PHP_OS = 1;
+}
+
+use const SomeNamespace\{/* testUseConstStatementGrouped */ PHP_OS, PHP_VERSION_ID};
+
+use Foo\{Bar, /* testUseStatementGrouped */ PHP_OS};
+
+/*
+ * The below should be recognized as use of a global constant.
+ */
+
+/* testEchoStatement */
+echo PHP_OS;
+
+/* testEchoStatementFullyQualified */
+echo \PHP_OS;
+
+// Note: this is counterintuitive behavior, as declaring a constant is not exactly the use of a constant. However, this
+// seems intentional considering the docblock of DiscouragedConstantsSniff states that it warns against both usage and
+// re-declaration of discouraged WP constants.
+/* testConstDeclaration */
+const my_const = 'something';
+const ABC = '123',
+	/* testConstDeclarationInList */ PHP_OS = 'something';
+
+/* testUseConstStatement */
+use const PHP_OS as SSP;

--- a/WordPress/Tests/Helpers/ConstantsHelper/IsUseOfGlobalConstantUnitTest.php
+++ b/WordPress/Tests/Helpers/ConstantsHelper/IsUseOfGlobalConstantUnitTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ConstantsHelper;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\ConstantsHelper;
+
+/**
+ * Tests for the `ConstantsHelper::is_use_of_global_constant()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ConstantsHelper::is_use_of_global_constant
+ */
+final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test is_use_of_global_constant() returns false if the token does not exist.
+	 *
+	 * @return void
+	 */
+	public function testIsUseOfGlobalConstantReturnsFalseIfTokenDoesNotExist() {
+		$this->assertFalse(
+			ConstantsHelper::is_use_of_global_constant(
+				self::$phpcsFile,
+				-1
+			)
+		);
+	}
+
+	/**
+	 * Test is_use_of_global_constant().
+	 *
+	 * @dataProvider dataIsUseOfGlobalConstant
+	 *
+	 * @param string      $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool        $expectedResult The expected return value.
+	 * @param int|null    $tokenType      Optional. The token type to use for the target token.
+	 * @param string|null $tokenContent   Optional. The token content to use for the target token.
+	 *
+	 * @return void
+	 */
+	public function testIsUseOfGlobalConstant( $testMarker, $expectedResult, $tokenType = \T_STRING, $tokenContent = null ) {
+		$stackPtr = $this->getTargetToken( $testMarker, $tokenType, $tokenContent );
+		$result   = ConstantsHelper::is_use_of_global_constant( self::$phpcsFile, $stackPtr );
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsUseOfGlobalConstant()
+	 *
+	 * @return array<string, array<string, bool|int|string>>
+	 */
+	public static function dataIsUseOfGlobalConstant() {
+		return array(
+			// Cases that should return false.
+			'variable_assignment' => array(
+				'testMarker'     => '/* testVariableAssignment */',
+				'expectedResult' => false,
+				'tokenType'      => \T_VARIABLE,
+			),
+			'function_call' => array(
+				'testMarker'     => '/* testFunctionCall */',
+				'expectedResult' => false,
+			),
+			'function_declaration' => array(
+				'testMarker'     => '/* testFunctionDeclaration */',
+				'expectedResult' => false,
+			),
+			'class_instantiation' => array(
+				'testMarker'     => '/* testClassInstantiation */',
+				'expectedResult' => false,
+			),
+			'static_method_call' => array(
+				'testMarker'     => '/* testStaticMethodCall */',
+				'expectedResult' => false,
+			),
+			'static_class_constant_access' => array(
+				'testMarker'     => '/* testStaticClassConstantAccess */',
+				'expectedResult' => false,
+			),
+			'class_name_resolution' => array(
+				'testMarker'     => '/* testClassNameResolution */',
+				'expectedResult' => false,
+			),
+			'namespace_declaration' => array(
+				'testMarker'     => '/* testNamespaceDeclaration */',
+				'expectedResult' => false,
+			),
+			'use_statement' => array(
+				'testMarker'     => '/* testUseStatement */',
+				'expectedResult' => false,
+			),
+			'class_extends' => array(
+				'testMarker'     => '/* testClassExtends */',
+				'expectedResult' => false,
+			),
+			'class_implements' => array(
+				'testMarker'     => '/* testClassImplements */',
+				'expectedResult' => false,
+			),
+			'class_instantiation_no_parentheses' => array(
+				'testMarker'     => '/* testClassInstantiationNoParentheses */',
+				'expectedResult' => false,
+			),
+			'instanceof' => array(
+				'testMarker'     => '/* testInstanceof */',
+				'expectedResult' => false,
+			),
+			'preceded_by_insteadof' => array(
+				'testMarker'     => '/* testPrecededByInsteadOf */',
+				'expectedResult' => false,
+			),
+			'goto_label' => array(
+				'testMarker'     => '/* testGotoLabel */',
+				'expectedResult' => false,
+			),
+			'preceded_by_as' => array(
+				'testMarker'     => '/* testPrecededByAs */',
+				'expectedResult' => false,
+			),
+			'class_declaration' => array(
+				'testMarker'     => '/* testClassDeclaration */',
+				'expectedResult' => false,
+			),
+			'interface_declaration' => array(
+				'testMarker'     => '/* testInterfaceDeclaration */',
+				'expectedResult' => false,
+			),
+			'trait_declaration' => array(
+				'testMarker'     => '/* testTraitDeclaration */',
+				'expectedResult' => false,
+			),
+			'enum_declaration' => array(
+				'testMarker'     => '/* testEnumDeclaration */',
+				'expectedResult' => false,
+			),
+			'object_property_access' => array(
+				'testMarker'     => '/* testObjectPropertyAccess */',
+				'expectedResult' => false,
+			),
+			'nullsafe_object_property_access' => array(
+				'testMarker'     => '/* testNullsafeObjectPropertyAccess */',
+				'expectedResult' => false,
+			),
+			'class_constant_access' => array(
+				'testMarker'     => '/* testClassConstantAccess */',
+				'expectedResult' => false,
+			),
+			'preceded_by_public' => array(
+				'testMarker'     => '/* testPrecededByPublic */',
+				'expectedResult' => false,
+			),
+			'preceded_by_protected' => array(
+				'testMarker'     => '/* testPrecededByProtected */',
+				'expectedResult' => false,
+			),
+			'preceded_by_private' => array(
+				'testMarker'     => '/* testPrecededByPrivate */',
+				'expectedResult' => false,
+			),
+			'preceded_by_public_set' => array(
+				'testMarker'     => '/* testPrecededByPublicSet */',
+				'expectedResult' => false,
+			),
+			'preceded_by_protected_set' => array(
+				'testMarker'     => '/* testPrecededByProtectedSet */',
+				'expectedResult' => false,
+			),
+			'preceded_by_private_set' => array(
+				'testMarker'     => '/* testPrecededByPrivateSet */',
+				'expectedResult' => false,
+			),
+			'partially_qualified_namespaced_constant' => array(
+				'testMarker'     => '/* testPartiallyQualifiedNamespacedConstant */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'PHP_OS',
+			),
+			'fully_qualified_namespaced_constant' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespacedConstant */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'PHP_OS',
+			),
+			'namespace_relative_constant' => array(
+				'testMarker'     => '/* testNamespaceRelativeConstant */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_sub_constant' => array(
+				'testMarker'     => '/* testNamespaceRelativeSubConstant */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'PHP_OS',
+			),
+			'class_constant_declaration' => array(
+				'testMarker'     => '/* testClassConstantDeclaration */',
+				'expectedResult' => false,
+			),
+			'use_const_statement_grouped' => array(
+				'testMarker'     => '/* testUseConstStatementGrouped */',
+				'expectedResult' => false,
+			),
+			'use_statement_grouped' => array(
+				'testMarker'     => '/* testUseStatementGrouped */',
+				'expectedResult' => false,
+			),
+
+			// Cases that should return true.
+			'echo_statement' => array(
+				'testMarker'     => '/* testEchoStatement */',
+				'expectedResult' => true,
+			),
+			'echo_statement_fully_qualified' => array(
+				'testMarker'     => '/* testEchoStatementFullyQualified */',
+				'expectedResult' => true,
+			),
+			'const_declaration' => array(
+				'testMarker'     => '/* testConstDeclaration */',
+				'expectedResult' => true,
+			),
+			'const_declaration_in_list' => array(
+				'testMarker'     => '/* testConstDeclarationInList */',
+				'expectedResult' => true,
+			),
+			'use_const_statement' => array(
+				'testMarker'     => '/* testUseConstStatement */',
+				'expectedResult' => true,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'PHP_OS',
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -20,7 +20,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::get_safe_cast_tokens
- * @covers \WordPressCS\WordPress\Helpers\ConstantsHelper::is_use_of_global_constant
  * @covers \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait
  * @covers \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait
  * @covers \WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `ConstantsHelper::is_use_of_global_constant()` method.

It also removes the now-redundant `@covers` tag for this method from `EscapeOutputUnitTest.php`, as the method is now covered by its own dedicated test.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272
