### PR TITLE
Update the minimum_wp_version to WP 6.7

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.6';
+	private $default_minimum_wp_version = '6.7';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.1.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.1.inc
@@ -422,13 +422,13 @@ wp_update_https_detection_errors();
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();
 block_core_query_ensure_interactivity_dependency();
+/* ============ WP 6.6 ============ */
+wp_interactivity_process_directives_of_interactive_blocks();
+wp_render_elements_support();
 
 /*
  * Warning.
  */
-/* ============ WP 6.6 ============ */
-wp_interactivity_process_directives_of_interactive_blocks();
-wp_render_elements_support();
 /* ============ WP 6.7 ============ */
 current_user_can_for_blog();
 wp_create_block_style_variation_instance_name();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -32,7 +32,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'DeprecatedFunctionsUnitTest.1.inc':
 				$start_line = 8;
-				$end_line   = 424;
+				$end_line   = 427;
 				$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 				// Unset the lines related to version comments.
@@ -85,7 +85,8 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 					$errors[383],
 					$errors[386],
 					$errors[410],
-					$errors[421]
+					$errors[421],
+					$errors[425]
 				);
 
 				return $errors;
@@ -112,13 +113,12 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {
 			case 'DeprecatedFunctionsUnitTest.1.inc':
-				$start_line = 430;
+				$start_line = 433;
 				$end_line   = 450;
 				$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 				// Unset the lines related to version comments.
 				unset(
-					$warnings[432],
 					$warnings[442],
 					$warnings[444],
 					$warnings[447]

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -56,6 +56,8 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 					49 => 1,
 					50 => 1,
 					51 => 1,
+					55 => 1,
+					56 => 1,
 					61 => 1,
 				);
 
@@ -67,20 +69,9 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @param string $testFile The name of the file being tested.
-	 *
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
-	public function getWarningList( $testFile = '' ) {
-		switch ( $testFile ) {
-			case 'DeprecatedParameterValuesUnitTest.1.inc':
-				return array(
-					55 => 1,
-					56 => 1,
-				);
-
-			default:
-				return array();
-		}
+	public function getWarningList() {
+		return array();
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -105,7 +105,7 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
 inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
-
-// All will give an WARNING as they have been deprecated after WP 6.6.
 wp_render_elements_support_styles('deprecated');
+
+// All will give an WARNING as they have been deprecated after WP 6.7.
 _wp_can_use_pcre_u('deprecated');

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 51;
-		$end_line   = 107;
+		$end_line   = 108;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -55,7 +55,6 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			110 => 1,
 			111 => 1,
 		);
 	}


### PR DESCRIPTION
# Description

The minimum version should be three versions behind the latest WP release. With WP 7.0 released, it should now become 6.7.

Includes updating the tests to match.

## Suggested changelog entry

Changed
- The default value for `minimum_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#various-sniffs-set-the-minimum-supported-wp-version), has been updated to `6.7`.


## Related issues/external references

Previous: #2121, #2321. #2436, #2553, #2656
