### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -168,6 +168,8 @@ jobs:
           # Allow for PHP deprecation notices.
           ini-values: error_reporting = E_ALL & ~E_DEPRECATED
           coverage: none
+        env:
+          fail-fast: true
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.dependencies == 'dev' }}
@@ -250,6 +252,8 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: phpstan:1.x
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -42,6 +42,8 @@ jobs:
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On
           coverage:  ${{ github.ref_name == 'develop' && 'xdebug' || 'none' }}
+        env:
+          fail-fast: true
 
       - name: Enable creation of `composer.lock` file
         if: ${{ matrix.dependencies == 'lowest' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -96,6 +96,8 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: cs2pr
+        env:
+          fail-fast: true
 
       - name: "Composer: set PHPCS dependencies for tests (dev)"
         if: ${{ matrix.dependencies == 'dev' }}


### PR DESCRIPTION
# Description
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional


## Suggested changelog entry
_N/A_