### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.13.5

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,8 +62,8 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ### Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.13.4 or higher
-* PHPCSUtils 1.1.0 or higher
+* PHP_CodeSniffer 3.13.5 or higher
+* PHPCSUtils 1.2.2 or higher
 * PHPCSExtra 1.5.0 or higher
 * PHPUnit 8.x - 9.x
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.13.4",
-		"phpcsstandards/phpcsutils": "^1.1.0",
+		"squizlabs/php_codesniffer": "^3.13.5",
+		"phpcsstandards/phpcsutils": "^1.2.2",
 		"phpcsstandards/phpcsextra": "^1.5.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
# Description
While not strictly _necessary_, raising the minimum supported PHPCS and PHPCSUtils versions buys us improved support for PHP 8.4 and 8.5, both runtime support, as well as improved syntax support.


## Suggested changelog entry
- The minimum required `PHP_CodeSniffer` version to 3.13.5 (was 3.13.4).
- The minimum required `PHPCSUtils` version to 1.2.2 (was 1.1.0).


