### PR TITLE
WPDBTrait::is_wpdb_method_call(): add tests

### DIFF
--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -20,7 +20,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_safe_casted
  * @covers \WordPressCS\WordPress\Helpers\FormattingFunctionsHelper
- * @covers \WordPressCS\WordPress\Helpers\WPDBTrait
  * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLSniff
  */
 final class PreparedSQLUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoMethodNameUnitTest.inc
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoMethodNameUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/*
+ * Intentional parse error (incomplete method call).
+ * This should be the only test in this file.
+ */
+$wpdb->

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoObjectOperatorUnitTest.inc
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoObjectOperatorUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/*
+ * Intentional parse error (no object operator after $wpdb).
+ * This should be the only test in this file.
+ */
+$wpdb

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoOpeningParenthesisUnitTest.inc
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallNoOpeningParenthesisUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/*
+ * Intentional parse error (missing opening parenthesis).
+ * This should be the only test in this file.
+ */
+$wpdb->prepare

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnclosedParenthesisUnitTest.inc
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnclosedParenthesisUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/*
+ * Intentional parse error (missing closing parenthesis).
+ * This should be the only test in this file.
+ */
+$wpdb->prepare(

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnitTest.inc
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnitTest.inc
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * The below should NOT be recognized as a $wpdb method call.
+ */
+
+/* testNotWpdbVariable */
+$db->prepare( 'SELECT * FROM table' );
+/* testNotWpdbClass */
+DB::esc_like( $find );
+$array[] = /* testWpdbNotMethodCall */ $wpdb;
+
+/* testPropertyAccess */
+echo $wpdb->num_queries /* testPropertyAccessOpenParen */ ;
+
+/* testFunctionCall */
+$result = wpdb( 'SELECT * FROM table' );
+/* testNotTargetMethod */
+$wpdb->insert /* testNotTargetMethodOpenParen */ ( 'table', array( 'name' => 'value' ) );
+/* testUppercaseWpdbVariable */
+$WPDB->prepare( 'SELECT * FROM table' );
+
+/* testVariableMethodCall */
+$wpdb->$prepare /* testVariableMethodCallOpenParen */ ( 'SELECT * FROM table' );
+
+/* testPartiallyQualified */
+MyNamespace\wpdb::esc_like /* testPartiallyQualifiedOpenParen */ ( $find );
+/* testFullyQualifiedNamespaced */
+\MyNamespace\wpdb::esc_like /* testFullyQualifiedNamespacedOpenParen */ ( $find );
+/* testNamespaceRelative */
+namespace\wpdb::esc_like /* testNamespaceRelativeOpenParen */ ( $find ); // The method should start recognizing this as a WPDB method call once it can resolve relative namespaces since this test file is not namespaced.
+/* testNamespaceRelativeSub */
+namespace\Sub\wpdb::esc_like /* testNamespaceRelativeSubOpenParen */ ( $find );
+
+/*
+ * The below should be recognized as a $wpdb method call.
+ */
+
+/* testObjectOperator */
+$wpdb->prepare /* testObjectOperatorOpenParen */ ( 'SELECT * FROM table WHERE id = %d', $id );
+/* testNullsafeObjectOperator */
+$wpdb?->PREPARE /* testNullsafeObjectOperatorOpenParen */ ( 'SELECT * FROM table WHERE id = %d', $id );
+/* testUnqualifiedClassUppercase */
+WPDB::esc_like /* testUnqualifiedClassUppercaseOpenParen */ ( $find );
+/* testUnqualifiedClassLowercase */
+wpdb::esc_like /* testUnqualifiedClassLowercaseOpenParen */ ( $find );
+/* testFullyQualifiedGlobalLowercase */
+\wpdb::esc_like /* testFullyQualifiedGlobalLowercaseOpenParen */ ( $find );
+/* testFullyQualifiedGlobalUppercase */
+\WPDB /* comment */ :: /* comment */ esc_like /* testFullyQualifiedGlobalUppercaseOpenParen */ ( $find );

--- a/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnitTest.php
+++ b/WordPress/Tests/Helpers/WPDBTrait/IsWpdbMethodCallUnitTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\WPDBTrait;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the `WPDBTrait::is_wpdb_method_call()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\WPDBTrait::is_wpdb_method_call
+ */
+final class IsWpdbMethodCallUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test helper class using the WPDBTrait.
+	 *
+	 * @var WPDBTraitWrapper
+	 */
+	private $testClass;
+
+	/**
+	 * Set up a fresh test class instance for each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testClass = new WPDBTraitWrapper();
+	}
+
+	/**
+	 * Test is_wpdb_method_call() returns false if the token does not exist.
+	 *
+	 * @return void
+	 */
+	public function testIsWpdbMethodCallReturnsFalseIfTokenDoesNotExist() {
+		$result = $this->testClass->invoke_is_wpdb_method_call(
+			self::$phpcsFile,
+			-1,
+			array( 'prepare' => true )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test is_wpdb_method_call() returns false when $target_methods is empty.
+	 *
+	 * @return void
+	 */
+	public function testIsWpdbMethodCallReturnsFalseWithEmptyTargetMethods() {
+		$stackPtr = $this->getTargetToken( '/* testObjectOperator */', \T_VARIABLE );
+		$result   = $this->testClass->invoke_is_wpdb_method_call(
+			self::$phpcsFile,
+			$stackPtr,
+			array()
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test is_wpdb_method_call() returns false for live coding / parse error situations.
+	 *
+	 * @dataProvider dataIsWpdbMethodCallLiveCoding
+	 *
+	 * @param string $caseFile The test case file to parse.
+	 *
+	 * @return void
+	 */
+	public function testIsWpdbMethodCallLiveCoding( $caseFile ) {
+		$phpcsFile = self::parseFile(
+			__DIR__ . '/' . $caseFile,
+			self::$phpcsFile->ruleset,
+			self::$phpcsFile->config
+		);
+
+		$stackPtr = $phpcsFile->findNext( \T_VARIABLE, 0 );
+		$this->assertNotFalse( $stackPtr );
+
+		$result = $this->testClass->invoke_is_wpdb_method_call(
+			$phpcsFile,
+			$stackPtr,
+			array( 'prepare' => true )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsWpdbMethodCallLiveCoding()
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function dataIsWpdbMethodCallLiveCoding() {
+		return array(
+			'no_object_operator' => array(
+				'caseFile' => 'IsWpdbMethodCallNoObjectOperatorUnitTest.inc',
+			),
+			'no_method_name' => array(
+				'caseFile' => 'IsWpdbMethodCallNoMethodNameUnitTest.inc',
+			),
+			'no_opening_parenthesis' => array(
+				'caseFile' => 'IsWpdbMethodCallNoOpeningParenthesisUnitTest.inc',
+			),
+			'unclosed_parenthesis' => array(
+				'caseFile' => 'IsWpdbMethodCallUnclosedParenthesisUnitTest.inc',
+			),
+		);
+	}
+
+	/**
+	 * Test is_wpdb_method_call().
+	 *
+	 * @dataProvider dataIsWpdbMethodCall
+	 *
+	 * @param string      $testMarker      The comment which prefaces the target token in the test file.
+	 * @param bool        $expectedResult  The expected return value.
+	 * @param int|string  $tokenType       The token type to search for.
+	 * @param string|null $tokenContent    The token content to search for (if applicable).
+	 * @param bool        $hasMethodPtr    Whether the methodPtr property should be set.
+	 * @param string|bool $openParenMarker The test marker for the expected i token, or false if not expected to be set.
+	 * @param bool        $hasEnd          Whether the end property should be set.
+	 *
+	 * @return void
+	 */
+	public function testIsWpdbMethodCall(
+		$testMarker,
+		$expectedResult,
+		$tokenType,
+		$tokenContent = null,
+		$hasMethodPtr = false,
+		$openParenMarker = false,
+		$hasEnd = false
+	) {
+		$stackPtr = $this->getTargetToken( $testMarker, $tokenType, $tokenContent );
+		$result   = $this->testClass->invoke_is_wpdb_method_call(
+			self::$phpcsFile,
+			$stackPtr,
+			array(
+				'prepare'  => true,
+				'esc_like' => true,
+			)
+		);
+
+		$this->assertSame( $expectedResult, $result );
+
+		if ( true === $hasMethodPtr ) {
+			$expectedPtr = self::$phpcsFile->findNext( \T_STRING, ( $stackPtr + 1 ) );
+			$this->assertSame( $expectedPtr, $this->testClass->methodPtr );
+		} else {
+			$this->assertNull( $this->testClass->methodPtr );
+		}
+
+		if ( false !== $openParenMarker ) {
+			$expectedIPtr = $this->getTargetToken( $openParenMarker, array( \T_OPEN_PARENTHESIS, \T_SEMICOLON ) );
+			$this->assertSame( $expectedIPtr, $this->testClass->i );
+		} else {
+			$this->assertNull( $this->testClass->i );
+		}
+
+		// Note: the exact value of end is not verified because it depends on the result of
+		// BCFile::findEndOfStatement() which would require reimplementing the method's logic in the test.
+		if ( true === $hasEnd ) {
+			$this->assertIsInt( $this->testClass->end );
+		} else {
+			$this->assertNull( $this->testClass->end );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsWpdbMethodCall()
+	 *
+	 * @return array<string, array<string, bool|int|string|null>>
+	 */
+	public static function dataIsWpdbMethodCall() {
+		return array(
+			// Cases that should return false.
+			'not_wpdb_variable' => array(
+				'testMarker'     => '/* testNotWpdbVariable */',
+				'expectedResult' => false,
+				'tokenType'      => \T_VARIABLE,
+			),
+			'not_wpdb_class' => array(
+				'testMarker'     => '/* testNotWpdbClass */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+			),
+			'wpdb_not_method_call' => array(
+				'testMarker'     => '/* testWpdbNotMethodCall */',
+				'expectedResult' => false,
+				'tokenType'      => \T_VARIABLE,
+			),
+			'property_access' => array(
+				'testMarker'      => '/* testPropertyAccess */',
+				'expectedResult'  => false,
+				'tokenType'       => \T_VARIABLE,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testPropertyAccessOpenParen */',
+			),
+			'function_call' => array(
+				'testMarker'     => '/* testFunctionCall */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+			),
+			'partially_qualified' => array(
+				'testMarker'     => '/* testPartiallyQualified */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'wpdb',
+			),
+			'fully_qualified_namespaced' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespaced */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'wpdb',
+			),
+			'namespace_relative' => array(
+				'testMarker'     => '/* testNamespaceRelative */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'wpdb',
+			),
+			'namespace_relative_sub' => array(
+				'testMarker'     => '/* testNamespaceRelativeSub */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+				'tokenContent'   => 'wpdb',
+			),
+			'not_target_method' => array(
+				'testMarker'      => '/* testNotTargetMethod */',
+				'expectedResult'  => false,
+				'tokenType'       => \T_VARIABLE,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testNotTargetMethodOpenParen */',
+			),
+			'uppercase_wpdb_variable' => array(
+				'testMarker'     => '/* testUppercaseWpdbVariable */',
+				'expectedResult' => false,
+				'tokenType'      => \T_VARIABLE,
+			),
+			'variable_method_call' => array(
+				'testMarker'      => '/* testVariableMethodCall */',
+				'expectedResult'  => false,
+				'tokenType'       => \T_VARIABLE,
+				'tokenContent'    => '$wpdb',
+				'hasMethodPtr'    => false,
+				'openParenMarker' => '/* testVariableMethodCallOpenParen */',
+			),
+
+			// Cases that should return true.
+			'object_operator' => array(
+				'testMarker'      => '/* testObjectOperator */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_VARIABLE,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testObjectOperatorOpenParen */',
+				'hasEnd'          => true,
+			),
+			'nullsafe_object_operator' => array(
+				'testMarker'      => '/* testNullsafeObjectOperator */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_VARIABLE,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testNullsafeObjectOperatorOpenParen */',
+				'hasEnd'          => true,
+			),
+			'unqualified_class_uppercase' => array(
+				'testMarker'      => '/* testUnqualifiedClassUppercase */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_STRING,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testUnqualifiedClassUppercaseOpenParen */',
+				'hasEnd'          => true,
+			),
+			'unqualified_class_lowercase' => array(
+				'testMarker'      => '/* testUnqualifiedClassLowercase */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_STRING,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testUnqualifiedClassLowercaseOpenParen */',
+				'hasEnd'          => true,
+			),
+			'fully_qualified_global_lowercase' => array(
+				'testMarker'      => '/* testFullyQualifiedGlobalLowercase */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_STRING,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testFullyQualifiedGlobalLowercaseOpenParen */',
+				'hasEnd'          => true,
+			),
+			'fully_qualified_global_uppercase' => array(
+				'testMarker'      => '/* testFullyQualifiedGlobalUppercase */',
+				'expectedResult'  => true,
+				'tokenType'       => \T_STRING,
+				'tokenContent'    => null,
+				'hasMethodPtr'    => true,
+				'openParenMarker' => '/* testFullyQualifiedGlobalUppercaseOpenParen */',
+				'hasEnd'          => true,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/WPDBTrait/WPDBTraitWrapper.php
+++ b/WordPress/Tests/Helpers/WPDBTrait/WPDBTraitWrapper.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\WPDBTrait;
+
+use PHP_CodeSniffer\Files\File;
+use WordPressCS\WordPress\Helpers\WPDBTrait;
+
+/**
+ * Test helper class that exposes the WPDBTrait::is_wpdb_method_call() method for testing.
+ *
+ * @since 3.4.0
+ */
+final class WPDBTraitWrapper {
+
+	use WPDBTrait;
+
+	/**
+	 * Stack pointer to the method name.
+	 *
+	 * @var int|null
+	 */
+	public $methodPtr = null;
+
+	/**
+	 * Stack pointer to the opening parenthesis of the method call.
+	 *
+	 * @var int|null
+	 */
+	public $i = null;
+
+	/**
+	 * Stack pointer to the end of the first parameter.
+	 *
+	 * @var int|null
+	 */
+	public $end = null;
+
+	/**
+	 * Wrapper for is_wpdb_method_call() for testing purposes.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file being scanned.
+	 * @param int                         $stackPtr      The index of the $wpdb variable or wpdb class name token.
+	 * @param array                       $targetMethods Array of methods. Key(s) should be method name in lowercase.
+	 *
+	 * @return bool Whether this is a $wpdb method call.
+	 */
+	public function invoke_is_wpdb_method_call( File $phpcsFile, $stackPtr, array $targetMethods ) {
+		return $this->is_wpdb_method_call( $phpcsFile, $stackPtr, $targetMethods );
+	}
+}


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds dedicated unit tests for the `WPDBTrait::is_wpdb_method_call()` helper method, which is used by the `WordPress.DB.PreparedSQL` and `WordPress.DB.PreparedSQLPlaceholders` sniffs to determine whether a piece of code is a call to one of a set of `$wpdb` methods.

While creating those tests, I found what I believe to be a bug in this method. Since it is a low priority one, I documented it in a separate issue: #2759.

## Suggested changelog entry

_N/A_
