### PR TITLE
Composer: update minimum version PHPCSUtils + PHPCSExtra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.13.5",
-		"phpcsstandards/phpcsutils": "^1.2.2",
-		"phpcsstandards/phpcsextra": "^1.5.0"
+		"phpcsstandards/phpcsutils": "^1.2.3",
+		"phpcsstandards/phpcsextra": "^1.5.1"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^10.0.0@dev",


### PR DESCRIPTION
# Description
PHPCSUtils has just released version 1.2.3, which includes a security fix which is relevant for two sniffs which are included in PHPCSExtra, which has released version 1.5.1 in response.

With that in mind, I'm bumping the minimum supported PHPCSUtils and PHPCSExtra versions to encourage users of to upgrade the underlying dependencies.

### Why does a version bump help ?

Well, it only helps when a new version of WordPressCS is released, which is what I intend to do next.
Once that's done, it helps as Composer will now show WordPressCS as a direct dependency which is outdated, while PHPCSUtils/PHPCSExtra would only show as an indirect dependency which is outdated, which doesn't have the same urgency for people to update.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.2.3
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.5.1


## Suggested changelog entry
- The minimum required `PHPCSUtils` version to 1.2.3 (was 1.2.2). [#xx]
- The minimum required `PHPCSExtra` version to 1.5.1 (was 1.5.0). [#xx]
