### PR TITLE
Update `minimum_wp_version` in phpcs.xml.dist.sample

### DIFF
--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -100,7 +100,7 @@
 	the wiki:
 	https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_wp_version" value="6.6"/>
+	<config name="minimum_wp_version" value="6.7"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
# Description

This PR updates the `phpcs.xml.dist.sample` file to reflect that WP 6.7 is now the minimum supported version (three versions behind the latest release).

## Suggested changelog entry

_N/A_
