### PR TITLE
Add `SECURITY.md` file

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+The latest minor version of the `3.x` release series is supported for security updates.
+
+## Reporting a Vulnerability
+
+The WordPressCS team takes security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+**Please do not report or discuss security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Issues can be reported privately to the maintainers by opening a [Security vulnerability report].
+
+> [!CAUTION]
+> Please take note that while the WordPress organisation has a HackerOne program, the WordPress Coding Standards software is not covered by this program.
+> Full details of the WordPress Security Policy and the list of covered projects and infrastructure can be found on [HackerOne][WordPress HackerOne].
+
+### Preferences
+
+* Please provide detailed reports with reproducible steps and a clearly defined impact.
+* Include the version number of the vulnerable package in your report.
+* Fixes are most welcome.
+    A private PR can be created from the security report to work on and discuss the patch.
+
+[Security vulnerability report]: https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/new
+[WordPress HackerOne]:           https://hackerone.com/wordpress

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -21,7 +21,8 @@ Issues can be reported privately to the maintainers by opening a [Security vulne
 * Please provide detailed reports with reproducible steps and a clearly defined impact.
 * Include the version number of the vulnerable package in your report.
 * Fixes are most welcome.
-    A private PR can be created from the security report to work on and discuss the patch.
+
+A private PR can be created from the security report to work on and discuss the patch.
 
 [Security vulnerability report]: https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/new
 [WordPress HackerOne]:           https://hackerone.com/wordpress


### PR DESCRIPTION
# Description
The other day, Rodrigo and me noticed that WPCS does not have a published security policy (via a `SECURITY.md` file).

This commit intends to add such a file, which should help inform security researchers how to disclose any findings they may have.

The file is placed in the `.github` directory. This will allow for it to be recognized correctly by GitHub, while not cluttering up the project root directory.

Ref: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy

## Suggested changelog entry
_N/A_


## Notes

I have checked the following pages to confirm that WPCS is not covered under HackerOne:
* https://hackerone.com/wordpress
* https://hackerone.com/wordpress/policy_scopes?type=team
* https://github.com/WordPress/wordpress-develop/blob/trunk/SECURITY.md
* https://wordpress.org/about/security/

The text is in part inspired by a similar policy for the [Requests library](https://github.com/WordPress/Requests/blob/develop/.github/SECURITY.md), which I previously wrote (so there are no copyright issues).