### PR TITLE
SanitizationHelperTrait: add tests for the sanitizing-function list methods

### DIFF
--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/GetSanitizingAndUnslashingFunctionsUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/GetSanitizingAndUnslashingFunctionsUnitTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::get_sanitizing_and_unslashing_functions()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::get_sanitizing_and_unslashing_functions
+ */
+final class GetSanitizingAndUnslashingFunctionsUnitTest extends TestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test that get_sanitizing_and_unslashing_functions() returns an array containing a known
+	 * sanitizing and unslashing function.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingAndUnslashingFunctionsContainsKnownFunction() {
+		$result = $this->testClass->get_sanitizing_and_unslashing_functions();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'absint', $result );
+		$this->assertTrue( $result['absint'] );
+	}
+
+	/**
+	 * Test that get_sanitizing_and_unslashing_functions() includes custom unslashing sanitizing functions.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingAndUnslashingFunctionsIncludesCustomFunctions() {
+		$defaultCount = count( $this->testClass->get_sanitizing_and_unslashing_functions() );
+		$this->testClass->customUnslashingSanitizingFunctions = array( 'my_custom_unslasher' );
+
+		$result = $this->testClass->get_sanitizing_and_unslashing_functions();
+
+		$this->assertCount( $defaultCount + 1, $result );
+		$this->assertArrayHasKey( 'my_custom_unslasher', $result );
+		$this->assertFalse( $result['my_custom_unslasher'] );
+	}
+
+	/**
+	 * Test that get_sanitizing_and_unslashing_functions() updates the result when custom
+	 * unslashing sanitizing functions are changed.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingAndUnslashingFunctionsUpdatesWhenCustomFunctionsChange() {
+		$this->testClass->customUnslashingSanitizingFunctions = array( 'first_custom' );
+		$result = $this->testClass->get_sanitizing_and_unslashing_functions();
+		$this->assertArrayHasKey( 'first_custom', $result );
+		$this->assertFalse( $result['first_custom'] );
+
+		$this->testClass->customUnslashingSanitizingFunctions = array( 'second_custom' );
+		$result = $this->testClass->get_sanitizing_and_unslashing_functions();
+		$this->assertArrayHasKey( 'second_custom', $result );
+		$this->assertFalse( $result['second_custom'] );
+		$this->assertArrayNotHasKey( 'first_custom', $result );
+	}
+}

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/GetSanitizingFunctionsUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/GetSanitizingFunctionsUnitTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::get_sanitizing_functions()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::get_sanitizing_functions
+ */
+final class GetSanitizingFunctionsUnitTest extends TestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test that get_sanitizing_functions() returns an array containing a known
+	 * sanitizing function.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingFunctionsContainsKnownFunction() {
+		$result = $this->testClass->get_sanitizing_functions();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'sanitize_text_field', $result );
+		$this->assertTrue( $result['sanitize_text_field'] );
+	}
+
+	/**
+	 * Test that get_sanitizing_functions() includes custom sanitizing functions.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingFunctionsIncludesCustomFunctions() {
+		$defaultCount                               = count( $this->testClass->get_sanitizing_functions() );
+		$this->testClass->customSanitizingFunctions = array( 'my_custom_sanitizer' );
+
+		$result = $this->testClass->get_sanitizing_functions();
+
+		$this->assertCount( $defaultCount + 1, $result );
+		$this->assertArrayHasKey( 'my_custom_sanitizer', $result );
+		$this->assertFalse( $result['my_custom_sanitizer'] );
+	}
+
+	/**
+	 * Test that get_sanitizing_functions() updates the result when custom
+	 * sanitizing functions are changed.
+	 *
+	 * @return void
+	 */
+	public function testGetSanitizingFunctionsUpdatesWhenCustomFunctionsChange() {
+		$this->testClass->customSanitizingFunctions = array( 'first_custom' );
+		$result                                     = $this->testClass->get_sanitizing_functions();
+		$this->assertArrayHasKey( 'first_custom', $result );
+		$this->assertFalse( $result['first_custom'] );
+
+		$this->testClass->customSanitizingFunctions = array( 'second_custom' );
+		$result                                     = $this->testClass->get_sanitizing_functions();
+		$this->assertArrayHasKey( 'second_custom', $result );
+		$this->assertFalse( $result['second_custom'] );
+		$this->assertArrayNotHasKey( 'first_custom', $result );
+	}
+}

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizingAndUnslashingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizingAndUnslashingFunctionUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::is_sanitizing_and_unslashing_function()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::is_sanitizing_and_unslashing_function
+ */
+final class IsSanitizingAndUnslashingFunctionUnitTest extends TestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private static $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		self::$testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test is_sanitizing_and_unslashing_function().
+	 *
+	 * @dataProvider dataIsSanitizingAndUnslashingFunction
+	 *
+	 * @param string $functionName   The function name to test.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsSanitizingAndUnslashingFunction( $functionName, $expectedResult ) {
+		$this->assertSame(
+			$expectedResult,
+			self::$testClass->is_sanitizing_and_unslashing_function( $functionName )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsSanitizingAndUnslashingFunction()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsSanitizingAndUnslashingFunction() {
+		return array(
+			'lowercase_name' => array(
+				'functionName'   => 'absint',
+				'expectedResult' => true,
+			),
+			'mixedcase_name' => array(
+				'functionName'   => 'iNtVaL',
+				'expectedResult' => true,
+			),
+			'not_a_sanitizing_and_unslashing_function' => array(
+				'functionName'   => 'sanitize_text_field',
+				'expectedResult' => false,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizingFunctionUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizingFunctionUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPUnit\Framework\TestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::is_sanitizing_function()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::is_sanitizing_function
+ */
+final class IsSanitizingFunctionUnitTest extends TestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private static $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		self::$testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test is_sanitizing_function().
+	 *
+	 * @dataProvider dataIsSanitizingFunction
+	 *
+	 * @param string $functionName   The function name to test.
+	 * @param bool   $expectedResult The expected return value.
+	 *
+	 * @return void
+	 */
+	public function testIsSanitizingFunction( $functionName, $expectedResult ) {
+		$this->assertSame(
+			$expectedResult,
+			self::$testClass->is_sanitizing_function( $functionName )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsSanitizingFunction()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsSanitizingFunction() {
+		return array(
+			'lowercase_name'            => array(
+				'functionName'   => 'sanitize_text_field',
+				'expectedResult' => true,
+			),
+			'mixedcase_name'            => array(
+				'functionName'   => 'SaNiTiZe_EmAiL',
+				'expectedResult' => true,
+			),
+			'not_a_sanitizing_function' => array(
+				'functionName'   => 'printf',
+				'expectedResult' => false,
+			),
+		);
+	}
+}


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `SanitizationHelperTrait::is_sanitizing_function()`, `SanitizationHelperTrait::is_sanitizing_and_unslashing_function()`, `SanitizationHelperTrait::get_sanitizing_functions()` and `SanitizationHelperTrait::get_sanitizing_and_unslashing_functions()` methods.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272
