### PR TITLE
SanitizationHelperTrait: add tests for is_sanitized() and is_only_sanitized()

### DIFF
--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsOnlySanitizedUnitTest.inc
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsOnlySanitizedUnitTest.inc
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Test cases that should not be considered only sanitized.
+ */
+
+/* testNotSanitizedEcho */
+echo $_POST['foo'];
+
+/* testInnerFunctionNotSanitizing */
+sanitize_text_field( strtolower( $_GET['name'] ) );
+
+/* testOnlyUnslashed */
+wp_unslash( $_REQUEST['content'] );
+
+/* testCastNestedInFunction */
+number_format( (float) $_POST['price'] );
+
+/* testSanitizedNestedInFunction */
+trim( sanitize_text_field( $_POST['name'] ) );
+
+/*
+ * Test cases that should be considered only sanitized.
+ */
+
+/* testSingleSanitizingFunction */
+sanitize_text_field( $_POST['name'] );
+
+/* testUnslashingSanitizingFunction */
+absint( $_GET['id'] );
+
+/* testArrayWalkingSanitizingCallback */
+array_map( 'sanitize_text_field', $_REQUEST['items'] );
+
+/* testInUnset */
+unset( $_FILES['temp'] );
+
+/* testSafeCast */
+(int) $_POST['count'];
+
+sanitize_text_field( /* testStringTokenSanitized */ get_input() ); // T_STRING entry token: not reached via the sniffs that call the method (they only ever pass a T_VARIABLE), but the method supports any token type.

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsOnlySanitizedUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsOnlySanitizedUnitTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::is_only_sanitized()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::is_only_sanitized
+ */
+final class IsOnlySanitizedUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private static $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @beforeClass
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test is_only_sanitized() returns false if the token does not exist.
+	 *
+	 * @return void
+	 */
+	public function testIsOnlySanitizedReturnsFalseIfTokenDoesNotExist() {
+		$this->assertFalse( self::$testClass->is_only_sanitized( self::$phpcsFile, -1 ) );
+	}
+
+	/**
+	 * Test is_only_sanitized().
+	 *
+	 * @dataProvider dataIsOnlySanitized
+	 *
+	 * @param string     $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool       $expectedResult The expected return value.
+	 * @param int|string $tokenType      The token type to search for. Defaults to T_VARIABLE.
+	 *
+	 * @return void
+	 */
+	public function testIsOnlySanitized( $testMarker, $expectedResult, $tokenType = \T_VARIABLE ) {
+		$stackPtr = $this->getTargetToken( $testMarker, $tokenType );
+		$result   = self::$testClass->is_only_sanitized(
+			self::$phpcsFile,
+			$stackPtr
+		);
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsOnlySanitized()
+	 *
+	 * @return array<string, array<string, bool|int|string>>
+	 */
+	public static function dataIsOnlySanitized() {
+		return array(
+			// Cases where false should be returned.
+			'not_sanitized_echo' => array(
+				'testMarker'     => '/* testNotSanitizedEcho */',
+				'expectedResult' => false,
+			),
+			'inner_function_not_sanitizing' => array(
+				'testMarker'     => '/* testInnerFunctionNotSanitizing */',
+				'expectedResult' => false,
+			),
+			'only_unslashed' => array(
+				'testMarker'     => '/* testOnlyUnslashed */',
+				'expectedResult' => false,
+			),
+			'cast_nested_in_function' => array(
+				'testMarker'     => '/* testCastNestedInFunction */',
+				'expectedResult' => false,
+			),
+			'sanitized_nested_in_function' => array(
+				'testMarker'     => '/* testSanitizedNestedInFunction */',
+				'expectedResult' => false,
+			),
+
+			// Cases where true should be returned.
+			'single_sanitizing_function' => array(
+				'testMarker'     => '/* testSingleSanitizingFunction */',
+				'expectedResult' => true,
+			),
+			'unslashing_sanitizing_function' => array(
+				'testMarker'     => '/* testUnslashingSanitizingFunction */',
+				'expectedResult' => true,
+			),
+			'array_walking_sanitizing_callback' => array(
+				'testMarker'     => '/* testArrayWalkingSanitizingCallback */',
+				'expectedResult' => true,
+			),
+			'in_unset' => array(
+				'testMarker'     => '/* testInUnset */',
+				'expectedResult' => true,
+			),
+			'safe_cast' => array(
+				'testMarker'     => '/* testSafeCast */',
+				'expectedResult' => true,
+			),
+			'string_token_sanitized' => array(
+				'testMarker'     => '/* testStringTokenSanitized */',
+				'expectedResult' => true,
+				'tokenType'      => \T_STRING,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizedUnitTest.inc
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizedUnitTest.inc
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Test cases that should not be considered sanitized.
+ */
+
+/* testNotWithinFunctionCall */
+$var = $_GET['bar'];
+
+/* testNonSanitizingFunction */
+strtolower( $_REQUEST['name'] );
+
+/* testInnerFunctionNotSanitizing */
+sanitize_text_field( strtolower( get_input() ) ); // T_STRING entry token: not reached via the sniffs that call the method (they only ever pass a T_VARIABLE), but the method supports any token type.
+
+/* testUnslashedInNonSanitizingFunction */
+strtolower( wp_unslash( $_POST['content'] ) );
+
+/* testPartiallyQualified */
+MyNamespace\sanitize_text_field( $_POST['title'] );
+
+/* testFullyQualifiedNamespaced */
+\MyNamespace\absint( $_GET['id'] );
+
+/* testNamespaceRelative */
+namespace\array_map( 'sanitize_text_field', $_REQUEST['items'] ); // The method should recognize this as sanitized once it can resolve relative namespaces since this test file is not namespaced.
+
+/* testNamespaceRelativeSub */
+namespace\Sub\wp_unslash( $_SERVER['foo'] );
+
+$obj->sanitize_text_field( /* testMethodCall */ $_POST['title'] );
+
+/* testStaticMethodCall */
+MyClass::sanitize_text_field( $_POST['title'] );
+
+/* testArrayWalkingNonSanitizingCallback */
+array_map( 'strtolower', $_POST['items'] );
+
+/* testArrayWalkingNonStringCallback */
+array_map( array( $obj, 'sanitize_text_field' ), $_POST['items'] );
+
+/* testArrayWalkingMissingCallback */
+map_deep( value: $_POST['items'] ); // Missing the required callback argument, but that's not the concern of the method.
+
+/*
+ * Test cases that should be considered sanitized.
+ */
+
+/* testInUnset */
+unset( $_COOKIE['temp'] );
+
+/* testSafeCast */
+(int) $_POST['count'];
+
+/* testSanitizingFunction */
+sanitize_text_field( $_GET['name'] );
+
+/* testSanitizingAndUnslashingFunction */
+\absint( $_POST['id'] );
+
+/* testUnslashedThenSanitized */
+sanitize_text_field( wp_unslash( $_POST['name'] ) );
+
+/* testArrayWalkingSanitizingCallback */
+array_map( 'sanitize_text_field', $_POST['items'] );
+
+sanitize_text_field( /* testStringTokenSanitized */ get_input() ); // T_STRING entry token: not reached via the sniffs that call the method (they only ever pass a T_VARIABLE), but the method supports any token type.
+
+/*
+ * Unslashing function call wrapped in a sanitizing function, across the namespace forms of the inner call.
+ * All of these currently return `true`.
+ *
+ * `\wp_unslash()` is the fully qualified global unslashing function, so `true` is correct in every version.
+ *
+ * `MyNamespace\wp_unslash()`, `\MyNamespace\wp_unslash()` and `namespace\Sub\wp_unslash()` are namespaced
+ * functions distinct from the global one, so the method should return `false`. They are false positives in
+ * PHPCS 3.x due to https://github.com/WordPress/WordPress-Coding-Standards/issues/2665. PHPCS 4.x returns
+ * `false` correctly.
+ *
+ * `namespace\wp_unslash()` is the global function in this non-namespaced file, so it should be `true`, but
+ * the method does not resolve relative names: like the namespaced forms it returns `true` in PHPCS 3.x (via
+ * the same bug) and `false` in PHPCS 4.x.
+ */
+/* testFullyQualifiedGlobalUnslashSanitized */
+sanitize_text_field( \wp_unslash( $_POST['foo'] ) );
+/* testPartiallyQualifiedUnslashSanitized */
+sanitize_text_field( MyNamespace\wp_unslash( $_POST['foo'] ) );
+/* testFullyQualifiedNamespacedUnslashSanitized */
+sanitize_text_field( \MyNamespace\wp_unslash( $_POST['foo'] ) );
+/* testNamespaceRelativeUnslashSanitized */
+sanitize_text_field( namespace\wp_unslash( $_POST['foo'] ) );
+/* testNamespaceRelativeSubUnslashSanitized */
+sanitize_text_field( namespace\Sub\wp_unslash( $_POST['foo'] ) );

--- a/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizedUnitTest.php
+++ b/WordPress/Tests/Helpers/SanitizationHelperTrait/IsSanitizedUnitTest.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Helpers\SanitizationHelperTrait;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use WordPressCS\WordPress\Helpers\SanitizationHelperTrait;
+
+/**
+ * Tests for the `SanitizationHelperTrait::is_sanitized()` utility method.
+ *
+ * @since 3.4.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait::is_sanitized
+ */
+final class IsSanitizedUnitTest extends UtilityMethodTestCase {
+
+	/**
+	 * Test class using the SanitizationHelperTrait for testing purposes.
+	 *
+	 * @var object
+	 */
+	private static $testClass;
+
+	/**
+	 * Set up the test class.
+	 *
+	 * @beforeClass
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$testClass = new class() {
+			use SanitizationHelperTrait;
+		};
+	}
+
+	/**
+	 * Test is_sanitized() returns false if the token does not exist.
+	 *
+	 * @return void
+	 */
+	public function testIsSanitizedReturnsFalseIfTokenDoesNotExist() {
+		$this->assertFalse( self::$testClass->is_sanitized( self::$phpcsFile, -1 ) );
+	}
+
+	/**
+	 * Test is_sanitized().
+	 *
+	 * @dataProvider dataIsSanitized
+	 *
+	 * @param string     $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool       $expectedResult The expected return value.
+	 * @param int|string $tokenType      The token type to search for. Defaults to T_VARIABLE.
+	 *
+	 * @return void
+	 */
+	public function testIsSanitized( $testMarker, $expectedResult, $tokenType = \T_VARIABLE ) {
+		$stackPtr = $this->getTargetToken( $testMarker, $tokenType );
+		$result   = self::$testClass->is_sanitized( self::$phpcsFile, $stackPtr );
+
+		$this->assertSame( $expectedResult, $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsSanitized()
+	 *
+	 * @return array<string, array<string, bool|int|string>>
+	 */
+	public static function dataIsSanitized() {
+		return array(
+			// Cases where false should be returned.
+			'not_within_function_call' => array(
+				'testMarker'     => '/* testNotWithinFunctionCall */',
+				'expectedResult' => false,
+			),
+			'non_sanitizing_function' => array(
+				'testMarker'     => '/* testNonSanitizingFunction */',
+				'expectedResult' => false,
+			),
+			'inner_function_not_sanitizing' => array(
+				'testMarker'     => '/* testInnerFunctionNotSanitizing */',
+				'expectedResult' => false,
+				'tokenType'      => \T_STRING,
+			),
+			'unslashed_in_non_sanitizing_function' => array(
+				'testMarker'     => '/* testUnslashedInNonSanitizingFunction */',
+				'expectedResult' => false,
+			),
+			'partially_qualified' => array(
+				'testMarker'     => '/* testPartiallyQualified */',
+				'expectedResult' => false,
+			),
+			'fully_qualified_namespaced' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespaced */',
+				'expectedResult' => false,
+			),
+			'namespace_relative' => array(
+				'testMarker'     => '/* testNamespaceRelative */',
+				'expectedResult' => false,
+			),
+			'namespace_relative_sub' => array(
+				'testMarker'     => '/* testNamespaceRelativeSub */',
+				'expectedResult' => false,
+			),
+			'method_call' => array(
+				'testMarker'     => '/* testMethodCall */',
+				'expectedResult' => false,
+			),
+			'static_method_call' => array(
+				'testMarker'     => '/* testStaticMethodCall */',
+				'expectedResult' => false,
+			),
+			'array_walking_non_sanitizing_callback' => array(
+				'testMarker'     => '/* testArrayWalkingNonSanitizingCallback */',
+				'expectedResult' => false,
+			),
+			'array_walking_non_string_callback' => array(
+				'testMarker'     => '/* testArrayWalkingNonStringCallback */',
+				'expectedResult' => false,
+			),
+			'array_walking_missing_callback' => array(
+				'testMarker'     => '/* testArrayWalkingMissingCallback */',
+				'expectedResult' => false,
+			),
+
+			// Cases where true should be returned.
+			'in_unset' => array(
+				'testMarker'     => '/* testInUnset */',
+				'expectedResult' => true,
+			),
+			'safe_cast' => array(
+				'testMarker'     => '/* testSafeCast */',
+				'expectedResult' => true,
+			),
+			'sanitizing_function' => array(
+				'testMarker'     => '/* testSanitizingFunction */',
+				'expectedResult' => true,
+			),
+			'sanitizing_and_unslashing_function' => array(
+				'testMarker'     => '/* testSanitizingAndUnslashingFunction */',
+				'expectedResult' => true,
+			),
+			'unslashed_then_sanitized' => array(
+				'testMarker'     => '/* testUnslashedThenSanitized */',
+				'expectedResult' => true,
+			),
+			'array_walking_sanitizing_callback' => array(
+				'testMarker'     => '/* testArrayWalkingSanitizingCallback */',
+				'expectedResult' => true,
+			),
+			'string_token_sanitized' => array(
+				'testMarker'     => '/* testStringTokenSanitized */',
+				'expectedResult' => true,
+				'tokenType'      => \T_STRING,
+			),
+			'fully_qualified_global_unslash_sanitized' => array(
+				'testMarker'     => '/* testFullyQualifiedGlobalUnslashSanitized */',
+				'expectedResult' => true,
+			),
+			'partially_qualified_unslash_sanitized' => array(
+				'testMarker'     => '/* testPartiallyQualifiedUnslashSanitized */',
+				'expectedResult' => true,
+			),
+			'fully_qualified_namespaced_unslash_sanitized' => array(
+				'testMarker'     => '/* testFullyQualifiedNamespacedUnslashSanitized */',
+				'expectedResult' => true,
+			),
+			'namespace_relative_unslash_sanitized' => array(
+				'testMarker'     => '/* testNamespaceRelativeUnslashSanitized */',
+				'expectedResult' => true,
+			),
+			'namespace_relative_sub_unslash_sanitized' => array(
+				'testMarker'     => '/* testNamespaceRelativeSubUnslashSanitized */',
+				'expectedResult' => true,
+			),
+		);
+	}
+
+	/**
+	 * Test that is_sanitized() invokes the unslash callback when the value is used
+	 * without being unslashed, and not when the value has already been unslashed.
+	 *
+	 * @dataProvider dataIsSanitizedUnslashCallback
+	 *
+	 * @param string $testMarker     The comment which prefaces the target token in the test file.
+	 * @param bool   $expectedResult The expected return value of is_sanitized().
+	 * @param bool   $expectedCalled Whether the unslash callback is expected to be called.
+	 *
+	 * @return void
+	 */
+	public function testIsSanitizedUnslashCallback( $testMarker, $expectedResult, $expectedCalled ) {
+		$stackPtr  = $this->getTargetToken( $testMarker, \T_VARIABLE );
+		$callCount = 0;
+		$callArgs  = array();
+		$callback  = static function ( $phpcsFile, $ptr ) use ( &$callCount, &$callArgs ) {
+			++$callCount;
+			$callArgs = array( $phpcsFile, $ptr );
+		};
+
+		$result = self::$testClass->is_sanitized( self::$phpcsFile, $stackPtr, $callback );
+
+		$this->assertSame( $expectedResult, $result, "Return value mismatch for $testMarker" );
+		$this->assertSame(
+			$expectedCalled ? 1 : 0,
+			$callCount,
+			"Unexpected number of unslash callback invocations for $testMarker"
+		);
+
+		if ( true === $expectedCalled ) {
+			$this->assertSame(
+				array( self::$phpcsFile, $stackPtr ),
+				$callArgs,
+				"The unslash callback received unexpected arguments for $testMarker"
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testIsSanitizedUnslashCallback()
+	 *
+	 * @return array<string, array<string, bool|string>>
+	 */
+	public static function dataIsSanitizedUnslashCallback() {
+		return array(
+			'not_within_function_call' => array(
+				'testMarker'     => '/* testNotWithinFunctionCall */',
+				'expectedResult' => false,
+				'expectedCalled' => true,
+			),
+			'non_sanitizing_function' => array(
+				'testMarker'     => '/* testNonSanitizingFunction */',
+				'expectedResult' => false,
+				'expectedCalled' => true,
+			),
+			'sanitized_not_unslashed' => array(
+				'testMarker'     => '/* testSanitizingFunction */',
+				'expectedResult' => true,
+				'expectedCalled' => true,
+			),
+			'unslashed_then_sanitized' => array(
+				'testMarker'     => '/* testUnslashedThenSanitized */',
+				'expectedResult' => true,
+				'expectedCalled' => false,
+			),
+			'unslashed_in_non_sanitizing_function' => array(
+				'testMarker'     => '/* testUnslashedInNonSanitizingFunction */',
+				'expectedResult' => false,
+				'expectedCalled' => false,
+			),
+			'sanitizing_and_unslashing_function' => array(
+				'testMarker'     => '/* testSanitizingAndUnslashingFunction */',
+				'expectedResult' => true,
+				'expectedCalled' => false,
+			),
+		);
+	}
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -19,7 +19,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since 1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
- * @covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait
  * @covers \WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\ValidationHelper
  * @covers \WordPressCS\WordPress\Helpers\VariableHelper


### PR DESCRIPTION
# Description

In preparation for supporting PHPCS 4.0, this PR adds unit tests for the `SanitizationHelperTrait::is_sanitized()` and `SanitizationHelperTrait::is_only_sanitized()` methods.

It also removes the `@covers \WordPressCS\WordPress\Helpers\SanitizationHelperTrait` annotation from the `ValidatedSanitizedInput` sniff tests, as the trait's methods now have their own dedicated tests and no longer need to rely on the sniff tests for coverage.

This PR should be merged after #2756, which adds tests for the other methods in `SanitizationHelperTrait`. Removing the `@covers` annotation is only correct once those tests are also in place.

## Suggested changelog entry

_N/A_

## Related issues/external references

Related to: #2272
