### PR TITLE
ArrayWalkingFunctionsHelper: add tests for is_array_walking_function() and get_callback_parameter()

### DIFF
--- a/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/GetCallbackParameterUnitTest.inc
+++ b/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/GetCallbackParameterUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Test cases where get_callback_parameter() should return false.
+ */
+
+/* testNotArrayWalkingFunction */
+array_filter( $array );
+
+/* testCallbackParamMissing */
+array_map();
+
+/*
+ * Test cases where get_callback_parameter() should return the callback parameter.
+ */
+
+/* testArrayMapCallback */
+array_map( 'sanitize_text_field', $array );
+
+/* testMapDeepMixedCase */
+Map_Deep( $array, 'esc_html' );

--- a/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/GetCallbackParameterUnitTest.php
+++ b/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/GetCallbackParameterUnitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ArrayWalkingFunctionsHelper;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper;
+
+/**
+ * Tests for the `ArrayWalkingFunctionsHelper::get_callback_parameter()` method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper::get_callback_parameter
+ */
+final class GetCallbackParameterUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test get_callback_parameter() returns false if the token does not exist.
+	 *
+	 * @return void
+	 */
+	public function testGetCallbackParameterReturnsFalseIfTokenDoesNotExist() {
+		$this->assertFalse( ArrayWalkingFunctionsHelper::get_callback_parameter( self::$phpcsFile, -1 ) );
+	}
+
+	/**
+	 * Test get_callback_parameter() returns the callback parameter info or false.
+	 *
+	 * @dataProvider dataGetCallbackParameter
+	 *
+	 * @param string       $testMarker      The comment which prefaces the target token in the test file.
+	 * @param string|false $expectedContent The expected 'clean' content of the callback parameter,
+	 *                                      or false if the method should return false.
+	 *
+	 * @return void
+	 */
+	public function testGetCallbackParameter( $testMarker, $expectedContent ) {
+		$stackPtr = $this->getTargetToken( $testMarker, array( \T_STRING, \T_NAME_FULLY_QUALIFIED ) );
+		$result   = ArrayWalkingFunctionsHelper::get_callback_parameter( self::$phpcsFile, $stackPtr );
+
+		if ( false === $expectedContent ) {
+			$this->assertFalse( $result );
+		} else {
+			$this->assertSame( $expectedContent, $result['clean'] );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testGetCallbackParameter()
+	 *
+	 * @return array<string, array<string, string|false>>
+	 */
+	public static function dataGetCallbackParameter() {
+		return array(
+			// Cases where false should be returned.
+			'not_array_walking_function' => array(
+				'testMarker'      => '/* testNotArrayWalkingFunction */',
+				'expectedContent' => false,
+			),
+			'callback_param_missing'     => array(
+				'testMarker'      => '/* testCallbackParamMissing */',
+				'expectedContent' => false,
+			),
+
+			// Cases where the callback parameter should be returned.
+			'array_map_callback'         => array(
+				'testMarker'      => '/* testArrayMapCallback */',
+				'expectedContent' => "'sanitize_text_field'",
+			),
+			'map_deep_mixed_case'        => array(
+				'testMarker'      => '/* testMapDeepMixedCase */',
+				'expectedContent' => "'esc_html'",
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/IsArrayWalkingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/ArrayWalkingFunctionsHelper/IsArrayWalkingFunctionUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\ArrayWalkingFunctionsHelper;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper;
+
+/**
+ * Tests for the `ArrayWalkingFunctionsHelper::is_array_walking_function()` method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper::is_array_walking_function
+ */
+final class IsArrayWalkingFunctionUnitTest extends TestCase {
+
+	/**
+	 * Test is_array_walking_function().
+	 *
+	 * @dataProvider dataIsArrayWalkingFunction
+	 *
+	 * @param string $functionName   The function name to test.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsArrayWalkingFunction( $functionName, $expectedResult ) {
+		$this->assertSame(
+			$expectedResult,
+			ArrayWalkingFunctionsHelper::is_array_walking_function( $functionName )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsArrayWalkingFunction()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsArrayWalkingFunction() {
+		return array(
+			'lowercase_name' => array(
+				'functionName'   => 'array_map',
+				'expectedResult' => true,
+			),
+			'mixedcase_name' => array(
+				'functionName'   => 'mAp_DeEp',
+				'expectedResult' => true,
+			),
+			'not_an_array_walking_function' => array(
+				'functionName'   => 'array_filter',
+				'expectedResult' => false,
+			),
+		);
+	}
+}


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `ArrayWalkingFunctionsHelper::is_array_walking_function()` and `ArrayWalkingFunctionsHelper::get_callback_parameter()` methods.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272
