### PR TITLE
WPDBTrait::is_wpdb_method_call(): fix false positives for static method calls to non-global classes called wpdb

### DIFF
--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Tokens\Collections;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 
 /**
  * Helper utilities for sniffs which examine WPDB method calls.
@@ -76,6 +77,11 @@ trait WPDBTrait {
 		if ( false === $is_object_call
 			|| isset( Collections::objectOperators()[ $tokens[ $is_object_call ]['code'] ] ) === false
 		) {
+			return false;
+		}
+
+		// If calling the method statically, ensure we are calling the global wpdb class.
+		if ( \T_STRING === $tokens[ $stackPtr ]['code'] && ContextHelper::is_token_namespaced( $phpcsFile, $stackPtr ) ) {
 			return false;
 		}
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -518,3 +518,17 @@ $where = $wpdb->prepare(
  */
 $callback = $wpdb->prepare(...); // OK.
 
+/*
+ * Safeguard correct handling of all types of namespaced calls to the wpdb::prepare() method.
+ *
+ * Note that calling wpdb::prepare() statically will result in an error. Still, the tests are included here since the
+ * sniff handles those calls.
+ *
+ * Related to: https://github.com/WordPress/WordPress-Coding-Standards/issues/2710.
+ */
+$sql = \wpdb::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // Error.
+$sql = \WPDB::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // Error.
+$sql = MyNamespace\wpdb::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // OK.
+$sql = \MyNamespace\WPDB::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // OK.
+$sql = namespace\wpdb::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // Ok. The sniff should start flagging this once it can resolve relative namespaces as this test file is not namespaced.
+$sql = namespace\Sub\wpdb::prepare( "SELECT * FROM $wpdb->users WHERE id = %d AND user_login = %s" ); // OK.

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -106,6 +106,10 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 
 			// Named parameter support.
 			418 => 1,
+
+			// Fully qualified calls to the global class wpdb.
+			529 => 1,
+			530 => 1,
 		);
 	}
 

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -142,6 +142,3 @@ echo $wpdb::CONSTANT_NAME;
 
 // Not an identifiable method call.
 $wpdb->{$methodName}('query');
-
-// Don't throw an error during live coding.
-wpdb::prepare( "SELECT * FROM $wpdb->posts

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -142,3 +142,18 @@ echo $wpdb::CONSTANT_NAME;
 
 // Not an identifiable method call.
 $wpdb->{$methodName}('query');
+
+/*
+ * Safeguard correct handling of all types of namespaced calls to the wpdb::prepare() method.
+ *
+ * Note that calling wpdb::prepare() statically will result in an error. Still, the tests are included here since the
+ * sniff handles those calls.
+ *
+ * Related to: https://github.com/WordPress/WordPress-Coding-Standards/issues/2710.
+ */
+\wpdb::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad.
+\WPDB::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad.
+MyNamespace\wpdb::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Ok.
+\MyNamespace\WPDB::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Ok.
+namespace\wpdb::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Ok. The sniff should start flagging this once it can resolve relative namespaces as this test file is not namespaced.
+namespace\Sub\wpdb::prepare( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . foo() . "';" ); // Ok.

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.3.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (unclosed string).
+ * This should be the only test in this file.
+ */
+
+wpdb::prepare( "SELECT * FROM $wpdb->posts

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -66,6 +66,8 @@ final class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 					124 => 1,
 					128 => 1,
 					132 => 2,
+					154 => 1,
+					155 => 1,
 				);
 
 			case 'PreparedSQLUnitTest.2.inc':


### PR DESCRIPTION
# Description

The `WordPress.DB.PreparedSQL` and `WordPress.DB.PreparedSQLPlaceholders` sniffs were producing false positives for static method calls to a class named `wpdb` that is preceded by a namespace (e.g. `MyNamespace\wpdb::prepare()`). The root cause was in `WPDBTrait::is_wpdb_method_call()`, which did not check whether the `wpdb` token was namespaced before treating it as a call to the global `wpdb` class.

The fix makes the method return `false` when the `wpdb` token is a namespaced call to a non-global `wpdb` class, so these calls are no longer mistaken for the global `wpdb` object.

## Suggested changelog entry

`WordPress.DB.PreparedSQL` and `WordPress.DB.PreparedSQLPlaceholders`: fixed a false positive for static method calls to a non-global class named `wpdb`.

## Related issues/external references

Fixes #2710